### PR TITLE
Add pagination token helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Cicero_V2-main/
 | `/insta/rapid-posts`   | GET | Ambil postingan Instagram via RapidAPI |
 | `/insta/profile`       | GET | Ambil profil Instagram dari database |
 
+Fungsi utilitas `fetchInstagramPostsByMonthToken(username, bulan, tahun)`
+tersedia pada kode untuk mengambil seluruh postingan bulan tertentu
+dengan memanfaatkan parameter `pagination_token` dari RapidAPI.
+
 ---
 
 ## Fitur & Flow Bisnis Utama


### PR DESCRIPTION
## Summary
- implement helper functions using `pagination_token` to fetch monthly Instagram posts
- document new helper in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684d2db827bc832787e4ce7bbe8ab192