### PR TITLE
Implement RapidAPI Instagram profile/post endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Cicero_V2-main/
 ]
 ```
 
+### 3. Instagram Rapid API
+
+| Endpoint | Method | Deskripsi |
+|----------|--------|-----------|
+| `/insta/rapid-profile` | GET | Ambil profil Instagram via RapidAPI |
+| `/insta/rapid-posts`   | GET | Ambil postingan Instagram via RapidAPI |
+
 ---
 
 ## Fitur & Flow Bisnis Utama

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -1,7 +1,7 @@
 // src/controller/instaController.js
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
-import { fetchInstagramPosts } from "../service/instaRapidService.js";
+import { fetchInstagramPosts, fetchInstagramProfile } from "../service/instaRapidService.js";
 import { sendSuccess } from "../utils/response.js";
 
 export async function getInstaRekapLikes(req, res) {
@@ -45,8 +45,31 @@ export async function getRapidInstagramPosts(req, res) {
     if (!username) {
       return res.status(400).json({ success: false, message: 'username wajib diisi' });
     }
-    const posts = await fetchInstagramPosts(username, limit);
+    const rawPosts = await fetchInstagramPosts(username, limit);
+    const posts = rawPosts.map(p => ({
+      id: p.code || p.id || p.pk,
+      created_at: p.taken_at ? new Date(p.taken_at * 1000).toISOString() : p.created_at,
+      type: p.media_type || p.type,
+      caption: p.caption && typeof p.caption === 'object' ? p.caption.text : p.caption,
+      like_count: p.like_count,
+      comment_count: p.comment_count,
+      share_count: p.share_count,
+      thumbnail: p.thumbnail || p.display_url
+    }));
     sendSuccess(res, posts);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+export async function getRapidInstagramProfile(req, res) {
+  try {
+    const username = req.query.username;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    }
+    const profile = await fetchInstagramProfile(username);
+    sendSuccess(res, profile);
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });
   }

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,6 +1,6 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts } from "../controller/instaController.js";
+import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile } from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
@@ -8,5 +8,6 @@ const router = Router();
 router.get("/rekap-likes", authRequired, getInstaRekapLikes);
 router.get("/posts", authRequired, getInstaPosts);
 router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
+router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
 
 export default router;

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -20,3 +20,22 @@ export async function fetchInstagramPosts(username, limit = 10) {
   const items = data?.data?.items || [];
   return limit ? items.slice(0, limit) : items;
 }
+
+export async function fetchInstagramProfile(username) {
+  if (!username) return null;
+  const params = new URLSearchParams({ username_or_id_or_url: username });
+
+  const res = await fetch(`https://${RAPIDAPI_HOST}/v1/profile?${params.toString()}`, {
+    headers: {
+      'X-RapidAPI-Key': RAPIDAPI_KEY,
+      'X-RapidAPI-Host': RAPIDAPI_HOST,
+      'x-cache-control': 'no-cache'
+    }
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text);
+  }
+  const data = await res.json();
+  return data?.data || null;
+}


### PR DESCRIPTION
## Summary
- support fetching Instagram profile via RapidAPI
- expose `/insta/rapid-profile` and `/insta/rapid-posts` routes
- normalize rapid post data
- document new Instagram RapidAPI routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: puppeteer download 403)*

------
https://chatgpt.com/codex/tasks/task_e_68498bb330888327bfb304b375edb968