### PR TITLE
Add RabbitMQ queue service

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,13 @@ CREATE TABLE insta_post_cache (
 - Tambahkan monitoring health DB, cron, dan log WhatsApp.
 - Optimasi DB dengan index pada field utama.
 
+## High Volume Queue (RabbitMQ)
+
+- Untuk memproses pekerjaan berjumlah besar secara asinkron gunakan RabbitMQ.
+- Atur URL koneksi pada variabel `AMQP_URL` di `.env`.
+- Service queue tersedia di `src/service/rabbitMQService.js` dengan fungsi
+  `publishToQueue` dan `consumeQueue`.
+
 ---
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "amqplib": "^0.10.8",
         "crypto-js": "^4.2.0",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
@@ -1599,6 +1600,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/amqplib": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.8.tgz",
+      "integrity": "sha512-Tfn1O9sFgAP8DqeMEpt2IacsVTENBpblB3SqLdn0jK2AeX8iyCvbptBc8lyATT9bQ31MsjVwUSQ1g8f4jHOUfw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2115,6 +2129,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT"
     },
     "node_modules/buffers": {
       "version": "0.1.1",
@@ -5994,6 +6014,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6111,6 +6137,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -6890,6 +6922,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"**/*.js\""
   },
   "dependencies": {
+    "amqplib": "^0.10.8",
     "crypto-js": "^4.2.0",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -17,5 +17,6 @@ export const env = cleanEnv(process.env, {
   RAPIDAPI_KEY: str({ default: '' }),
   ADMIN_WHATSAPP: str({ default: '' }),
   APP_SESSION_NAME: str({ default: '' }),
-  DEBUG_FETCH_INSTAGRAM: bool({ default: false })
+  DEBUG_FETCH_INSTAGRAM: bool({ default: false }),
+  AMQP_URL: str({ default: 'amqp://localhost' })
 });

--- a/src/service/rabbitMQService.js
+++ b/src/service/rabbitMQService.js
@@ -1,0 +1,37 @@
+import amqp from 'amqplib';
+import { env } from '../config/env.js';
+
+let connection = null;
+let channel = null;
+
+export async function initRabbitMQ() {
+  if (connection && channel) return { connection, channel };
+  connection = await amqp.connect(env.AMQP_URL);
+  channel = await connection.createChannel();
+  return { connection, channel };
+}
+
+export async function publishToQueue(queue, msg) {
+  if (!channel) await initRabbitMQ();
+  await channel.assertQueue(queue, { durable: true });
+  return channel.sendToQueue(queue, Buffer.from(JSON.stringify(msg)), {
+    persistent: true
+  });
+}
+
+export async function consumeQueue(queue, onMessage) {
+  if (!channel) await initRabbitMQ();
+  await channel.assertQueue(queue, { durable: true });
+  channel.consume(queue, async (msg) => {
+    if (msg === null) return;
+    try {
+      const data = JSON.parse(msg.content.toString());
+      await onMessage(data);
+      channel.ack(msg);
+    } catch (err) {
+      console.error('[RabbitMQ] consumer error', err);
+      channel.nack(msg, false, false);
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- add amqplib dependency
- support `AMQP_URL` environment variable
- implement RabbitMQ queue service with basic publish/consume helpers
- document queue usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f9cfe19a083279abc2460304d2c11