### PR TITLE
Implement pagination delay for monthly IG post fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ sehingga setelah ada tanggal lebih lama, tidak ada lagi posting
 dari bulan tersebut di halaman selanjutnya. Semua posting yang
 terkumpul kemudian difilter sehingga hanya tersisa data pada bulan
 yang diminta.
+Jika `bulan` atau `tahun` tidak diberikan, fungsi otomatis mengambil
+postingan pada bulan dan tahun berjalan. Setiap permintaan paginasi
+ditunda selama 1.5 detik untuk menghindari batasan API.
 
 ---
 

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -221,6 +221,9 @@ export async function fetchInstagramPostsByMonthToken(username, month, year) {
     // older than the start of the month, no further pages will contain
     // newer posts from that month.
     if (!has_more || !token || lastDate < start) break;
+
+    // add delay between pagination requests
+    await new Promise(resolve => setTimeout(resolve, 1500));
   } while (true);
 
   logDebug('fetchInstagramPostsByMonthToken done', { total: all.length });


### PR DESCRIPTION
## Summary
- add 1.5s delay between RapidAPI pagination calls
- document default month behaviour and new delay in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d954814dc8327823b8180849318c9