### PR TITLE
Improve RapidAPI error handling

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -16,7 +16,8 @@ export async function getInstaRekapLikes(req, res) {
     const data = await getRekapLikesByClient(client_id, periode);
     res.json({ success: true, data });
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -35,7 +36,8 @@ export async function getInstaPosts(req, res) {
     const posts = await instaPostService.findByClientId(client_id);
     sendSuccess(res, posts);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -76,7 +78,8 @@ export async function getRapidInstagramPosts(req, res) {
     });
     sendSuccess(res, posts);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -118,7 +121,8 @@ export async function getRapidInstagramPostsStore(req, res) {
     await instaPostCacheService.insertCache(username, posts);
     sendSuccess(res, posts);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -142,7 +146,8 @@ export async function getRapidInstagramProfile(req, res) {
     }
     sendSuccess(res, profile);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -155,7 +160,8 @@ export async function getRapidInstagramInfo(req, res) {
     const info = await fetchInstagramInfo(username);
     sendSuccess(res, info);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -171,6 +177,7 @@ export async function getInstagramProfile(req, res) {
     }
     sendSuccess(res, profile);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -52,7 +52,8 @@ export async function getTiktokPosts(req, res) {
     const posts = await tiktokPostService.findByClientId(client_id);
     sendSuccess(res, posts);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -68,7 +69,8 @@ export async function getTiktokRekapKomentar(req, res) {
     const data = await getRekapKomentarByClient(client_id, periode);
     res.json({ success: true, data });
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -82,7 +84,8 @@ export async function getRapidTiktokProfile(req, res) {
     const profile = await fetchTiktokProfile(username);
     sendSuccess(res, profile);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -107,7 +110,8 @@ export async function getRapidTiktokInfo(req, res) {
     const info = await fetchTiktokInfo(username);
     sendSuccess(res, info);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }
 
@@ -139,6 +143,7 @@ export async function getRapidTiktokPosts(req, res) {
       : await fetchTiktokPosts(username, limit);
     sendSuccess(res, posts);
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
   }
 }

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -16,7 +16,9 @@ export async function fetchInstagramPosts(username, limit = 10) {
   });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(text);
+    const err = new Error(text);
+    err.statusCode = res.status;
+    throw err;
   }
   const data = await res.json();
   const items = data?.data?.items || [];
@@ -36,7 +38,9 @@ export async function fetchInstagramProfile(username) {
   });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(text);
+    const err = new Error(text);
+    err.statusCode = res.status;
+    throw err;
   }
   const data = await res.json();
   return data?.data || null;
@@ -57,7 +61,9 @@ export async function fetchInstagramInfo(username) {
     const msg = err.response?.data
       ? JSON.stringify(err.response.data)
       : err.message;
-    throw new Error(msg);
+    const error = new Error(msg);
+    error.statusCode = err.response?.status;
+    throw error;
   }
 }
 

