### PR TITLE
Improve auth security and add profile caching

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import morgan from 'morgan';
 import { env } from './src/config/env.js';
 import cors from 'cors';
+import cookieParser from 'cookie-parser';
 import routes from './src/routes/index.js';
 import authRoutes from './src/routes/authRoutes.js';
 import { notFound, errorHandler } from './src/middleware/errorHandler.js';
@@ -23,6 +24,7 @@ app.use(cors({
 }));
 
 app.use(express.json());
+app.use(cookieParser());
 app.use(morgan('dev'));
 app.use(dedupRequest);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "amqplib": "^0.10.8",
+        "cookie-parser": "^1.4.6",
         "crypto-js": "^4.2.0",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
@@ -2457,6 +2458,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "morgan": "^1.10.0",
+    "cookie-parser": "^1.4.6",
     "pg": "^8.16.0",
     "qrcode-terminal": "^0.12.0",
     "redis": "^4.6.7",

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -4,6 +4,7 @@ import * as instaPostService from "../service/instaPostService.js";
 import { fetchInstagramPosts, fetchInstagramProfile, fetchInstagramInfo, fetchInstagramPostsByMonthToken } from "../service/instagramApi.js";
 import * as instaProfileService from "../service/instaProfileService.js";
 import * as instaPostCacheService from "../service/instaPostCacheService.js";
+import * as profileCache from "../service/profileCacheService.js";
 import { sendSuccess } from "../utils/response.js";
 import { sendConsoleDebug } from "../middleware/debugHandler.js";
 
@@ -198,7 +199,13 @@ export async function getRapidInstagramProfile(req, res) {
       return res.status(400).json({ success: false, message: 'username wajib diisi' });
     }
     sendConsoleDebug({ tag: "INSTA", msg: `getRapidInstagramProfile ${username}` });
-    const profile = await fetchInstagramProfile(username);
+    let profile = await profileCache.getProfile('insta', username);
+    if (!profile) {
+      profile = await fetchInstagramProfile(username);
+      if (profile) {
+        await profileCache.setProfile('insta', username, profile);
+      }
+    }
     if (profile && profile.username) {
       await instaProfileService.upsertProfile({
         username: profile.username,

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -8,6 +8,7 @@ import {
   fetchTiktokPostsBySecUid,
   fetchTiktokInfo
 } from '../service/tiktokApi.js';
+import * as profileCache from '../service/profileCacheService.js';
 
 export async function getTiktokComments(req, res, next) {
   try {
@@ -81,7 +82,13 @@ export async function getRapidTiktokProfile(req, res) {
     if (!username) {
       return res.status(400).json({ success: false, message: 'username wajib diisi' });
     }
-    const profile = await fetchTiktokProfile(username);
+    let profile = await profileCache.getProfile('tiktok', username);
+    if (!profile) {
+      profile = await fetchTiktokProfile(username);
+      if (profile) {
+        await profileCache.setProfile('tiktok', username, profile);
+      }
+    }
     sendSuccess(res, profile);
   } catch (err) {
     const code = err.statusCode || err.response?.status || 500;

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -2,7 +2,7 @@
 import jwt from 'jsonwebtoken';
 
 export function authRequired(req, res, next) {
-  const token = req.headers.authorization?.split(' ')[1];
+  const token = req.cookies?.token || req.headers.authorization?.split(' ')[1];
   if (!token) return res.status(401).json({ success: false, message: 'Token required' });
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET || "secretkey");

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,8 +1,12 @@
+import { sendDebug } from './debugHandler.js';
+
 export function notFound(req, res, next) {
+  sendDebug({ tag: 'ERROR', msg: `NotFound ${req.originalUrl}` });
   res.status(404).json({ success: false, message: 'Endpoint not found' });
 }
 
 export function errorHandler(err, req, res, next) {
+  sendDebug({ tag: 'ERROR', msg: err.message });
   const code = err.statusCode || 500;
   res.status(code).json({
     success: false,

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -66,8 +66,14 @@ router.post("/login", async (req, res) => {
   } catch (err) {
     console.error('[AUTH] Gagal menyimpan token login:', err.message);
   }
+  res.cookie('token', token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    maxAge: 2 * 60 * 60 * 1000,
+    secure: process.env.NODE_ENV === 'production'
+  });
   // Kembalikan token dan data client
-  return res.json({ success: true, token, client: payload });
+  return res.json({ success: true, client: payload });
 });
 
 export default router;

--- a/src/service/profileCacheService.js
+++ b/src/service/profileCacheService.js
@@ -1,0 +1,14 @@
+import redis from '../config/redis.js';
+
+const TTL_SEC = 3600; // 1 hour
+
+export async function getProfile(platform, username) {
+  const key = `${platform}:profile:${username}`;
+  const val = await redis.get(key);
+  return val ? JSON.parse(val) : null;
+}
+
+export async function setProfile(platform, username, profile) {
+  const key = `${platform}:profile:${username}`;
+  await redis.set(key, JSON.stringify(profile), { EX: TTL_SEC });
+}


### PR DESCRIPTION
## Summary
- use `cookie-parser` and store login token in httpOnly cookies
- read cookie token in auth middleware
- log errors via `sendDebug`
- cache instagram and tiktok profile responses in Redis

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850374229e48327b0dd5ee76a36bbf2