### PR TITLE
Add month filter for rapid Instagram posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Cicero_V2-main/
 | Endpoint | Method | Deskripsi |
 |----------|--------|-----------|
 | `/insta/rapid-profile` | GET | Ambil profil Instagram via RapidAPI |
-| `/insta/rapid-posts`   | GET | Ambil postingan Instagram via RapidAPI |
+| `/insta/rapid-posts`   | GET | Ambil postingan Instagram via RapidAPI. Tambahkan query `month` dan `year` untuk filter bulan tertentu |
 | `/insta/profile`       | GET | Ambil profil Instagram dari database |
 
 ---

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -2,6 +2,7 @@
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
 import { fetchInstagramPosts, fetchInstagramProfile, fetchInstagramInfo } from "../service/instaRapidService.js";
+import { filterPostsByMonth } from "../utils/filterPosts.js";
 import * as instaProfileService from "../service/instaProfileService.js";
 import * as instaPostCacheService from "../service/instaPostCacheService.js";
 import { sendSuccess } from "../utils/response.js";
@@ -45,12 +46,14 @@ export async function getRapidInstagramPosts(req, res) {
   try {
     const username = req.query.username;
     let limit = parseInt(req.query.limit);
-    if (Number.isNaN(limit) || limit <= 0) limit = 10;
+    if (Number.isNaN(limit) || limit <= 0) limit = 100;
+    const month = req.query.month;
+    const year = req.query.year;
     if (!username) {
       return res.status(400).json({ success: false, message: 'username wajib diisi' });
     }
     const rawPosts = await fetchInstagramPosts(username, limit);
-    const posts = rawPosts.map(p => {
+    let posts = rawPosts.map(p => {
       const thumbnail =
         p.thumbnail_url ||
         p.thumbnail_src ||
@@ -76,6 +79,9 @@ export async function getRapidInstagramPosts(req, res) {
         thumbnail
       };
     });
+    if (month || year) {
+      posts = filterPostsByMonth(posts, month, year);
+    }
     sendSuccess(res, posts);
   } catch (err) {
     const code = err.statusCode || err.response?.status || 500;

--- a/src/utils/filterPosts.js
+++ b/src/utils/filterPosts.js
@@ -1,0 +1,14 @@
+export function filterPostsByMonth(posts, month, year) {
+  if (!Array.isArray(posts)) return [];
+  const now = new Date();
+  const m = parseInt(month);
+  const y = parseInt(year);
+  const monthNum = Number.isNaN(m) ? now.getMonth() + 1 : m;
+  const yearNum = Number.isNaN(y) ? now.getFullYear() : y;
+  const start = new Date(yearNum, monthNum - 1, 1);
+  const end = new Date(yearNum, monthNum, 1);
+  return posts.filter(p => {
+    const createdAt = new Date(p.created_at || p.taken_at || p.timestamp);
+    return createdAt >= start && createdAt < end;
+  });
+}

--- a/tests/filterPosts.test.js
+++ b/tests/filterPosts.test.js
@@ -1,0 +1,16 @@
+import { filterPostsByMonth } from '../src/utils/filterPosts.js';
+
+describe('filterPostsByMonth', () => {
+  test('returns posts within month', () => {
+    const posts = [
+      { created_at: '2024-05-31T23:00:00Z' },
+      { created_at: '2024-06-01T01:00:00Z' },
+      { created_at: '2024-06-15T12:00:00Z' },
+      { created_at: '2024-07-01T00:00:00Z' }
+    ];
+    const result = filterPostsByMonth(posts, 6, 2024);
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe(posts[1]);
+    expect(result[1]).toBe(posts[2]);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to filter posts by month
- expose `month`/`year` query for `/insta/rapid-posts`
- document the new parameters
- test filtering logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d2897b4e4832791c33257876003a5