### PR TITLE
Normalize WA admin prefix for deletion

### DIFF
--- a/src/handler/menu/clientRequestHandlers.js
+++ b/src/handler/menu/clientRequestHandlers.js
@@ -11,7 +11,7 @@ import {
   sortDivisionKeys,
   formatNama,
 } from "../../utils/utilsHelper.js";
-import { getAdminWAIds } from "../../utils/waHelper.js";
+import { getAdminWAIds, getAdminWANumbers } from "../../utils/waHelper.js";
 
 async function absensiUsernameInsta(client_id, userModel, mode = "all") {
   let sudah = [], belum = [];
@@ -1296,7 +1296,12 @@ export const clientRequestHandlers = {
       return;
     }
     try {
-      const updated = await userModel.clearUsersWithAdminWA(getAdminWAIds());
+      const numbers0 = getAdminWANumbers();
+      const numbers62 = numbers0.map((n) =>
+        n.startsWith("0") ? "62" + n.slice(1) : n
+      );
+      const targets = Array.from(new Set([...numbers0, ...numbers62]));
+      const updated = await userModel.clearUsersWithAdminWA(targets);
       await waClient.sendMessage(
         chatId,
         `✅ WhatsApp dikosongkan untuk ${updated.length} user.`

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -88,3 +88,14 @@ export function getAdminWAIds() {
     n.endsWith("@c.us") ? n : n.replace(/[^0-9]/g, "") + "@c.us"
   );
 }
+
+// Normalisasi nomor admin ke awalan 0 (tanpa @c.us)
+export function getAdminWANumbers() {
+  const numbers = ADMIN_WHATSAPP.map((n) => {
+    let num = String(n).replace(/[^0-9]/g, "");
+    if (num.startsWith("62")) num = "0" + num.slice(2);
+    if (!num.startsWith("0")) num = "0" + num;
+    return num;
+  });
+  return Array.from(new Set(numbers));
+}


### PR DESCRIPTION
## Summary
- normalize admin WA numbers to `0` prefix in helper
- use normalized variants when removing admin WhatsApp numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c593b372c83279fa55c76e1c750a1