### PR TITLE
Fix dashboard 404 for file.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ menukar kode menjadi access token melalui API Instagram.
     pm2 start app.js --name cicero_v2
     ```
 
+6. **Folder `public/` untuk aset statis**
+   
+   Server Express kini menyajikan berkas statis dari folder `public`. Pastikan
+   ikon atau aset seperti `file.svg` berada di sana agar tidak muncul lagi
+   kesalahan 404 saat dashboard dimuat.
+
 ---
 
 ## Migrasi Database (Struktur Tabel Contoh)

--- a/app.js
+++ b/app.js
@@ -24,6 +24,8 @@ app.use(cors({
 
 app.use(express.json());
 app.use(morgan('dev'));
+// Serve static files such as icons or logos
+app.use(express.static('public'));
 app.use(dedupRequest);
 
 // ===== ROUTE LOGIN (TANPA TOKEN) =====

--- a/public/file.svg
+++ b/public/file.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+  <path d="M3 9h18M9 21V9" />
+</svg>


### PR DESCRIPTION
## Summary
- serve static files via Express
- document new `public/` directory
- add placeholder `file.svg`

## Testing
- `npm test`
- `npm run lint` *(fails: console/process not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685025dc95788327945047ee3b0337a4