### PR TITLE
Implement login limit per client

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ Cicero_V2-main/
 
     Untuk login dashboard, Anda dapat menggunakan nomor operator masing-masing
     atau salah satu nomor pada `ADMIN_WHATSAPP`. Cukup isi `client_id` yang ada
-    dan masukkan nomor admin tersebut pada kolom WhatsApp.
+    dan masukkan nomor admin tersebut pada kolom WhatsApp. Setiap `client_id`
+    dibatasi maksimal **3** sesi login aktif sekaligus (termasuk yang memakai
+    `ADMIN_WHATSAPP`).
 
 3. **Install Redis:**
     ```bash


### PR DESCRIPTION
## Summary
- enforce max 3 concurrent logins per `client_id` using Redis
- document the login limit in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c3ae93828832795848ef0e6617f6b