### PR TITLE
Fix pagination merge for Instagram posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ dengan tanggal di luar rentang bulan yang diminta.
 Hal ini karena data dari RapidAPI sudah diurutkan dari yang terbaru
 sehingga setelah ada tanggal lebih lama, tidak ada lagi posting
 dari bulan tersebut di halaman selanjutnya. Semua posting yang
-terkumpul kemudian difilter sehingga hanya tersisa data pada bulan
-yang diminta.
+terkumpul dari setiap halaman kemudian digabung dan difilter sehingga
+semua data pada bulan yang diminta dapat masuk ke dalam daftar.
 Jika `bulan` atau `tahun` tidak diberikan, fungsi otomatis mengambil
 postingan pada bulan dan tahun berjalan. Setiap permintaan paginasi
 ditunda selama 1.5 detik untuk menghindari batasan API.

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -155,7 +155,7 @@ export async function fetchInstagramPostsByMonth(username, month, year) {
 }
 
 export async function fetchInstagramPostsPageToken(username, token = null) {
-  if (!username) return { items: [], pagination_token: null};
+  if (!username) return { items: [], next_token: null, has_more: false};
   const params = new URLSearchParams({ username_or_id_or_url: username });
   if (token) params.append('pagination_token', token);
 
@@ -179,11 +179,10 @@ export async function fetchInstagramPostsPageToken(username, token = null) {
   // log raw response data for debugging and to inspect pagination token
   sendConsoledebug('fetchInstagramPostsPageToken raw', data);
   const items = data?.data?.items || [];
-  const next_token =
-    data?.pagination_token ||
-    null;
-  sendConsoledebug('fetchInstagramPostsPageToken success', { items: items.length, next_token });
-  return { items, next_token };
+  const next_token = data?.pagination_token || null;
+  const has_more = (data?.has_more || false) || (next_token && next_token !== '');
+  sendConsoledebug('fetchInstagramPostsPageToken success', { items: items.length, next_token, has_more });
+  return { items, next_token, has_more };
 }
 
 export async function fetchInstagramPostsByMonthToken(username, month, year) {
@@ -208,8 +207,8 @@ export async function fetchInstagramPostsByMonthToken(username, month, year) {
   do {
 
     sendConsoledebug('fetchInstagramPostsPageToken', { token });
-    const { items, pagination_token } = await fetchInstagramPostsPageToken(username, token);
-    sendConsoledebug('fetched page', { items: items.length, pagination_token });
+    const { items, next_token } = await fetchInstagramPostsPageToken(username, token);
+    sendConsoledebug('fetched page', { items: items.length, next_token });
     // show raw items for debugging
     sendConsoledebug('page items', items);
     if (!items.length) break;
@@ -217,7 +216,7 @@ export async function fetchInstagramPostsByMonthToken(username, month, year) {
 
     const last = items[items.length - 1];
     const lastDate = new Date((last.taken_at ? last.taken_at * 1000 : last.created_at || 0));
-    token = pagination_token;
+    token = next_token;
     sendConsoledebug('pagination token updated', { token });
     // Stop early when the last item falls before the requested month
     // because results are returned in descending order. Once a date is


### PR DESCRIPTION
## Summary
- ensure `fetchInstagramPostsPageToken` returns `has_more` and correct token
- use `next_token` when collecting month posts
- clarify README about merging paginated data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da57c95188327a03a29c6e2bb2afe