### PR TITLE
Refactor API calls into dedicated services

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -1,7 +1,7 @@
 // src/controller/instaController.js
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
-import { fetchInstagramPosts, fetchInstagramProfile, fetchInstagramInfo, fetchInstagramPostsByMonthToken } from "../service/instaRapidService.js";
+import { fetchInstagramPosts, fetchInstagramProfile, fetchInstagramInfo, fetchInstagramPostsByMonthToken } from "../service/instagramApi.js";
 import * as instaProfileService from "../service/instaProfileService.js";
 import * as instaPostCacheService from "../service/instaPostCacheService.js";
 import { sendSuccess } from "../utils/response.js";

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -7,7 +7,7 @@ import {
   fetchTiktokPosts,
   fetchTiktokPostsBySecUid,
   fetchTiktokInfo
-} from '../service/tiktokRapidService.js';
+} from '../service/tiktokApi.js';
 
 export async function getTiktokComments(req, res, next) {
   try {

--- a/src/handler/fetchEngagement/fetchLikesInstagram.js
+++ b/src/handler/fetchEngagement/fetchLikesInstagram.js
@@ -1,13 +1,10 @@
 // src/handler/fetchEngagement/fetchLikesInstagram.js
 
-import axios from "axios";
 import pLimit from "p-limit";
 import { pool } from "../../config/db.js";
 import { sendDebug } from "../../middleware/debugHandler.js";
+import { fetchAllInstagramLikes } from "../../service/instagramApi.js";
 
-// Konfigurasi RapidAPI
-const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY;
-const RAPIDAPI_HOST = "social-api4.p.rapidapi.com";
 const limit = pLimit(3); // Rate limit parallel request
 
 // Ambil likes lama (existing) dari database dan kembalikan sebagai array string
@@ -36,62 +33,7 @@ async function getExistingLikes(shortcode) {
  * @param {string|null} client_id
  */
 async function fetchAndStoreLikes(shortcode, client_id = null) {
-  // Paginate likes (max 20 page)
-  let allLikes = [];
-  let nextCursor = null;
-  let page = 1;
-  const maxTry = 20;
-  do {
-    let params = { code_or_id_or_url: shortcode };
-    if (nextCursor) params.cursor = nextCursor;
-
-    let likesRes;
-    try {
-      likesRes = await axios.get(`https://${RAPIDAPI_HOST}/v1/likes`, {
-        params,
-        headers: {
-          "x-cache-control": "no-cache",
-          "X-RapidAPI-Key": RAPIDAPI_KEY,
-          "X-RapidAPI-Host": RAPIDAPI_HOST,
-        },
-      });
-    } catch (e) {
-      sendDebug({
-        tag: "IG LIKES ERROR",
-        msg: `Fetch likes page gagal: ${e.response?.data ? JSON.stringify(e.response.data) : (e.message || String(e))}`,
-        client_id: shortcode
-      });
-      break;
-    }
-
-    const likeItems = likesRes.data?.data?.items || [];
-    sendDebug({
-      tag: "IG LIKES PAGE",
-      msg: `Shortcode ${shortcode} Page ${page}: ${likeItems.length} username`,
-      client_id: client_id || shortcode,
-    });
-
-    allLikes.push(
-      ...likeItems
-        .map((like) => (like.username ? like.username : like))
-        .filter(Boolean)
-    );
-
-    nextCursor =
-      likesRes.data?.data?.next_cursor ||
-      likesRes.data?.data?.end_cursor ||
-      null;
-    const hasMore =
-      likesRes.data?.data?.has_more || (nextCursor && nextCursor !== "");
-
-    sendDebug({
-      tag: "IG LIKES PAGING",
-      msg: `Shortcode ${shortcode} Total fetched sementara: ${allLikes.length} | next_cursor: ${!!nextCursor}`,
-      client_id: client_id || shortcode,
-    });
-
-    if (!hasMore || !nextCursor || page++ >= maxTry) break;
-  } while (true);
+  const allLikes = await fetchAllInstagramLikes(shortcode);
 
   const uniqueLikes = [...new Set(allLikes)];
   const existingLikes = await getExistingLikes(shortcode);

--- a/src/service/instagramApi.js
+++ b/src/service/instagramApi.js
@@ -1,0 +1,8 @@
+export {
+  fetchInstagramPosts,
+  fetchInstagramProfile,
+  fetchInstagramInfo,
+  fetchInstagramPostsByMonthToken,
+  fetchInstagramLikesPage,
+  fetchAllInstagramLikes
+} from './instaRapidService.js';

--- a/src/service/tiktokApi.js
+++ b/src/service/tiktokApi.js
@@ -1,0 +1,8 @@
+export {
+  fetchTiktokProfile,
+  fetchTiktokPosts,
+  fetchTiktokPostsBySecUid,
+  fetchTiktokInfo,
+  fetchTiktokCommentsPage,
+  fetchAllTiktokComments
+} from './tiktokRapidService.js';


### PR DESCRIPTION
## Summary
- create instagramApi and tiktokApi wrappers
- delegate IG likes and TikTok comments retrieval to service layer
- remove direct RapidAPI usage from handlers
- update controllers to use new API wrappers

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685002348d8083279b47dce690e371e4