### PR TITLE
Allow multiple tokens through dedup middleware

### DIFF
--- a/src/middleware/dedupRequestMiddleware.js
+++ b/src/middleware/dedupRequestMiddleware.js
@@ -5,8 +5,15 @@ const TTL_SEC = 5 * 60; // 5 minutes
 
 export async function dedupRequest(req, res, next) {
   try {
+    const tokenPart = req.headers.authorization
+      ? req.headers.authorization.split(' ')[1]
+      : '';
     const userPart =
-      req.user?.client_id || req.headers['x-client-id'] || req.ip || '';
+      tokenPart ||
+      req.user?.client_id ||
+      req.headers['x-client-id'] ||
+      req.ip ||
+      '';
     const hash = crypto
       .createHash('sha1')
       .update(


### PR DESCRIPTION
## Summary
- handle duplicate account fetches by adding the Authorization token when computing the dedup key

## Testing
- `npm install --ignore-scripts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c3d967fd88327b8d78f6b504aacab