### PR TITLE
Add Instagram Basic Display API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Cicero_V2-main/
 | `/insta/rapid-profile` | GET | Ambil profil Instagram via RapidAPI |
 | `/insta/rapid-posts`   | GET | Ambil postingan Instagram via RapidAPI |
 | `/insta/profile`       | GET | Ambil profil Instagram dari database |
+| `/insta/basic-posts`   | GET | Ambil postingan user melalui Instagram Basic Display API |
+| `/insta/basic-profile` | GET | Ambil profil user melalui Instagram Basic Display API |
 
 Fungsi utilitas `fetchInstagramPostsByMonthToken(username, bulan, tahun)`
 tersedia pada kode untuk mengambil seluruh postingan bulan tertentu

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -1,7 +1,14 @@
 // src/controller/instaController.js
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
-import { fetchInstagramPosts, fetchInstagramProfile, fetchInstagramInfo, fetchInstagramPostsByMonthToken } from "../service/instagramApi.js";
+import {
+  fetchInstagramPosts,
+  fetchInstagramProfile,
+  fetchInstagramInfo,
+  fetchInstagramPostsByMonthToken,
+  fetchBasicProfile,
+  fetchBasicPosts,
+} from "../service/instagramApi.js";
 import * as instaProfileService from "../service/instaProfileService.js";
 import * as instaPostCacheService from "../service/instaPostCacheService.js";
 import * as profileCache from "../service/profileCacheService.js";
@@ -255,6 +262,40 @@ export async function getInstagramProfile(req, res) {
     sendSuccess(res, profile);
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstagramProfile: ${err.message}` });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
+  }
+}
+
+export async function getBasicInstagramPosts(req, res) {
+  try {
+    const accessToken = req.query.access_token || req.headers['x-instagram-token'];
+    let limit = parseInt(req.query.limit);
+    if (Number.isNaN(limit) || limit <= 0) limit = 10;
+    if (!accessToken) {
+      return res.status(400).json({ success: false, message: 'access_token wajib diisi' });
+    }
+    sendConsoleDebug({ tag: 'INSTA', msg: `getBasicInstagramPosts ${limit}` });
+    const posts = await fetchBasicPosts(accessToken, limit);
+    sendSuccess(res, posts);
+  } catch (err) {
+    sendConsoleDebug({ tag: 'INSTA', msg: `Error getBasicInstagramPosts: ${err.message}` });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
+  }
+}
+
+export async function getBasicInstagramProfile(req, res) {
+  try {
+    const accessToken = req.query.access_token || req.headers['x-instagram-token'];
+    if (!accessToken) {
+      return res.status(400).json({ success: false, message: 'access_token wajib diisi' });
+    }
+    sendConsoleDebug({ tag: 'INSTA', msg: 'getBasicInstagramProfile' });
+    const profile = await fetchBasicProfile(accessToken);
+    sendSuccess(res, profile);
+  } catch (err) {
+    sendConsoleDebug({ tag: 'INSTA', msg: `Error getBasicInstagramProfile: ${err.message}` });
     const code = err.statusCode || err.response?.status || 500;
     res.status(code).json({ success: false, message: err.message });
   }

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -1,13 +1,17 @@
 // src/routes/instaRoutes.js
 import { Router } from "express";
-import { getInstaRekapLikes, 
-    getInstaPosts, 
-    getRapidInstagramPosts, 
-    getRapidInstagramProfile, 
-    getRapidInstagramInfo, 
-    getInstagramProfile, 
-    getRapidInstagramPostsStore, 
-    getRapidInstagramPostsByMonth } from "../controller/instaController.js";
+import {
+  getInstaRekapLikes,
+  getInstaPosts,
+  getRapidInstagramPosts,
+  getRapidInstagramProfile,
+  getRapidInstagramInfo,
+  getInstagramProfile,
+  getRapidInstagramPostsStore,
+  getRapidInstagramPostsByMonth,
+  getBasicInstagramPosts,
+  getBasicInstagramProfile,
+} from "../controller/instaController.js";
 import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
 
 const router = Router();
@@ -20,5 +24,7 @@ router.get("/rapid-posts-store", authRequired, getRapidInstagramPostsStore);
 router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
 router.get("/rapid-info", authRequired, getRapidInstagramInfo);
 router.get("/profile", authRequired, getInstagramProfile);
+router.get("/basic-posts", authRequired, getBasicInstagramPosts);
+router.get("/basic-profile", authRequired, getBasicInstagramProfile);
 
 export default router;

--- a/src/service/instaOfficialService.js
+++ b/src/service/instaOfficialService.js
@@ -1,0 +1,30 @@
+const BASE_URL = 'https://graph.instagram.com';
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = data?.error?.message || res.statusText;
+    const err = new Error(`Instagram API error: ${msg}`);
+    err.statusCode = data?.error?.code || res.status;
+    throw err;
+  }
+  return data;
+}
+
+export async function fetchBasicProfile(accessToken) {
+  if (!accessToken) return null;
+  const fields = 'id,username,account_type,media_count';
+  const url = `${BASE_URL}/me?fields=${fields}&access_token=${accessToken}`;
+  const data = await fetchJson(url);
+  return data;
+}
+
+export async function fetchBasicPosts(accessToken, limit = 10) {
+  if (!accessToken) return [];
+  const fields = 'id,caption,media_type,media_url,thumbnail_url,permalink,timestamp';
+  const url = `${BASE_URL}/me/media?fields=${fields}&access_token=${accessToken}&limit=${limit}`;
+  const data = await fetchJson(url);
+  return Array.isArray(data?.data) ? data.data : [];
+}
+

--- a/src/service/instagramApi.js
+++ b/src/service/instagramApi.js
@@ -4,5 +4,10 @@ export {
   fetchInstagramInfo,
   fetchInstagramPostsByMonthToken,
   fetchInstagramLikesPage,
-  fetchAllInstagramLikes
+  fetchAllInstagramLikes,
 } from './instaRapidService.js';
+
+export {
+  fetchBasicProfile,
+  fetchBasicPosts,
+} from './instaOfficialService.js';


### PR DESCRIPTION
## Summary
- expose official Instagram Basic Display API functions
- add controller methods for `/insta/basic-posts` and `/insta/basic-profile`
- document new endpoints

## Testing
- `npm test`
- `npm run lint` *(fails: 211 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68504624e1588327bf159c9bf02d30ef