### PR TITLE
Add Instagram webhook callback routes

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -17,6 +17,7 @@ export const env = cleanEnv(process.env, {
   RAPIDAPI_KEY: str({ default: '' }),
   ADMIN_WHATSAPP: str({ default: '' }),
   APP_SESSION_NAME: str({ default: '' }),
+  IG_VERIFY_TOKEN: str({ default: '' }),
   DEBUG_FETCH_INSTAGRAM: bool({ default: false }),
   AMQP_URL: str({ default: 'amqp://localhost' })
 });

--- a/src/controller/instaCallbackController.js
+++ b/src/controller/instaCallbackController.js
@@ -1,0 +1,17 @@
+import { env } from '../config/env.js';
+
+export function verifyWebhook(req, res) {
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+
+  if (mode === 'subscribe' && token === env.IG_VERIFY_TOKEN) {
+    return res.status(200).send(challenge);
+  }
+  return res.status(403).send('Forbidden');
+}
+
+export function receiveWebhook(req, res) {
+  console.log('[IG WEBHOOK]', JSON.stringify(req.body));
+  res.status(200).json({ received: true });
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,6 +4,7 @@ import clientRoutes from './clientRoutes.js';
 import authRoutes from './authRoutes.js';
 import dashboardRoutes from "./dashboardRoutes.js";
 import instaRoutes from "./instaRoutes.js";
+import instaCallbackRoutes from "./instaCallbackRoutes.js";
 import tiktokRoutes from "./tiktokRoutes.js";
 
 const router = express.Router();
@@ -12,6 +13,7 @@ router.use('/clients', clientRoutes);
 router.use('/users', userRoutes); // Pastikan sudah ada baris ini!
 router.use('/auth', authRoutes);
 router.use("/dashboard", dashboardRoutes);
+router.use("/insta/callback", instaCallbackRoutes);
 router.use("/insta", instaRoutes);
 router.use("/tiktok", tiktokRoutes);
 

--- a/src/routes/instaCallbackRoutes.js
+++ b/src/routes/instaCallbackRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { verifyWebhook, receiveWebhook } from '../controller/instaCallbackController.js';
+
+const router = Router();
+
+router.get('/', verifyWebhook);
+router.post('/', receiveWebhook);
+
+export default router;


### PR DESCRIPTION
## Summary
- allow IG_VERIFY_TOKEN env var
- handle Instagram webhook verification and events
- expose `/api/insta/callback` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fb9af12808327b5f42ed0879b5de2