--- a/src/service/tiktokRapidService.js
+++ b/src/service/tiktokRapidService.js
@@ -21,25 +21,34 @@ function parsePosts(resData) {
 
 export async function fetchTiktokProfile(username) {
   if (!username) return null;
-  const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/info`, {
-    params: { uniqueId: username.replace(/^@/, '') },
-    headers: {
-      'X-RapidAPI-Key': RAPIDAPI_KEY,
-      'X-RapidAPI-Host': RAPIDAPI_HOST,
-      'x-cache-control': 'no-cache'
-    }
-  });
-  const data = res.data?.userInfo;
-  if (!data) return res.data;
-  return {
-    username: data.user?.uniqueId,
-    nickname: data.user?.nickname,
-    follower_count: data.stats?.followerCount,
-    following_count: data.stats?.followingCount,
-    like_count: data.stats?.heart,
-    video_count: data.stats?.videoCount,
-    avatar_url: data.user?.avatarThumb
-  };
+  try {
+    const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/info`, {
+      params: { uniqueId: username.replace(/^@/, '') },
+      headers: {
+        'X-RapidAPI-Key': RAPIDAPI_KEY,
+        'X-RapidAPI-Host': RAPIDAPI_HOST,
+        'x-cache-control': 'no-cache'
+      }
+    });
+    const data = res.data?.userInfo;
+    if (!data) return res.data;
+    return {
+      username: data.user?.uniqueId,
+      nickname: data.user?.nickname,
+      follower_count: data.stats?.followerCount,
+      following_count: data.stats?.followingCount,
+      like_count: data.stats?.heart,
+      video_count: data.stats?.videoCount,
+      avatar_url: data.user?.avatarThumb
+    };
+  } catch (err) {
+    const msg = err.response?.data
+      ? JSON.stringify(err.response.data)
+      : err.message;
+    const error = new Error(msg);
+    error.statusCode = err.response?.status;
+    throw error;
+  }
 }
 
 export async function fetchTiktokInfo(username) {
@@ -58,42 +67,62 @@ export async function fetchTiktokInfo(username) {
     const msg = err.response?.data
       ? JSON.stringify(err.response.data)
       : err.message;
-    throw new Error(msg);
+    const error = new Error(msg);
+    error.statusCode = err.response?.status;
+    throw error;
   }
 }
 
 export async function fetchTiktokPosts(username, limit = 10) {
   if (!username) return [];
-  const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/posts`, {
-    params: {
-      uniqueId: username.replace(/^@/, ''),
-      count: String(limit > 0 ? limit : 10),
-      cursor: '0'
-    },
-    headers: {
-      'X-RapidAPI-Key': RAPIDAPI_KEY,
-      'X-RapidAPI-Host': RAPIDAPI_HOST,
-      'x-cache-control': 'no-cache'
-    }
-  });
-  const items = parsePosts(res);
-  return limit ? items.slice(0, limit) : items;
+  try {
+    const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/posts`, {
+      params: {
+        uniqueId: username.replace(/^@/, ''),
+        count: String(limit > 0 ? limit : 10),
+        cursor: '0'
+      },
+      headers: {
+        'X-RapidAPI-Key': RAPIDAPI_KEY,
+        'X-RapidAPI-Host': RAPIDAPI_HOST,
+        'x-cache-control': 'no-cache'
+      }
+    });
+    const items = parsePosts(res);
+    return limit ? items.slice(0, limit) : items;
+  } catch (err) {
+    const msg = err.response?.data
+      ? JSON.stringify(err.response.data)
+      : err.message;
+    const error = new Error(msg);
+    error.statusCode = err.response?.status;
+    throw error;
+  }
 }
 
 export async function fetchTiktokPostsBySecUid(secUid, limit = 10) {
   if (!secUid) return [];
-  const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/posts`, {
-    params: {
-      secUid,
-      count: String(limit > 0 ? limit : 10),
-      cursor: '0'
-    },
-    headers: {
-      'X-RapidAPI-Key': RAPIDAPI_KEY,
-      'X-RapidAPI-Host': RAPIDAPI_HOST,
-      'x-cache-control': 'no-cache'
-    }
-  });
-  const items = parsePosts(res);
-  return limit ? items.slice(0, limit) : items;
+  try {
+    const res = await axios.get(`https://${RAPIDAPI_HOST}/api/user/posts`, {
+      params: {
+        secUid,
+        count: String(limit > 0 ? limit : 10),
+        cursor: '0'
+      },
+      headers: {
+        'X-RapidAPI-Key': RAPIDAPI_KEY,
+        'X-RapidAPI-Host': RAPIDAPI_HOST,
+        'x-cache-control': 'no-cache'
+      }
+    });
+    const items = parsePosts(res);
+    return limit ? items.slice(0, limit) : items;
+  } catch (err) {
+    const msg = err.response?.data
+      ? JSON.stringify(err.response.data)
+      : err.message;
+    const error = new Error(msg);
+    error.statusCode = err.response?.status;
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary
- propagate RapidAPI status codes in Rapid TikTok and Instagram controllers
- attach status codes to Rapid service errors

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684d17cf07c08327bddb098dcad3c752