### PR TITLE
Add Instagram posts cache API

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ CREATE TABLE tiktok_comment (
   comments JSONB,
   updated_at TIMESTAMP
 );
+
+-- Cache hasil fetch posting Instagram per username
+CREATE TABLE insta_post_cache (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR NOT NULL,
+  posts JSONB,
+  fetched_at TIMESTAMP DEFAULT NOW()
+);
 ```
 
 ---

--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -1,0 +1,197 @@
+"use client";
+import { useEffect, useState } from "react";
+import CardStat from "@/components/CardStat";
+import EngagementLineChart from "@/components/EngagementLineChart";
+import EngagementByTypeChart from "@/components/EngagementByTypeChart";
+import HeatmapTable from "@/components/HeatmapTable";
+import PostMetricsChart from "@/components/PostMetricsChart";
+import InstagramPostsGrid from "@/components/InstagramPostsGrid";
+import Loader from "@/components/Loader";
+import {
+  getInstagramProfileViaBackend,
+  getInstagramPostsViaBackend,
+  getClientProfile,
+} from "@/utils/api";
+
+export default function InstagramPostAnalysisPage() {
+  const [profile, setProfile] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+    const clientId =
+      typeof window !== "undefined" ? localStorage.getItem("client_id") : null;
+
+    if (!token || !clientId) {
+      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
+      setLoading(false);
+      return;
+    }
+
+    async function fetchData() {
+      try {
+        const clientProfile = await getClientProfile(token, clientId);
+        const username =
+          clientProfile.client?.client_insta?.replace(/^@/, "") ||
+          clientProfile.client_insta?.replace(/^@/, "") ||
+          process.env.NEXT_PUBLIC_INSTAGRAM_USER ||
+          "instagram";
+
+        const profileRes = await getInstagramProfileViaBackend(token, username);
+        setProfile(profileRes.data || profileRes.profile || profileRes);
+
+        const postRes = await getInstagramPostsViaBackend(token, username, 50);
+        const postData = postRes.data || postRes.posts || postRes;
+        setPosts(Array.isArray(postData) ? postData : []);
+      } catch (err) {
+        setError("Gagal mengambil data: " + (err.message || err));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchData();
+  }, []);
+
+  if (loading) return <Loader />;
+  if (error)
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-100">
+        <div className="bg-white rounded-lg shadow-md p-6 text-red-500 font-bold">
+          {error}
+        </div>
+      </div>
+    );
+  if (!profile) return null;
+
+  const sortedPosts = [...posts].sort(
+    (a, b) => new Date(a.created_at) - new Date(b.created_at)
+  );
+  const firstDate = sortedPosts.length
+    ? new Date(sortedPosts[0].created_at)
+    : new Date();
+  const lastDate = sortedPosts.length
+    ? new Date(sortedPosts[sortedPosts.length - 1].created_at)
+    : new Date();
+  const diffDays = (lastDate - firstDate) / (1000 * 60 * 60 * 24) || 1;
+  const postingFreq = (sortedPosts.length / diffDays).toFixed(2);
+  const followerRatio = profile.followers
+    ? (profile.followers / profile.following).toFixed(2)
+    : "0";
+
+  const hashtagMap = {};
+  const mentionMap = {};
+  const lineData = [];
+  const typeMap = {};
+  const heatmap = {};
+  const buckets = ["0-5", "6-11", "12-17", "18-23"];
+  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+  sortedPosts.forEach((p) => {
+    const eng =
+      ((p.like_count + p.comment_count + p.share_count) / profile.followers) *
+      100;
+    lineData.push({
+      date: new Date(p.created_at).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      }),
+      rate: parseFloat(eng.toFixed(2)),
+    });
+
+    if (!typeMap[p.type]) typeMap[p.type] = { total: 0, count: 0 };
+    typeMap[p.type].total += eng;
+    typeMap[p.type].count += 1;
+
+    const tags = p.caption.match(/#\w+/g) || [];
+    tags.forEach((t) => {
+      hashtagMap[t] = (hashtagMap[t] || 0) + 1;
+    });
+    const mentions = p.caption.match(/@\w+/g) || [];
+    mentions.forEach((m) => {
+      mentionMap[m] = (mentionMap[m] || 0) + 1;
+    });
+
+    const d = new Date(p.created_at);
+    const day = dayNames[d.getDay()];
+    const bucket = buckets[Math.floor(d.getHours() / 6)];
+    if (!heatmap[day]) heatmap[day] = {};
+    if (!heatmap[day][bucket]) heatmap[day][bucket] = 0;
+    heatmap[day][bucket] += eng / 10;
+  });
+
+  const typeData = Object.entries(typeMap).map(([type, v]) => ({
+    type,
+    engagement: parseFloat((v.total / v.count).toFixed(2)),
+  }));
+
+  const topHashtags = Object.entries(hashtagMap)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+  const topMentions = Object.entries(mentionMap)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
+      <div className="w-full max-w-5xl flex flex-col gap-8">
+        <h1 className="text-2xl font-bold text-blue-700">Instagram Post Analysis</h1>
+        <p className="text-gray-600">Analisis performa postingan Instagram.</p>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <CardStat title="Followers" value={profile.followers} />
+          <CardStat title="Following" value={profile.following} />
+          <CardStat title="Follower/Following" value={followerRatio} />
+          <CardStat title="Posts / Day" value={postingFreq} />
+        </div>
+
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h2 className="font-semibold mb-2">Engagement Trend</h2>
+          <EngagementLineChart data={lineData} />
+        </div>
+
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h2 className="font-semibold mb-2">Engagement by Content Type</h2>
+          <EngagementByTypeChart data={typeData} />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="bg-white p-4 rounded-xl shadow">
+            <h3 className="font-semibold mb-2">Top Hashtags</h3>
+            <ul className="list-disc ml-5 text-sm">
+              {topHashtags.map(([t, c]) => (
+                <li key={t}>{t} - {c}x</li>
+              ))}
+            </ul>
+          </div>
+          <div className="bg-white p-4 rounded-xl shadow">
+            <h3 className="font-semibold mb-2">Top Mentions</h3>
+            <ul className="list-disc ml-5 text-sm">
+              {topMentions.map(([m, c]) => (
+                <li key={m}>{m} - {c}x</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h3 className="font-semibold mb-2">Posting Time Heatmap</h3>
+          <HeatmapTable data={heatmap} days={dayNames} buckets={buckets} />
+        </div>
+
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h3 className="font-semibold mb-2">Posts Overview</h3>
+          <InstagramPostsGrid posts={sortedPosts} />
+        </div>
+
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h3 className="font-semibold mb-2">Post Metrics Comparison</h3>
+          <PostMetricsChart posts={sortedPosts} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -3,6 +3,7 @@ import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
 import { fetchInstagramPosts, fetchInstagramProfile, fetchInstagramInfo } from "../service/instaRapidService.js";
 import * as instaProfileService from "../service/instaProfileService.js";
+import * as instaPostCacheService from "../service/instaPostCacheService.js";
 import { sendSuccess } from "../utils/response.js";
 
 export async function getInstaRekapLikes(req, res) {
@@ -57,6 +58,32 @@ export async function getRapidInstagramPosts(req, res) {
       share_count: p.share_count,
       thumbnail: p.thumbnail || p.display_url
     }));
+    sendSuccess(res, posts);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+export async function getRapidInstagramPostsStore(req, res) {
+  try {
+    const username = req.query.username;
+    let limit = parseInt(req.query.limit);
+    if (Number.isNaN(limit) || limit <= 0) limit = 10;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    }
+    const rawPosts = await fetchInstagramPosts(username, limit);
+    const posts = rawPosts.map(p => ({
+      id: p.code || p.id || p.pk,
+      created_at: p.taken_at ? new Date(p.taken_at * 1000).toISOString() : p.created_at,
+      type: p.media_type || p.type,
+      caption: p.caption && typeof p.caption === 'object' ? p.caption.text : p.caption,
+      like_count: p.like_count,
+      comment_count: p.comment_count,
+      share_count: p.share_count,
+      thumbnail: p.thumbnail || p.display_url
+    }));
+    await instaPostCacheService.insertCache(username, posts);
     sendSuccess(res, posts);
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });

--- a/src/model/instaPostCacheModel.js
+++ b/src/model/instaPostCacheModel.js
@@ -1,0 +1,20 @@
+import { pool } from '../config/db.js';
+
+export async function insertCache(username, posts) {
+  if (!username) return;
+  await pool.query(
+    `INSERT INTO insta_post_cache (username, posts, fetched_at)
+     VALUES ($1, $2, NOW())`,
+    [username, JSON.stringify(posts)]
+  );
+}
+
+export async function getLatestCache(username) {
+  const res = await pool.query(
+    `SELECT posts, fetched_at FROM insta_post_cache
+     WHERE username = $1
+     ORDER BY fetched_at DESC LIMIT 1`,
+    [username]
+  );
+  return res.rows[0] || null;
+}

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,6 +1,6 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile, getRapidInstagramInfo, getInstagramProfile } from "../controller/instaController.js";
+import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile, getRapidInstagramInfo, getInstagramProfile, getRapidInstagramPostsStore } from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
@@ -8,6 +8,7 @@ const router = Router();
 router.get("/rekap-likes", authRequired, getInstaRekapLikes);
 router.get("/posts", authRequired, getInstaPosts);
 router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
+router.get("/rapid-posts-store", authRequired, getRapidInstagramPostsStore);
 router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
 router.get("/rapid-info", authRequired, getRapidInstagramInfo);
 router.get("/profile", authRequired, getInstagramProfile);

--- a/src/service/instaPostCacheService.js
+++ b/src/service/instaPostCacheService.js
@@ -1,0 +1,4 @@
+import * as cacheModel from '../model/instaPostCacheModel.js';
+
+export const insertCache = cacheModel.insertCache;
+export const getLatestCache = cacheModel.getLatestCache;


### PR DESCRIPTION
## Summary
- add Next.js Instagram analysis page
- implement backend cache for instagram posts
- expose `GET /insta/rapid-posts-store` endpoint
- document `insta_post_cache` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a5a6561808327b45b265f5846f01d