### PR TITLE
Update Instagram posts retrieval

### DIFF
--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -53,6 +53,17 @@ export async function getPostsByClientId(client_id) {
   return res.rows;
 }
 
+export async function getPostsThisMonthByClient(client_id) {
+  const res = await pool.query(
+    `SELECT * FROM insta_post
+     WHERE client_id = $1
+       AND created_at >= date_trunc('month', CURRENT_DATE)
+     ORDER BY created_at DESC`,
+    [client_id]
+  );
+  return res.rows;
+}
+
 export async function findByClientId(client_id) {
-  return getPostsByClientId(client_id);
+  return getPostsThisMonthByClient(client_id);
 }


### PR DESCRIPTION
## Summary
- limit `/posts` to show Instagram posts from the current month only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d25c4152883279f58e2b566214b60