### PR TITLE
Add secUid based fetch for TikTok posts

### DIFF
--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -1,7 +1,12 @@
 import * as tiktokPostService from '../service/tiktokPostService.js';
 import * as tiktokCommentService from '../service/tiktokCommentService.js';
 import { sendSuccess } from '../utils/response.js';
-import { fetchTiktokProfile, fetchTiktokPosts, fetchTiktokInfo } from '../service/tiktokRapidService.js';
+import {
+  fetchTiktokProfile,
+  fetchTiktokPosts,
+  fetchTiktokPostsBySecUid,
+  fetchTiktokInfo
+} from '../service/tiktokRapidService.js';
 
 export async function getTiktokComments(req, res, next) {
   try {
@@ -95,13 +100,15 @@ export async function getRapidTiktokInfo(req, res) {
 
 export async function getRapidTiktokPosts(req, res) {
   try {
-    const username = req.query.username;
+    const { username, secUid } = req.query;
     let limit = parseInt(req.query.limit);
     if (Number.isNaN(limit) || limit <= 0) limit = 10;
-    if (!username) {
-      return res.status(400).json({ success: false, message: 'username wajib diisi' });
+    if (!username && !secUid) {
+      return res.status(400).json({ success: false, message: 'username atau secUid wajib diisi' });
     }
-    const posts = await fetchTiktokPosts(username, limit);
+    const posts = secUid
+      ? await fetchTiktokPostsBySecUid(secUid, limit)
+      : await fetchTiktokPosts(username, limit);
     sendSuccess(res, posts);
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });

--- a/src/service/tiktokRapidService.js
+++ b/src/service/tiktokRapidService.js
@@ -79,3 +79,21 @@ export async function fetchTiktokPosts(username, limit = 10) {
   const items = parsePosts(res);
   return limit ? items.slice(0, limit) : items;
 }
+
+export async function fetchTiktokPostsBySecUid(secUid, limit = 10) {
+  if (!secUid) return [];
+  const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/posts`, {
+    params: {
+      secUid,
+      count: String(limit > 0 ? limit : 10),
+      cursor: '0'
+    },
+    headers: {
+      'X-RapidAPI-Key': RAPIDAPI_KEY,
+      'X-RapidAPI-Host': RAPIDAPI_HOST,
+      'x-cache-control': 'no-cache'
+    }
+  });
+  const items = parsePosts(res);
+  return limit ? items.slice(0, limit) : items;
+}


### PR DESCRIPTION
## Summary
- add a helper to fetch TikTok posts using secUid
- support secUid query param in the `GET /tiktok/rapid-posts` route

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a962baee48327b229815e42757abf