### PR TITLE
Add WA readiness check to avoid puppeteer errors

### DIFF
--- a/src/middleware/debugHandler.js
+++ b/src/middleware/debugHandler.js
@@ -1,6 +1,6 @@
 // src/middleware/debugHandler.js
 
-import waClient from "../service/waService.js";
+import waClient, { waReady } from "../service/waService.js";
 
 // Helper: stringifier aman untuk circular object
 function safeStringify(obj) {
@@ -45,8 +45,10 @@ export function sendDebug({ tag = "DEBUG", msg, client_id = "" } = {}) {
   if (client_id) prefix += `[${client_id}]`;
 
   const fullMsg = `${prefix} ${safeMsg}`;
-  for (const wa of adminWA) {
-    waClient.sendMessage(wa, fullMsg).catch(() => {});
+  if (waReady) {
+    for (const wa of adminWA) {
+      waClient.sendMessage(wa, fullMsg).catch(() => {});
+    }
   }
   console.log(fullMsg);
 }

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -82,6 +82,9 @@ const waClient = new Client({
   puppeteer: { headless: true },
 });
 
+// Track readiness state
+let waReady = false;
+
 // Handle QR code (scan)
 waClient.on("qr", (qr) => {
   qrcode.generate(qr, { small: true });
@@ -90,6 +93,7 @@ waClient.on("qr", (qr) => {
 
 // Wa Bot siap
 waClient.on("ready", () => {
+  waReady = true;
   console.log("[WA] WhatsApp client is ready!");
 });
 
@@ -1506,8 +1510,13 @@ Jika ingin menggunakan menu manual, copy & paste perintah di atas sesuai kebutuh
 // =======================
 // INISIALISASI WA CLIENT
 // =======================
-waClient.initialize();
+try {
+  waClient.initialize();
+} catch (err) {
+  console.error("[WA] Initialization failed:", err.message);
+}
 
 export default waClient;
+export { waReady };
 
 // ======================= end of file ======================


### PR DESCRIPTION
## Summary
- ensure WhatsApp client readiness flag before sending debug messages
- handle initialization errors gracefully

## Testing
- `npm test` *(fails: Cannot find module '/workspace/Cicero_V2/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_684c1cef9f1c8327bcf3dd9211333669