### PR TITLE
Add monthly Instagram posts fetch endpoint

### DIFF
--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,6 +1,6 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile, getRapidInstagramInfo, getInstagramProfile, getRapidInstagramPostsStore } from "../controller/instaController.js";
+import { getInstaRekapLikes, getInstaPosts, getRapidInstagramPosts, getRapidInstagramProfile, getRapidInstagramInfo, getInstagramProfile, getRapidInstagramPostsStore, getRapidInstagramPostsByMonth } from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
@@ -8,6 +8,7 @@ const router = Router();
 router.get("/rekap-likes", authRequired, getInstaRekapLikes);
 router.get("/posts", authRequired, getInstaPosts);
 router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
+router.get("/rapid-posts-month", authRequired, getRapidInstagramPostsByMonth);
 router.get("/rapid-posts-store", authRequired, getRapidInstagramPostsStore);
 router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
 router.get("/rapid-info", authRequired, getRapidInstagramInfo);


### PR DESCRIPTION
## Summary
- fetch Instagram posts for a specific month via RapidAPI
- expose new route `/insta/rapid-posts-month`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684d340532e8832798712d78aeec432d