### PR TITLE
Add Instagram info endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node app.js",
     "dev": "nodemon app.js",
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "dotenv": "^16.5.0",

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -1,7 +1,7 @@
 // src/controller/instaController.js
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
-import { fetchInstagramPosts, fetchInstagramProfile } from "../service/instaRapidService.js";
+import { fetchInstagramPosts, fetchInstagramProfile, fetchInstagramInfo } from "../service/instaRapidService.js";
 import { sendSuccess } from "../utils/response.js";
 
 export async function getInstaRekapLikes(req, res) {
@@ -70,6 +70,19 @@ export async function getRapidInstagramProfile(req, res) {
     }
     const profile = await fetchInstagramProfile(username);
     sendSuccess(res, profile);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+export async function getRapidInstagramInfo(req, res) {
+  try {
+    const username = req.query.username;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    }
+    const info = await fetchInstagramInfo(username);
+    sendSuccess(res, info);
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });
   }

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,6 +1,6 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile } from "../controller/instaController.js";
+import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile, getRapidInstagramInfo } from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
@@ -9,5 +9,6 @@ router.get("/rekap-likes", authRequired, getInstaRekapLikes);
 router.get("/posts", authRequired, getInstaPosts);
 router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
 router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
+router.get("/rapid-info", authRequired, getRapidInstagramInfo);
 
 export default router;

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY;
 const RAPIDAPI_HOST = 'social-api4.p.rapidapi.com';
 
@@ -39,3 +41,23 @@ export async function fetchInstagramProfile(username) {
   const data = await res.json();
   return data?.data || null;
 }
+
+export async function fetchInstagramInfo(username) {
+  if (!username) return null;
+  try {
+    const response = await axios.get(`https://${RAPIDAPI_HOST}/v1/info`, {
+      params: { username_or_id_or_url: username },
+      headers: {
+        'X-RapidAPI-Key': RAPIDAPI_KEY,
+        'X-RapidAPI-Host': RAPIDAPI_HOST,
+      },
+    });
+    return response.data?.data || null;
+  } catch (err) {
+    const msg = err.response?.data
+      ? JSON.stringify(err.response.data)
+      : err.message;
+    throw new Error(msg);
+  }
+}
+

--- a/tests/crypt.test.js
+++ b/tests/crypt.test.js
@@ -1,10 +1,15 @@
-import { encrypt, decrypt } from '../src/utils/crypt.js';
+
+let encrypt;
+let decrypt;
 
 describe('crypt utilities', () => {
   const KEY = 'jest-secret-key';
 
-  beforeAll(() => {
+  beforeAll(async () => {
     process.env.SECRET_KEY = KEY;
+    const module = await import('../src/utils/crypt.js');
+    encrypt = module.encrypt;
+    decrypt = module.decrypt;
   });
 
   test('decrypt(encrypt(text)) returns original text', () => {


### PR DESCRIPTION
## Summary
- add axios-based `fetchInstagramInfo` to service
- expose new controller and route for `/rapid-info`
- update Jest test to load crypt utils after setting env
- run tests with experimental VM modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498e419ac08327bf11796a9bf7bed7