### PR TITLE
refactor: remove legacy WA lookup fallback

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -67,9 +67,7 @@ export const userMenuHandlers = {
     // === CASE 1: Lihat Data Saya ===
     if (text === "1" || text.toLowerCase().includes("data")) {
       const pengirim = chatId.replace(/[^0-9]/g, "");
-      const userByWA = (await userModel.findUserByWhatsApp)
-        ? await userModel.findUserByWhatsApp(pengirim)
-        : await findUserByWhatsApp(pengirim);
+      const userByWA = await userModel.findUserByWhatsApp(pengirim);
 
       if (userByWA) {
         const salam = getGreeting();
@@ -97,9 +95,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
     // === CASE 2: Update Data Saya ===
     if (text === "2" || text.toLowerCase().includes("update")) {
       const pengirim = chatId.replace(/[^0-9]/g, "");
-      const userByWA = (await userModel.findUserByWhatsApp)
-        ? await userModel.findUserByWhatsApp(pengirim)
-        : await findUserByWhatsApp(pengirim);
+      const userByWA = await userModel.findUserByWhatsApp(pengirim);
 
       if (userByWA) {
         const salam = getGreeting();

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -330,9 +330,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       return;
     }
     let waNum = chatId.replace(/[^0-9]/g, "");
-    let user = (await userModel.findUserByWhatsApp)
-      ? await userModel.findUserByWhatsApp(waNum)
-      : await userModel.findUserByWA(waNum);
+    let user = await userModel.findUserByWhatsApp(waNum);
     if (user) {
       await userModel.updateUserField(user.user_id, field, username);
       await waClient.sendMessage(
@@ -379,9 +377,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       return;
     }
     let waNum = chatId.replace(/[^0-9]/g, "");
-    let waUsed = (await userModel.findUserByWhatsApp)
-      ? await userModel.findUserByWhatsApp(waNum)
-      : await userModel.findUserByWA(waNum);
+    let waUsed = await userModel.findUserByWhatsApp(waNum);
     if (waUsed && waUsed.user_id !== user.user_id) {
       await waClient.sendMessage(
         chatId,


### PR DESCRIPTION
## Summary
- rely on `userModel.findUserByWhatsApp` directly
- simplify lookup logic in `userMenuHandlers` and `waService`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848541bcddc832799793d9ce70bb773