### PR TITLE
Fix RapidAPI Instagram posts limit issue

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -40,7 +40,8 @@ export async function getInstaPosts(req, res) {
 export async function getRapidInstagramPosts(req, res) {
   try {
     const username = req.query.username;
-    const limit = parseInt(req.query.limit) || 10;
+    let limit = parseInt(req.query.limit);
+    if (Number.isNaN(limit) || limit <= 0) limit = 10;
     if (!username) {
       return res.status(400).json({ success: false, message: 'username wajib diisi' });
     }

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -4,7 +4,6 @@ const RAPIDAPI_HOST = 'social-api4.p.rapidapi.com';
 export async function fetchInstagramPosts(username, limit = 10) {
   if (!username) return [];
   const params = new URLSearchParams({ username_or_id_or_url: username });
-  if (limit) params.append('limit', limit);
 
   const res = await fetch(`https://${RAPIDAPI_HOST}/v1/posts?${params.toString()}`, {
     headers: {


### PR DESCRIPTION
## Summary
- do not send `limit` to RapidAPI when fetching posts
- validate numeric `limit` in controller

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497f6973648327b173f71683438511