### PR TITLE
Fix null waClient on IG cron

### DIFF
--- a/src/handler/fetchEngagement/fetchLikesInstagram.js
+++ b/src/handler/fetchEngagement/fetchLikesInstagram.js
@@ -139,7 +139,12 @@ export async function handleFetchLikesInstagram(waClient, chatId, client_id) {
     );
 
     if (!rows.length) {
-      await waClient.sendMessage(chatId, `Tidak ada konten IG hari ini untuk client ${client_id}.`);
+      if (waClient && chatId) {
+        await waClient.sendMessage(
+          chatId,
+          `Tidak ada konten IG hari ini untuk client ${client_id}.`
+        );
+      }
       return;
     }
 
@@ -159,15 +164,19 @@ export async function handleFetchLikesInstagram(waClient, chatId, client_id) {
       }
     }
 
-    await waClient.sendMessage(
-      chatId,
-      `✅ Selesai fetch likes IG client ${client_id}. Berhasil: ${sukses}, Gagal: ${gagal}`
-    );
+    if (waClient && chatId) {
+      await waClient.sendMessage(
+        chatId,
+        `✅ Selesai fetch likes IG client ${client_id}. Berhasil: ${sukses}, Gagal: ${gagal}`
+      );
+    }
   } catch (err) {
-    await waClient.sendMessage(
-      chatId,
-      `❌ Error utama fetch likes IG: ${(err && err.message) || String(err)}`
-    );
+    if (waClient && chatId) {
+      await waClient.sendMessage(
+        chatId,
+        `❌ Error utama fetch likes IG: ${(err && err.message) || String(err)}`
+      );
+    }
     sendDebug({
       tag: "IG FETCH LIKES ERROR",
       msg: (err && err.message) || String(err),


### PR DESCRIPTION
## Summary
- check waClient and chatId before calling `sendMessage` in `handleFetchLikesInstagram`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e400acb6c8327868a3789d2050083