### PR TITLE
Enable admin login with any client

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Cicero_V2-main/
     REDIS_URL=redis://localhost:6379
     ```
 
+    Untuk login dashboard, Anda dapat menggunakan nomor operator masing-masing
+    atau salah satu nomor pada `ADMIN_WHATSAPP`. Cukup isi `client_id` yang ada
+    dan masukkan nomor admin tersebut pada kolom WhatsApp.
+
 3. **Install Redis:**
     ```bash
     sudo apt-get install redis-server

--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -1,12 +1,19 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { login } from "@/utils/api";
 
 export default function LoginPage() {
   const [clientId, setClientId] = useState("");
   const [wa, setWa] = useState(process.env.NEXT_PUBLIC_CLIENT_OPERATOR || "");
+  const [useAdmin, setUseAdmin] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const adminWa = (process.env.NEXT_PUBLIC_ADMIN_WHATSAPP || "").split(",")[0] || "";
+    const defaultOp = process.env.NEXT_PUBLIC_CLIENT_OPERATOR || "";
+    setWa(useAdmin ? adminWa : defaultOp);
+  }, [useAdmin]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -52,6 +59,15 @@ export default function LoginPage() {
             placeholder={process.env.NEXT_PUBLIC_ADMIN_WHATSAPP}
             required
           />
+        </label>
+        <label className="flex items-center mb-2 text-sm">
+          <input
+            type="checkbox"
+            className="mr-2"
+            checked={useAdmin}
+            onChange={(e) => setUseAdmin(e.target.checked)}
+          />
+          Login sebagai Admin
         </label>
         {error && <p className="text-red-500 text-sm">{error}</p>}
         <button


### PR DESCRIPTION
## Summary
- enable dashboard login using admin WhatsApp numbers
- add toggle on login page to login as admin
- document admin login in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684c353c180c8327ab5116d1a7e8e36d