### PR TITLE
Allow concurrent user requests

### DIFF
--- a/src/middleware/dedupRequestMiddleware.js
+++ b/src/middleware/dedupRequestMiddleware.js
@@ -5,9 +5,16 @@ const TTL_SEC = 5 * 60; // 5 minutes
 
 export async function dedupRequest(req, res, next) {
   try {
+    const userPart =
+      req.user?.client_id || req.headers['x-client-id'] || req.ip || '';
     const hash = crypto
       .createHash('sha1')
-      .update(req.method + req.originalUrl + JSON.stringify(req.body || {}))
+      .update(
+        req.method +
+          req.originalUrl +
+          JSON.stringify(req.body || {}) +
+          userPart
+      )
       .digest('hex');
     const key = `dedup:${hash}`;
     const exists = await redis.exists(key);


### PR DESCRIPTION
## Summary
- ensure deduplication middleware includes client information so requests from different users aren't blocked

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c0bed08b883278f62c52d88ea5ecf