### PR TITLE
Rename logDebug to sendConsoledebug

### DIFF
--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -4,32 +4,32 @@ const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY;
 const RAPIDAPI_HOST = 'social-api4.p.rapidapi.com';
 const DEBUG_FETCH_IG = process.env.DEBUG_FETCH_INSTAGRAM === 'true';
 
-function logDebug(...args) {
+function sendConsoledebug(...args) {
   if (DEBUG_FETCH_IG) console.log('[DEBUG IG]', ...args);
 }
 
 export async function fetchInstagramPosts(username, limit = 10) {
   if (!username) return [];
 
-  logDebug('fetchInstagramPosts start', { username, limit });
+  sendConsoledebug('fetchInstagramPosts start', { username, limit });
 
   const all = [];
   let token = null;
 
   do {
-    logDebug('fetchInstagramPostsPageToken', { token });
+    sendConsoledebug('fetchInstagramPostsPageToken', { token });
     const { items, next_token, has_more } = await fetchInstagramPostsPageToken(username, token);
-    logDebug('fetched page', { items: items.length, next_token, has_more });
+    sendConsoledebug('fetched page', { items: items.length, next_token, has_more });
     // show raw items for debugging
-    logDebug('page items', items);
+    sendConsoledebug('page items', items);
     if (!items.length) break;
     all.push(...items);
     token = next_token;
-    logDebug('pagination token updated', { token });
+    sendConsoledebug('pagination token updated', { token });
     if (!has_more || !token || (limit && all.length >= limit)) break;
   } while (true);
 
-  logDebug('fetchInstagramPosts done', { total: all.length });
+  sendConsoledebug('fetchInstagramPosts done', { total: all.length });
 
   return limit ? all.slice(0, limit) : all;
 }
@@ -38,7 +38,7 @@ export async function fetchInstagramProfile(username) {
   if (!username) return null;
   const params = new URLSearchParams({ username_or_id_or_url: username });
 
-  logDebug('fetchInstagramProfile request', params.toString());
+  sendConsoledebug('fetchInstagramProfile request', params.toString());
 
   const res = await fetch(`https://${RAPIDAPI_HOST}/v1/info?${params.toString()}`, {
     headers: {
@@ -51,18 +51,18 @@ export async function fetchInstagramProfile(username) {
     const text = await res.text();
     const err = new Error(text);
     err.statusCode = res.status;
-    logDebug('fetchInstagramProfile error', err.message);
+    sendConsoledebug('fetchInstagramProfile error', err.message);
     throw err;
   }
   const data = await res.json();
-  logDebug('fetchInstagramProfile success');
+  sendConsoledebug('fetchInstagramProfile success');
   return data?.data || null;
 }
 
 export async function fetchInstagramInfo(username) {
   if (!username) return null;
   try {
-    logDebug('fetchInstagramInfo request', username);
+    sendConsoledebug('fetchInstagramInfo request', username);
     const response = await axios.get(`https://${RAPIDAPI_HOST}/v1/info`, {
       params: { username_or_id_or_url: username },
       headers: {
@@ -70,7 +70,7 @@ export async function fetchInstagramInfo(username) {
         'X-RapidAPI-Host': RAPIDAPI_HOST,
       },
     });
-    logDebug('fetchInstagramInfo success');
+    sendConsoledebug('fetchInstagramInfo success');
     return response.data?.data || null;
   } catch (err) {
     const msg = err.response?.data
@@ -78,7 +78,7 @@ export async function fetchInstagramInfo(username) {
       : err.message;
     const error = new Error(msg);
     error.statusCode = err.response?.status;
-    logDebug('fetchInstagramInfo error', error.message);
+    sendConsoledebug('fetchInstagramInfo error', error.message);
     throw error;
   }
 }
@@ -88,7 +88,7 @@ export async function fetchInstagramPostsPage(username, cursor = null) {
   const params = new URLSearchParams({ username_or_id_or_url: username });
   if (cursor) params.append('pagination_token', cursor);
 
-  logDebug('fetchInstagramPostsPage request', { username, cursor });
+  sendConsoledebug('fetchInstagramPostsPage request', { username, cursor });
 
   const res = await fetch(`https://${RAPIDAPI_HOST}/v1/posts?${params.toString()}`, {
     headers: {
@@ -101,7 +101,7 @@ export async function fetchInstagramPostsPage(username, cursor = null) {
     const text = await res.text();
     const err = new Error(text);
     err.statusCode = res.status;
-    logDebug('fetchInstagramPostsPage error', err.message);
+    sendConsoledebug('fetchInstagramPostsPage error', err.message);
     throw err;
   }
   const data = await res.json();
@@ -113,7 +113,7 @@ export async function fetchInstagramPostsPage(username, cursor = null) {
     null;
   const has_more =
     (data?.data?.has_more || false) || (next_cursor && next_cursor !== '');
-  logDebug('fetchInstagramPostsPage success', { items: items.length, next_cursor, has_more });
+  sendConsoledebug('fetchInstagramPostsPage success', { items: items.length, next_cursor, has_more });
   return { items, next_cursor, has_more };
 }
 
@@ -130,13 +130,13 @@ export async function fetchInstagramPostsByMonth(username, month, year) {
   let cursor = null;
   const all = [];
 
-  logDebug('fetchInstagramPostsByMonth start', { username, month: monthNum, year: yearNum });
+  sendConsoledebug('fetchInstagramPostsByMonth start', { username, month: monthNum, year: yearNum });
 
   do {
-    logDebug('fetchInstagramPostsPage', { cursor });
+    sendConsoledebug('fetchInstagramPostsPage', { cursor });
 
     const { items, pagination_token } = await fetchInstagramPostsPage(username, cursor);
-    logDebug('fetched page', { items: items.length, pagination_token });
+    sendConsoledebug('fetched page', { items: items.length, pagination_token });
     if (!items.length) break;
     all.push(...items);
 
@@ -146,7 +146,7 @@ export async function fetchInstagramPostsByMonth(username, month, year) {
     if (!cursor || lastDate < start) break;
   } while (true);
 
-  logDebug('fetchInstagramPostsByMonth done', { total: all.length });
+  sendConsoledebug('fetchInstagramPostsByMonth done', { total: all.length });
 
   return all.filter(p => {
     const d = new Date(p.taken_at ? p.taken_at * 1000 : p.created_at || 0);
@@ -159,7 +159,7 @@ export async function fetchInstagramPostsPageToken(username, token = null) {
   const params = new URLSearchParams({ username_or_id_or_url: username });
   if (token) params.append('pagination_token', token);
 
-  logDebug('fetchInstagramPostsPageToken request', { token });
+  sendConsoledebug('fetchInstagramPostsPageToken request', { token });
 
   const res = await fetch(`https://${RAPIDAPI_HOST}/v1/posts?${params.toString()}`, {
     headers: {
@@ -172,22 +172,22 @@ export async function fetchInstagramPostsPageToken(username, token = null) {
     const text = await res.text();
     const err = new Error(text);
     err.statusCode = res.status;
-    logDebug('fetchInstagramPostsPageToken error', err.message);
+    sendConsoledebug('fetchInstagramPostsPageToken error', err.message);
     throw err;
   }
   const data = await res.json();
   // log raw response data for debugging and to inspect pagination token
-  logDebug('fetchInstagramPostsPageToken raw', data);
+  sendConsoledebug('fetchInstagramPostsPageToken raw', data);
   const items = data?.data?.items || [];
   const next_token =
     data?.pagination_token ||
     null;
-  logDebug('fetchInstagramPostsPageToken success', { items: items.length, next_token });
+  sendConsoledebug('fetchInstagramPostsPageToken success', { items: items.length, next_token });
   return { items, next_token };
 }
 
 export async function fetchInstagramPostsByMonthToken(username, month, year) {
-  logDebug('fetchInstagramPostsByMonthToken XXX', {username});
+  sendConsoledebug('fetchInstagramPostsByMonthToken XXX', {username});
 
 
   if (!username) return [];
@@ -203,22 +203,22 @@ export async function fetchInstagramPostsByMonthToken(username, month, year) {
   let token = null;
   const all = [];
 
-  logDebug('fetchInstagramPostsByMonthToken start', { username, month: monthNum, year: yearNum });
+  sendConsoledebug('fetchInstagramPostsByMonthToken start', { username, month: monthNum, year: yearNum });
 
   do {
 
-    logDebug('fetchInstagramPostsPageToken', { token });
+    sendConsoledebug('fetchInstagramPostsPageToken', { token });
     const { items, pagination_token } = await fetchInstagramPostsPageToken(username, token);
-    logDebug('fetched page', { items: items.length, pagination_token });
+    sendConsoledebug('fetched page', { items: items.length, pagination_token });
     // show raw items for debugging
-    logDebug('page items', items);
+    sendConsoledebug('page items', items);
     if (!items.length) break;
     all.push(...items);
 
     const last = items[items.length - 1];
     const lastDate = new Date((last.taken_at ? last.taken_at * 1000 : last.created_at || 0));
     token = pagination_token;
-    logDebug('pagination token updated', { token });
+    sendConsoledebug('pagination token updated', { token });
     // Stop early when the last item falls before the requested month
     // because results are returned in descending order. Once a date is
     // older than the start of the month, no further pages will contain
@@ -229,7 +229,7 @@ export async function fetchInstagramPostsByMonthToken(username, month, year) {
     await new Promise(resolve => setTimeout(resolve, 1500));
   } while (true);
 
-  logDebug('fetchInstagramPostsByMonthToken done', { total: all.length });
+  sendConsoledebug('fetchInstagramPostsByMonthToken done', { total: all.length });
 
   return all.filter(p => {
     const d = new Date(p.taken_at ? p.taken_at * 1000 : p.created_at || 0);


### PR DESCRIPTION
## Summary
- rename internal `logDebug` helper to `sendConsoledebug`
- update all callsites to use the new name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da2d4c8a883279ef5bae96abaacb7