### PR TITLE
Add endpoint to remove IG callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ ditunda selama 1.5 detik untuk menghindari batasan API.
 | `/oauth/callback` | GET    | Callback URL setelah proses OAuth dari provider |
 | `/oauth/instagram/callback` | GET | Tukar kode otorisasi Instagram menjadi token |
 | `/oauth/instagram/deauthorize` | POST | Terima notifikasi de-authorize dari Instagram |
+| `/oauth/instagram/callback-url` | DELETE | Hapus URL callback dari API Instagram |
 
 Endpoint ini menerima parameter `code` dan `state` dari penyedia OAuth.
 Saat ini fungsinya hanya mencatat parameter tersebut, tetapi dapat

--- a/src/controller/oauthController.js
+++ b/src/controller/oauthController.js
@@ -1,5 +1,6 @@
 import { env } from '../config/env.js';
 import { verifySignedRequest } from '../utils/instagramWebhooks.js';
+import { deleteInstagramCallback } from '../service/instagramApi.js';
 
 /**
  * Handle OAuth provider callback.
@@ -86,6 +87,17 @@ export async function handleInstagramDeauthorize(req, res) {
     return res
       .status(400)
       .json({ success: false, message: 'Invalid signed_request' });
+  }
+}
+
+export async function removeInstagramCallback(req, res) {
+  try {
+    const result = await deleteInstagramCallback();
+    return res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    console.error('[IG REMOVE CALLBACK ERROR]', err.message);
+    const code = err.statusCode || err.response?.status || 500;
+    return res.status(code).json({ success: false, message: err.message });
   }
 }
 

--- a/src/routes/oauthRoutes.js
+++ b/src/routes/oauthRoutes.js
@@ -3,6 +3,7 @@ import {
   handleOAuthCallback,
   handleInstagramOAuthCallback,
   handleInstagramDeauthorize,
+  removeInstagramCallback,
 } from '../controller/oauthController.js';
 
 const router = Router();
@@ -11,5 +12,6 @@ const router = Router();
 router.get('/callback', handleOAuthCallback);
 router.get('/instagram/callback', handleInstagramOAuthCallback);
 router.post('/instagram/deauthorize', handleInstagramDeauthorize);
+router.delete('/instagram/callback-url', removeInstagramCallback);
 
 export default router;

--- a/src/service/instagramApi.js
+++ b/src/service/instagramApi.js
@@ -11,3 +11,5 @@ export {
   fetchBasicProfile,
   fetchBasicPosts,
 } from './instaOfficialService.js';
+
+export { deleteInstagramCallback } from './instagramWebhookService.js';

--- a/src/service/instagramWebhookService.js
+++ b/src/service/instagramWebhookService.js
@@ -1,0 +1,21 @@
+import { env } from '../config/env.js';
+
+const GRAPH_URL = 'https://graph.facebook.com/v18.0';
+
+async function fetchJson(url, options = {}) {
+  const res = await fetch(url, options);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = data?.error?.message || res.statusText;
+    const err = new Error(`Instagram API error: ${msg}`);
+    err.statusCode = data?.error?.code || res.status;
+    throw err;
+  }
+  return data;
+}
+
+export async function deleteInstagramCallback() {
+  const appToken = `${env.INSTAGRAM_APP_ID}|${env.INSTAGRAM_APP_SECRET}`;
+  const url = `${GRAPH_URL}/${env.INSTAGRAM_APP_ID}/subscriptions?access_token=${appToken}`;
+  return await fetchJson(url, { method: 'DELETE' });
+}


### PR DESCRIPTION
## Summary
- implement `deleteInstagramCallback` service using Instagram Graph API
- expose new service through `instagramApi.js`
- add `removeInstagramCallback` controller
- route `DELETE /oauth/instagram/callback-url`
- document new endpoint in README

## Testing
- `npm test`
- `npm run lint` *(fails: console and process not defined errors)*

------
https://chatgpt.com/codex/tasks/task_e_685052ca2598832780ff98e30e633655