### PR TITLE
Add admin WA cleanup option

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -310,6 +310,16 @@ export async function createUser(userData) {
   return res.rows[0];
 }
 
+// Hapus field WhatsApp untuk semua user yang nomornya terdapat pada adminWAList
+export async function clearUsersWithAdminWA(adminWAList) {
+  if (!adminWAList || adminWAList.length === 0) return [];
+  const { rows } = await pool.query(
+    "UPDATE \"user\" SET whatsapp = '' WHERE whatsapp = ANY($1::text[]) RETURNING user_id",
+    [adminWAList]
+  );
+  return rows;
+}
+
 // --- Alias for backward compatibility ---
 export const findUsersByClientId = getUsersByClient;
 export const findUserByWA = findUserByWhatsApp;

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -293,6 +293,7 @@ Silakan balas angka *1-2* atau ketik *batal* untuk keluar.
 7️⃣ Absensi Username TikTok
 8️⃣ Transfer User
 9️⃣ Exception Info
+🔟 Hapus WA Admin
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Ketik *angka* menu, atau *batal* untuk keluar.
 `.trim()


### PR DESCRIPTION
## Summary
- add `Hapus WA Admin` option in client request menu
- implement handlers to clear whatsapp numbers matching `ADMIN_WHATSAPP`
- expose `clearUsersWithAdminWA` in `userModel`
- show new option when starting clientrequest session

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684c50fe6ff4832792acd500a7f7cdc1