### PR TITLE
Limit WA debug output

### DIFF
--- a/src/middleware/debugHandler.js
+++ b/src/middleware/debugHandler.js
@@ -45,11 +45,21 @@ export function sendDebug({ tag = "DEBUG", msg, client_id = "" } = {}) {
   if (client_id) prefix += `[${client_id}]`;
 
   const fullMsg = `${prefix} ${safeMsg}`;
-  if (waReady) {
+
+  const isStartOrEnd = /\b(mulai|start|selesai|end)\b/i.test(safeMsg);
+  const isError = /error/i.test(safeMsg);
+
+  if (waReady && (isStartOrEnd || isError)) {
+    let waMsg = fullMsg;
+    if (isError) {
+      // kirim hanya potongan pendek agar tidak mengandung raw data
+      waMsg = `${prefix} ${safeMsg.toString().substring(0, 200)}`;
+    }
     for (const wa of adminWA) {
-      waClient.sendMessage(wa, fullMsg).catch(() => {});
+      waClient.sendMessage(wa, waMsg).catch(() => {});
     }
   }
+
   console.log(fullMsg);
 }
 


### PR DESCRIPTION
## Summary
- send WhatsApp debug messages only for start/end/error situations
- truncate error notifications to avoid sending raw data

## Testing
- `npm test` *(fails: Cannot find module 'jest' due to blocked dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_684d630ef9448327ba7e8425ce7b4d3e