### PR TITLE
Allow duplicate GET requests

### DIFF
--- a/src/middleware/dedupRequestMiddleware.js
+++ b/src/middleware/dedupRequestMiddleware.js
@@ -4,8 +4,13 @@ import redis from '../config/redis.js';
 const TTL_SEC = 5 * 60; // 5 minutes
 
 export async function dedupRequest(req, res, next) {
-  // Allow duplicate requests for the root path
-  if (req.path === '/') {
+  // Skip all checks if disabled via env var
+  if (process.env.ALLOW_DUPLICATE_REQUESTS === 'true') {
+    return next();
+  }
+
+  // Allow duplicate requests for the root path or for all GET requests
+  if (req.path === '/' || req.method === 'GET') {
     return next();
   }
   try {


### PR DESCRIPTION
## Summary
- update dedupRequest middleware to ignore GET requests
- add env option `ALLOW_DUPLICATE_REQUESTS` to disable dedup checks entirely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c449257788327941539dd1f0b4a3c