### PR TITLE
Add TikTok rapid info API

### DIFF
--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -1,6 +1,7 @@
 import * as tiktokPostService from '../service/tiktokPostService.js';
 import * as tiktokCommentService from '../service/tiktokCommentService.js';
 import { sendSuccess } from '../utils/response.js';
+import { fetchTiktokProfile, fetchTiktokPosts } from '../service/tiktokRapidService.js';
 
 export async function getTiktokComments(req, res, next) {
   try {
@@ -65,3 +66,31 @@ export async function getTiktokRekapKomentar(req, res) {
   }
 }
 
+
+export async function getRapidTiktokProfile(req, res) {
+  try {
+    const username = req.query.username;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    }
+    const profile = await fetchTiktokProfile(username);
+    sendSuccess(res, profile);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+export async function getRapidTiktokPosts(req, res) {
+  try {
+    const username = req.query.username;
+    let limit = parseInt(req.query.limit);
+    if (Number.isNaN(limit) || limit <= 0) limit = 10;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    }
+    const posts = await fetchTiktokPosts(username, limit);
+    sendSuccess(res, posts);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}

--- a/src/routes/tiktokRoutes.js
+++ b/src/routes/tiktokRoutes.js
@@ -1,5 +1,11 @@
 import { Router } from 'express';
-import { getTiktokComments, getTiktokRekapKomentar, getTiktokPosts } from '../controller/tiktokController.js';
+import {
+  getTiktokComments,
+  getTiktokRekapKomentar,
+  getTiktokPosts,
+  getRapidTiktokProfile,
+  getRapidTiktokPosts
+} from '../controller/tiktokController.js';
 import { authRequired } from '../middleware/authMiddleware.js';
 
 const router = Router();
@@ -7,5 +13,7 @@ const router = Router();
 router.get('/comments', authRequired, getTiktokComments);
 router.get('/rekap-komentar', authRequired, getTiktokRekapKomentar);
 router.get('/posts', authRequired, getTiktokPosts);
+router.get('/rapid-profile', authRequired, getRapidTiktokProfile);
+router.get('/rapid-posts', authRequired, getRapidTiktokPosts);
 
 export default router;

--- a/src/service/tiktokRapidService.js
+++ b/src/service/tiktokRapidService.js
@@ -1,0 +1,61 @@
+import axios from 'axios';
+
+const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY;
+const RAPIDAPI_HOST = 'tiktok-api23.p.rapidapi.com';
+
+function parsePosts(resData) {
+  let dataObj = resData?.data?.data || resData?.data?.result || resData?.data;
+  if (typeof dataObj === 'string') {
+    try {
+      dataObj = JSON.parse(dataObj);
+    } catch (e) {
+      dataObj = {};
+    }
+  }
+  if (Array.isArray(dataObj.itemList)) return dataObj.itemList;
+  if (Array.isArray(dataObj.items)) return dataObj.items;
+  if (Array.isArray(resData?.data?.result?.videos)) return resData.data.result.videos;
+  if (Array.isArray(dataObj.videos)) return dataObj.videos;
+  return [];
+}
+
+export async function fetchTiktokProfile(username) {
+  if (!username) return null;
+  const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/info`, {
+    params: { uniqueId: username.replace(/^@/, '') },
+    headers: {
+      'X-RapidAPI-Key': RAPIDAPI_KEY,
+      'X-RapidAPI-Host': RAPIDAPI_HOST,
+      'x-cache-control': 'no-cache'
+    }
+  });
+  const data = res.data?.userInfo;
+  if (!data) return res.data;
+  return {
+    username: data.user?.uniqueId,
+    nickname: data.user?.nickname,
+    follower_count: data.stats?.followerCount,
+    following_count: data.stats?.followingCount,
+    like_count: data.stats?.heart,
+    video_count: data.stats?.videoCount,
+    avatar_url: data.user?.avatarThumb
+  };
+}
+
+export async function fetchTiktokPosts(username, limit = 10) {
+  if (!username) return [];
+  const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/posts`, {
+    params: {
+      uniqueId: username.replace(/^@/, ''),
+      count: String(limit > 0 ? limit : 10),
+      cursor: '0'
+    },
+    headers: {
+      'X-RapidAPI-Key': RAPIDAPI_KEY,
+      'X-RapidAPI-Host': RAPIDAPI_HOST,
+      'x-cache-control': 'no-cache'
+    }
+  });
+  const items = parsePosts(res);
+  return limit ? items.slice(0, limit) : items;
+}


### PR DESCRIPTION
## Summary
- add service to fetch TikTok profile and posts from RapidAPI
- expose new `/tiktok/rapid-profile` and `/tiktok/rapid-posts` routes
- implement controller handlers for those routes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a90d2f4808327806fa1370c82f1fa