### PR TITLE
Improve Instagram analysis thumbnail data

### DIFF
--- a/src/utils/analyzeInstagram.js
+++ b/src/utils/analyzeInstagram.js
@@ -4,7 +4,12 @@ export function analyzeInstagramData(json) {
   }
 
   const posts = json.items.map(item => {
-    const thumbnail = item.thumbnail_url || (item.image_versions?.items?.[0]?.url);
+    const thumbnail =
+      item.thumbnail_url ||
+      item.thumbnail_src ||
+      item.display_url ||
+      (item.image_versions?.items?.[0]?.url) ||
+      (item.image_versions2?.candidates?.[0]?.url);
     const caption = typeof item.caption === 'object' ? item.caption.text : item.caption;
     const taken_at = item.taken_at_ts ? new Date(item.taken_at_ts * 1000).toISOString() : (item.taken_at || null);
     return {
@@ -14,6 +19,7 @@ export function analyzeInstagramData(json) {
       like_count: item.like_count || 0,
       comment_count: item.comment_count || 0,
       thumbnail_url: thumbnail || null,
+      thumbnail: thumbnail || null,
       is_video: item.is_video || false,
     };
   });

--- a/tests/analyzeInstagram.test.js
+++ b/tests/analyzeInstagram.test.js
@@ -10,6 +10,8 @@ describe('analyzeInstagramData', () => {
     expect(result.stats.total_posts).toBe(2);
     expect(result.stats.total_likes).toBe(15);
     expect(result.posts[0].thumbnail_url).toBe('a');
+    expect(result.posts[0].thumbnail).toBe('a');
     expect(result.posts[1].thumbnail_url).toBe('b');
+    expect(result.posts[1].thumbnail).toBe('b');
   });
 });


### PR DESCRIPTION
## Summary
- improve detection of thumbnail fields when analyzing Instagram data
- return a `thumbnail` alias property alongside `thumbnail_url`
- update unit tests for the new field

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a6062daa88327ba31b82e0eb12930