### PR TITLE
Add RapidAPI Instagram fetch endpoint

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -1,6 +1,7 @@
 // src/controller/instaController.js
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
+import { fetchInstagramPosts } from "../service/instaRapidService.js";
 import { sendSuccess } from "../utils/response.js";
 
 export async function getInstaRekapLikes(req, res) {
@@ -30,6 +31,20 @@ export async function getInstaPosts(req, res) {
     }
 
     const posts = await instaPostService.findByClientId(client_id);
+    sendSuccess(res, posts);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+export async function getRapidInstagramPosts(req, res) {
+  try {
+    const username = req.query.username;
+    const limit = parseInt(req.query.limit) || 10;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    }
+    const posts = await fetchInstagramPosts(username, limit);
     sendSuccess(res, posts);
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,11 +1,12 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes, getInstaPosts } from "../controller/instaController.js";
+import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts } from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
 
 router.get("/rekap-likes", authRequired, getInstaRekapLikes);
 router.get("/posts", authRequired, getInstaPosts);
+router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
 
 export default router;

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -1,0 +1,23 @@
+const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY;
+const RAPIDAPI_HOST = 'social-api4.p.rapidapi.com';
+
+export async function fetchInstagramPosts(username, limit = 10) {
+  if (!username) return [];
+  const params = new URLSearchParams({ username_or_id_or_url: username });
+  if (limit) params.append('limit', limit);
+
+  const res = await fetch(`https://${RAPIDAPI_HOST}/v1/posts?${params.toString()}`, {
+    headers: {
+      'X-RapidAPI-Key': RAPIDAPI_KEY,
+      'X-RapidAPI-Host': RAPIDAPI_HOST,
+      'x-cache-control': 'no-cache'
+    }
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text);
+  }
+  const data = await res.json();
+  const items = data?.data?.items || [];
+  return limit ? items.slice(0, limit) : items;
+}


### PR DESCRIPTION
## Summary
- provide service to call RapidAPI for Instagram posts
- expose new controller and route for `/insta/rapid-posts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497dfb255483279ee45cf7f14107d4