### PR TITLE
Update README with monthly fetch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ dengan memanfaatkan parameter `pagination_token` dari RapidAPI.
 Fungsi ini akan menelusuri semua halaman hingga token paginasi habis
 agar seluruh data posting pada bulan tersebut tersimpan.
 
+Contoh penggunaannya:
+
+```javascript
+import { fetchInstagramPostsByMonthToken } from './src/service/instaRapidService.js';
+
+async function fetchPosts() {
+  const username = 'polresbojonegoroofficial';
+  // bulan menggunakan format 1-12, tahun format 4 digit
+  const posts = await fetchInstagramPostsByMonthToken(username, 6, 2025);
+  console.log('total posts', posts.length);
+}
+
+fetchPosts();
+```
+
+Fungsi di atas akan melakukan request awal tanpa `pagination_token` dan
+secara otomatis melanjutkan ke halaman berikutnya menggunakan token yang
+diberikan hingga semua data pada bulan tersebut diperoleh.
+
 ---
 
 ## Fitur & Flow Bisnis Utama


### PR DESCRIPTION
## Summary
- add instructions showing how to use `fetchInstagramPostsByMonthToken` for monthly post retrieval with pagination

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684d6c409098832781c3735dd7b73f64