### PR TITLE
Add TikTok info endpoint

### DIFF
--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -1,7 +1,7 @@
 import * as tiktokPostService from '../service/tiktokPostService.js';
 import * as tiktokCommentService from '../service/tiktokCommentService.js';
 import { sendSuccess } from '../utils/response.js';
-import { fetchTiktokProfile, fetchTiktokPosts } from '../service/tiktokRapidService.js';
+import { fetchTiktokProfile, fetchTiktokPosts, fetchTiktokInfo } from '../service/tiktokRapidService.js';
 
 export async function getTiktokComments(req, res, next) {
   try {
@@ -75,6 +75,19 @@ export async function getRapidTiktokProfile(req, res) {
     }
     const profile = await fetchTiktokProfile(username);
     sendSuccess(res, profile);
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+export async function getRapidTiktokInfo(req, res) {
+  try {
+    const username = req.query.username;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    }
+    const info = await fetchTiktokInfo(username);
+    sendSuccess(res, info);
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });
   }

--- a/src/routes/tiktokRoutes.js
+++ b/src/routes/tiktokRoutes.js
@@ -4,7 +4,8 @@ import {
   getTiktokRekapKomentar,
   getTiktokPosts,
   getRapidTiktokProfile,
-  getRapidTiktokPosts
+  getRapidTiktokPosts,
+  getRapidTiktokInfo
 } from '../controller/tiktokController.js';
 import { authRequired } from '../middleware/authMiddleware.js';
 
@@ -15,5 +16,6 @@ router.get('/rekap-komentar', authRequired, getTiktokRekapKomentar);
 router.get('/posts', authRequired, getTiktokPosts);
 router.get('/rapid-profile', authRequired, getRapidTiktokProfile);
 router.get('/rapid-posts', authRequired, getRapidTiktokPosts);
+router.get('/rapid-info', authRequired, getRapidTiktokInfo);
 
 export default router;

--- a/src/service/tiktokRapidService.js
+++ b/src/service/tiktokRapidService.js
@@ -42,6 +42,26 @@ export async function fetchTiktokProfile(username) {
   };
 }
 
+export async function fetchTiktokInfo(username) {
+  if (!username) return null;
+  try {
+    const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/info`, {
+      params: { uniqueId: username.replace(/^@/, '') },
+      headers: {
+        'X-RapidAPI-Key': RAPIDAPI_KEY,
+        'X-RapidAPI-Host': RAPIDAPI_HOST,
+        'x-cache-control': 'no-cache'
+      }
+    });
+    return res.data || null;
+  } catch (err) {
+    const msg = err.response?.data
+      ? JSON.stringify(err.response.data)
+      : err.message;
+    throw new Error(msg);
+  }
+}
+
 export async function fetchTiktokPosts(username, limit = 10) {
   if (!username) return [];
   const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/posts`, {


### PR DESCRIPTION
## Summary
- add `fetchTiktokInfo` service
- expose `/api/tiktok/rapid-info` endpoint
- provide controller logic for new info route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a925afcc48327ab96a38abc7b6958