### PR TITLE
Add Instagram deauthorize webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ ditunda selama 1.5 detik untuk menghindari batasan API.
 |-------------------|--------|----------------------------------------------------|
 | `/oauth/callback` | GET    | Callback URL setelah proses OAuth dari provider |
 | `/oauth/instagram/callback` | GET | Tukar kode otorisasi Instagram menjadi token |
+| `/oauth/instagram/deauthorize` | POST | Terima notifikasi de-authorize dari Instagram |
 
 Endpoint ini menerima parameter `code` dan `state` dari penyedia OAuth.
 Saat ini fungsinya hanya mencatat parameter tersebut, tetapi dapat

--- a/src/controller/oauthController.js
+++ b/src/controller/oauthController.js
@@ -1,4 +1,5 @@
 import { env } from '../config/env.js';
+import { verifySignedRequest } from '../utils/instagramWebhooks.js';
 
 /**
  * Handle OAuth provider callback.
@@ -57,6 +58,34 @@ export async function handleInstagramOAuthCallback(req, res) {
   } catch (err) {
     console.error('[IG OAUTH ERROR]', err.message);
     return res.status(500).json({ success: false, message: 'Failed to retrieve Instagram token' });
+  }
+}
+
+/**
+ * Instagram deauthorization callback handler.
+ * Validates the signed_request sent by Instagram when a user revokes access.
+ */
+export async function handleInstagramDeauthorize(req, res) {
+  const { signed_request } = req.body || {};
+
+  if (!signed_request) {
+    return res
+      .status(400)
+      .json({ success: false, message: 'Missing signed_request' });
+  }
+
+  try {
+    const payload = verifySignedRequest(
+      signed_request,
+      env.INSTAGRAM_APP_SECRET
+    );
+    console.log('[IG DEAUTH]', payload);
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error('[IG DEAUTH ERROR]', err.message);
+    return res
+      .status(400)
+      .json({ success: false, message: 'Invalid signed_request' });
   }
 }
 

--- a/src/routes/oauthRoutes.js
+++ b/src/routes/oauthRoutes.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import {
   handleOAuthCallback,
   handleInstagramOAuthCallback,
+  handleInstagramDeauthorize,
 } from '../controller/oauthController.js';
 
 const router = Router();
@@ -9,5 +10,6 @@ const router = Router();
 // OAuth provider redirects users to this callback URL
 router.get('/callback', handleOAuthCallback);
 router.get('/instagram/callback', handleInstagramOAuthCallback);
+router.post('/instagram/deauthorize', handleInstagramDeauthorize);
 
 export default router;

--- a/src/utils/instagramWebhooks.js
+++ b/src/utils/instagramWebhooks.js
@@ -1,0 +1,21 @@
+import crypto from 'crypto';
+
+// Verify a signed_request from Instagram and return the decoded payload
+export function verifySignedRequest(signedRequest, appSecret) {
+  const [sig, payload] = (signedRequest || '').split('.');
+  if (!sig || !payload) {
+    throw new Error('Invalid signed_request');
+  }
+  const expected = crypto
+    .createHmac('sha256', appSecret)
+    .update(payload)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  if (sig !== expected) {
+    throw new Error('Signature mismatch');
+  }
+  const json = Buffer.from(payload, 'base64').toString();
+  return JSON.parse(json);
+}

--- a/tests/instagramWebhook.test.js
+++ b/tests/instagramWebhook.test.js
@@ -1,0 +1,24 @@
+import crypto from 'crypto';
+import { verifySignedRequest } from '../src/utils/instagramWebhooks.js';
+
+describe('verifySignedRequest', () => {
+  test('returns payload when signature is valid', () => {
+    const secret = 'test-secret';
+    const payload = { user_id: '1', issued_at: 123 };
+    const encodedPayload = Buffer.from(JSON.stringify(payload))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const signature = crypto
+      .createHmac('sha256', secret)
+      .update(encodedPayload)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const signed = `${signature}.${encodedPayload}`;
+    const result = verifySignedRequest(signed, secret);
+    expect(result.user_id).toBe(payload.user_id);
+  });
+});


### PR DESCRIPTION
## Summary
- implement verification utility for Instagram `signed_request`
- expose `/oauth/instagram/deauthorize` endpoint for official API notifications
- document the new endpoint in README
- test verification helper

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685051be9580832796223a54c6b992b8