### PR TITLE
Refactor client summary to service layer

### DIFF
--- a/src/controller/clientController.js
+++ b/src/controller/clientController.js
@@ -137,31 +137,9 @@ export const getTiktokComments = async (req, res, next) => {
 export const getSummary = async (req, res, next) => {
   try {
     const client_id = req.params.client_id;
-    const client = await clientService.findClientById(client_id);
-    if (!client) return res.status(404).json({ error: 'Client not found' });
-
-    const users = await userModel.findUsersByClientId(client_id);
-    const instaPosts = await instaPostService.findByClientId(client_id);
-    let instaLikes = 0;
-    for (const post of instaPosts) {
-      const like = await instaLikeService.findByShortcode(post.shortcode);
-      instaLikes += Array.isArray(like?.likes) ? like.likes.length : 0;
-    }
-    const tiktokPosts = await tiktokPostService.findByClientId(client_id);
-    let tiktokComments = 0;
-    for (const post of tiktokPosts) {
-      const comm = await tiktokCommentService.findByVideoId(post.video_id);
-      tiktokComments += Array.isArray(comm?.comments) ? comm.comments.length : 0;
-    }
-
-    sendSuccess(res, {
-      client,
-      user_count: users.length,
-      insta_post_count: instaPosts.length,
-      tiktok_post_count: tiktokPosts.length,
-      total_insta_likes: instaLikes,
-      total_tiktok_comments: tiktokComments,
-    });
+    const summary = await clientService.getClientSummary(client_id);
+    if (!summary) return res.status(404).json({ error: 'Client not found' });
+    sendSuccess(res, summary);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- move business logic for client summary from controller to service
- expose new `getClientSummary` in the client service
- update controller to call the service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec112426c8327a7e9cb3cc22a3e09