### PR TITLE
Add Jest setup and crypt utility test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "dev": "nodemon app.js"
+    "dev": "nodemon app.js",
+    "test": "jest"
   },
   "dependencies": {
     "dotenv": "^16.5.0",
@@ -17,7 +18,8 @@
     "whatsapp-web.js": "^1.28.0"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "jest": "^29.6.1"
   },
   "description": "Cicero V2 with postgresql",
   "author": "Rizqo Febryan Prastyo",

--- a/tests/crypt.test.js
+++ b/tests/crypt.test.js
@@ -1,0 +1,16 @@
+import { encrypt, decrypt } from '../src/utils/crypt.js';
+
+describe('crypt utilities', () => {
+  const KEY = 'jest-secret-key';
+
+  beforeAll(() => {
+    process.env.SECRET_KEY = KEY;
+  });
+
+  test('decrypt(encrypt(text)) returns original text', () => {
+    const text = 'Hello from Jest';
+    const encrypted = encrypt(text);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(text);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest-based test for `encrypt`/`decrypt`
- configure Jest with a basic config file
- add `test` script and Jest dev dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484f7e7bf08327b38b6e69ce588cb6