### PR TITLE
Add IG profile persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Cicero_V2-main/
 |----------|--------|-----------|
 | `/insta/rapid-profile` | GET | Ambil profil Instagram via RapidAPI |
 | `/insta/rapid-posts`   | GET | Ambil postingan Instagram via RapidAPI |
+| `/insta/profile`       | GET | Ambil profil Instagram dari database |
 
 ---
 
@@ -205,6 +206,17 @@ CREATE TABLE insta_post (
 CREATE TABLE insta_like (
   shortcode VARCHAR PRIMARY KEY REFERENCES insta_post(shortcode),
   likes JSONB,
+  updated_at TIMESTAMP
+);
+
+CREATE TABLE insta_profile (
+  username VARCHAR PRIMARY KEY,
+  full_name VARCHAR,
+  biography TEXT,
+  follower_count INT,
+  following_count INT,
+  post_count INT,
+  profile_pic_url TEXT,
   updated_at TIMESTAMP
 );
 

--- a/src/model/instaProfileModel.js
+++ b/src/model/instaProfileModel.js
@@ -1,0 +1,32 @@
+import { pool } from '../config/db.js';
+
+export async function upsertInstaProfile(data) {
+  const {
+    username,
+    full_name = null,
+    biography = null,
+    follower_count = 0,
+    following_count = 0,
+    post_count = 0,
+    profile_pic_url = null,
+  } = data;
+  if (!username) return;
+  await pool.query(
+    `INSERT INTO insta_profile (username, full_name, biography, follower_count, following_count, post_count, profile_pic_url, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,NOW())
+     ON CONFLICT (username) DO UPDATE
+       SET full_name = EXCLUDED.full_name,
+           biography = EXCLUDED.biography,
+           follower_count = EXCLUDED.follower_count,
+           following_count = EXCLUDED.following_count,
+           post_count = EXCLUDED.post_count,
+           profile_pic_url = EXCLUDED.profile_pic_url,
+           updated_at = NOW()`,
+    [username, full_name, biography, follower_count, following_count, post_count, profile_pic_url]
+  );
+}
+
+export async function findByUsername(username) {
+  const res = await pool.query('SELECT * FROM insta_profile WHERE username = $1', [username]);
+  return res.rows[0] || null;
+}

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,6 +1,6 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile, getRapidInstagramInfo } from "../controller/instaController.js";
+import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile, getRapidInstagramInfo, getInstagramProfile } from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
@@ -10,5 +10,6 @@ router.get("/posts", authRequired, getInstaPosts);
 router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
 router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
 router.get("/rapid-info", authRequired, getRapidInstagramInfo);
+router.get("/profile", authRequired, getInstagramProfile);
 
 export default router;

--- a/src/service/instaProfileService.js
+++ b/src/service/instaProfileService.js
@@ -1,0 +1,9 @@
+import * as instaProfileModel from '../model/instaProfileModel.js';
+
+export const upsertProfile = async (data) => {
+  return instaProfileModel.upsertInstaProfile(data);
+};
+
+export const findByUsername = async (username) => {
+  return instaProfileModel.findByUsername(username);
+};


### PR DESCRIPTION
## Summary
- create new table docs for insta_profile
- save Instagram profiles fetched via Rapid API
- expose `/insta/profile` endpoint to read stored profile
- add model & service for insta profiles

## Testing
- `npm install` *(with `PUPPETEER_SKIP_DOWNLOAD=1`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a1e253ae883279bc07736d58672d9