### PR TITLE
Allow duplicate requests on root path

### DIFF
--- a/src/middleware/dedupRequestMiddleware.js
+++ b/src/middleware/dedupRequestMiddleware.js
@@ -4,6 +4,10 @@ import redis from '../config/redis.js';
 const TTL_SEC = 5 * 60; // 5 minutes
 
 export async function dedupRequest(req, res, next) {
+  // Allow duplicate requests for the root path
+  if (req.path === '/') {
+    return next();
+  }
   try {
     const tokenPart = req.headers.authorization
       ? req.headers.authorization.split(' ')[1]


### PR DESCRIPTION
## Summary
- allow duplicate requests for the root `/` endpoint

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684c423a4fe083279d5d1e9e0c273581