### PR TITLE
Add request deduplication middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ import routes from './src/routes/index.js';
 import authRoutes from './src/routes/authRoutes.js';        // <--- tambahkan
 import { notFound, errorHandler } from './src/middleware/errorHandler.js';
 import { authRequired } from './src/middleware/authMiddleware.js'; // <--- tambahkan
+import { dedupRequest } from './src/middleware/dedupRequestMiddleware.js';
 
 // Load environment variables dulu
 dotenv.config();
@@ -29,6 +30,7 @@ app.use(cors({
 
 app.use(express.json());
 app.use(morgan('dev'));
+app.use(dedupRequest);
 
 // ===== ROUTE LOGIN (TANPA TOKEN) =====
 app.use('/api/auth', authRoutes);

--- a/src/middleware/dedupRequestMiddleware.js
+++ b/src/middleware/dedupRequestMiddleware.js
@@ -1,0 +1,37 @@
+import crypto from 'crypto';
+
+// Simple LRU cache to store recent request hashes and timestamps
+const cache = new Map();
+const MAX_ENTRIES = 1000; // limit memory usage
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+function cleanup() {
+  const now = Date.now();
+  for (const [key, ts] of cache) {
+    if (now - ts > TTL_MS) cache.delete(key);
+  }
+  while (cache.size > MAX_ENTRIES) {
+    const firstKey = cache.keys().next().value;
+    cache.delete(firstKey);
+  }
+}
+
+export function dedupRequest(req, res, next) {
+  try {
+    const hash = crypto
+      .createHash('sha1')
+      .update(req.method + req.originalUrl + JSON.stringify(req.body || {}))
+      .digest('hex');
+    const now = Date.now();
+    if (cache.has(hash) && now - cache.get(hash) < TTL_MS) {
+      return res
+        .status(429)
+        .json({ success: false, message: 'Duplicate request detected' });
+    }
+    cache.set(hash, now);
+    cleanup();
+  } catch (e) {
+    // If hashing fails, ignore dedup check to avoid blocking requests
+  }
+  next();
+}


### PR DESCRIPTION
## Summary
- add a small LRU-based cache to filter duplicate requests
- register the deduplication middleware in `app.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bcf6a8e4c8327b8633adb43351c2d