### PR TITLE
Clarify monthly IG pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,13 @@ Cicero_V2-main/
 Fungsi utilitas `fetchInstagramPostsByMonthToken(username, bulan, tahun)`
 tersedia pada kode untuk mengambil seluruh postingan bulan tertentu
 dengan memanfaatkan parameter `pagination_token` dari RapidAPI.
-Fungsi ini akan menelusuri semua halaman hingga token paginasi habis
-agar seluruh data posting pada bulan tersebut tersimpan.
+Pengambilan data akan berhenti ketika sudah ditemukan posting
+dengan tanggal di luar rentang bulan yang diminta.
+Hal ini karena data dari RapidAPI sudah diurutkan dari yang terbaru
+sehingga setelah ada tanggal lebih lama, tidak ada lagi posting
+dari bulan tersebut di halaman selanjutnya. Semua posting yang
+terkumpul kemudian difilter sehingga hanya tersisa data pada bulan
+yang diminta.
 
 ---
 

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -163,6 +163,10 @@ export async function fetchInstagramPostsByMonthToken(username, month, year) {
     const last = items[items.length - 1];
     const lastDate = new Date((last.taken_at ? last.taken_at * 1000 : last.created_at || 0));
     token = next_token;
+    // Stop early when the last item falls before the requested month
+    // because results are returned in descending order. Once a date is
+    // older than the start of the month, no further pages will contain
+    // newer posts from that month.
     if (!has_more || !token || lastDate < start) break;
   } while (true);
 


### PR DESCRIPTION
## Summary
- clarify monthly fetch logic in README
- document early exit condition in `fetchInstagramPostsByMonthToken`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm install` *(fails: Download failed from storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684d6dee80a083278bc8d3ef12a2e7a0