### PR TITLE
Add endpoints for fetching Instagram and TikTok posts

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -1,5 +1,7 @@
 // src/controller/instaController.js
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
+import * as instaPostService from "../service/instaPostService.js";
+import { sendSuccess } from "../utils/response.js";
 
 export async function getInstaRekapLikes(req, res) {
   const client_id = req.query.client_id;
@@ -10,6 +12,25 @@ export async function getInstaRekapLikes(req, res) {
   try {
     const data = await getRekapLikesByClient(client_id, periode);
     res.json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+export async function getInstaPosts(req, res) {
+  try {
+    const client_id =
+      req.query.client_id ||
+      req.user?.client_id ||
+      req.headers["x-client-id"];
+    if (!client_id) {
+      return res
+        .status(400)
+        .json({ success: false, message: "client_id wajib diisi" });
+    }
+
+    const posts = await instaPostService.findByClientId(client_id);
+    sendSuccess(res, posts);
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });
   }

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -30,6 +30,25 @@ export async function getTiktokComments(req, res, next) {
   }
 }
 
+export async function getTiktokPosts(req, res) {
+  try {
+    const client_id =
+      req.query.client_id ||
+      req.user?.client_id ||
+      req.headers["x-client-id"];
+    if (!client_id) {
+      return res
+        .status(400)
+        .json({ success: false, message: "client_id wajib diisi" });
+    }
+
+    const posts = await tiktokPostService.findByClientId(client_id);
+    sendSuccess(res, posts);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
 import { getRekapKomentarByClient } from '../model/tiktokCommentModel.js';
 
 export async function getTiktokRekapKomentar(req, res) {

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,10 +1,11 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes } from "../controller/instaController.js";
+import { getInstaRekapLikes, getInstaPosts } from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
 
 router.get("/rekap-likes", authRequired, getInstaRekapLikes);
+router.get("/posts", authRequired, getInstaPosts);
 
 export default router;

--- a/src/routes/tiktokRoutes.js
+++ b/src/routes/tiktokRoutes.js
@@ -1,10 +1,11 @@
 import { Router } from 'express';
-import { getTiktokComments, getTiktokRekapKomentar } from '../controller/tiktokController.js';
+import { getTiktokComments, getTiktokRekapKomentar, getTiktokPosts } from '../controller/tiktokController.js';
 import { authRequired } from '../middleware/authMiddleware.js';
 
 const router = Router();
 
 router.get('/comments', authRequired, getTiktokComments);
 router.get('/rekap-komentar', authRequired, getTiktokRekapKomentar);
+router.get('/posts', authRequired, getTiktokPosts);
 
 export default router;


### PR DESCRIPTION
## Summary
- allow fetching instagram posts via `GET /api/insta/posts`
- allow fetching tiktok posts via `GET /api/tiktok/posts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849120a5cd0832787bddbb77f7d75cf