### PR TITLE
Add polda and Instagram search workflow

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -78,3 +78,28 @@ CREATE TABLE polres_insta (
   last_post_at TIMESTAMP,
   checked_at TIMESTAMP DEFAULT NOW()
 );
+
+-- Data Polda dan Kota
+CREATE TABLE polda (
+  id SERIAL PRIMARY KEY,
+  nama VARCHAR UNIQUE NOT NULL
+);
+
+CREATE TABLE polda_kota (
+  id SERIAL PRIMARY KEY,
+  polda_id INTEGER REFERENCES polda(id),
+  nama VARCHAR NOT NULL,
+  UNIQUE(polda_id, nama)
+);
+
+-- Hasil pencarian akun Instagram
+CREATE TABLE insta_user_search (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR UNIQUE NOT NULL,
+  full_name VARCHAR,
+  instagram_id VARCHAR,
+  is_private BOOLEAN,
+  is_verified BOOLEAN,
+  profile_pic_url TEXT,
+  searched_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/controller/poldaController.js
+++ b/src/controller/poldaController.js
@@ -1,0 +1,30 @@
+import { initPolda } from '../service/poldaService.js';
+import { searchAllCities, fetchInfoForAllUsers } from '../service/instaSearchService.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function init(req, res, next) {
+  try {
+    await initPolda();
+    sendSuccess(res, { initialized: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function searchInstagram(req, res, next) {
+  try {
+    await searchAllCities();
+    sendSuccess(res, { done: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function fetchInfo(req, res, next) {
+  try {
+    await fetchInfoForAllUsers();
+    sendSuccess(res, { done: true });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/data/polda.json
+++ b/src/data/polda.json
@@ -1,0 +1,4 @@
+[
+  {"polda": "Jawa Timur", "kota": ["Surabaya", "Malang", "Kediri"]},
+  {"polda": "Jawa Tengah", "kota": ["Semarang", "Solo", "Magelang"]}
+]

--- a/src/model/instaUserSearchModel.js
+++ b/src/model/instaUserSearchModel.js
@@ -1,0 +1,30 @@
+import { query } from '../repository/db.js';
+
+export async function upsertSearchUser(data) {
+  const {
+    username,
+    full_name = null,
+    instagram_id = null,
+    is_private = null,
+    is_verified = null,
+    profile_pic_url = null,
+  } = data;
+  if (!username) return;
+  await query(
+    `INSERT INTO insta_user_search (username, full_name, instagram_id, is_private, is_verified, profile_pic_url, searched_at)
+     VALUES ($1,$2,$3,$4,$5,$6,NOW())
+     ON CONFLICT (username) DO UPDATE
+       SET full_name = EXCLUDED.full_name,
+           instagram_id = EXCLUDED.instagram_id,
+           is_private = EXCLUDED.is_private,
+           is_verified = EXCLUDED.is_verified,
+           profile_pic_url = EXCLUDED.profile_pic_url,
+           searched_at = NOW()`,
+    [username, full_name, instagram_id, is_private, is_verified, profile_pic_url]
+  );
+}
+
+export async function findAllUsernames() {
+  const res = await query('SELECT username FROM insta_user_search ORDER BY username');
+  return res.rows.map(r => r.username);
+}

--- a/src/model/poldaModel.js
+++ b/src/model/poldaModel.js
@@ -1,0 +1,39 @@
+import { query } from '../repository/db.js';
+
+export async function upsertPolda(nama) {
+  if (!nama) return null;
+  const res = await query(
+    `INSERT INTO polda (nama) VALUES ($1)
+     ON CONFLICT (nama) DO UPDATE SET nama = EXCLUDED.nama
+     RETURNING *`,
+    [nama]
+  );
+  return res.rows[0];
+}
+
+export async function findAllPolda() {
+  const res = await query('SELECT * FROM polda ORDER BY nama');
+  return res.rows;
+}
+
+export async function upsertKota(polda_id, nama) {
+  if (!polda_id || !nama) return null;
+  const res = await query(
+    `INSERT INTO polda_kota (polda_id, nama)
+     VALUES ($1, $2)
+     ON CONFLICT (polda_id, nama) DO NOTHING
+     RETURNING *`,
+    [polda_id, nama]
+  );
+  return res.rows[0] || null;
+}
+
+export async function findAllKota() {
+  const res = await query('SELECT * FROM polda_kota');
+  return res.rows;
+}
+
+export async function findKotaByPolda(polda_id) {
+  const res = await query('SELECT * FROM polda_kota WHERE polda_id = $1', [polda_id]);
+  return res.rows;
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,6 +7,7 @@ import instaRoutes from "./instaRoutes.js";
 import oauthRoutes from './oauthRoutes.js';
 import tiktokRoutes from "./tiktokRoutes.js";
 import polresRoutes from './polresRoutes.js';
+import poldaRoutes from './poldaRoutes.js';
 
 const router = express.Router();
 
@@ -18,6 +19,7 @@ router.use("/insta", instaRoutes);
 router.use("/tiktok", tiktokRoutes);
 router.use('/oauth', oauthRoutes);
 router.use('/polres', polresRoutes);
+router.use('/polda', poldaRoutes);
 
 
 export default router;

--- a/src/routes/poldaRoutes.js
+++ b/src/routes/poldaRoutes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { init, searchInstagram, fetchInfo } from '../controller/poldaController.js';
+import { authRequired } from '../middleware/authMiddleware.js';
+
+const router = Router();
+
+router.post('/init', authRequired, init);
+router.post('/search-instagram', authRequired, searchInstagram);
+router.post('/fetch-info', authRequired, fetchInfo);
+
+export default router;

--- a/src/service/instaSearchService.js
+++ b/src/service/instaSearchService.js
@@ -1,0 +1,39 @@
+import { searchInstagramUsers, fetchInstagramInfo } from './instaRapidService.js';
+import { findAllKota } from '../model/poldaModel.js';
+import { upsertSearchUser, findAllUsernames } from '../model/instaUserSearchModel.js';
+import { upsertProfile } from './instaProfileService.js';
+
+export async function searchAllCities() {
+  const cities = await findAllKota();
+  for (const kota of cities) {
+    const results = await searchInstagramUsers(kota.nama, 5);
+    for (const r of results) {
+      await upsertSearchUser({
+        username: r.username,
+        full_name: r.full_name,
+        instagram_id: r.id || r.pk,
+        is_private: r.is_private,
+        is_verified: r.is_verified,
+        profile_pic_url: r.profile_pic_url,
+      });
+    }
+  }
+}
+
+export async function fetchInfoForAllUsers() {
+  const usernames = await findAllUsernames();
+  for (const username of usernames) {
+    const info = await fetchInstagramInfo(username);
+    if (info) {
+      await upsertProfile({
+        username: info.username,
+        full_name: info.full_name,
+        biography: info.biography,
+        follower_count: info.follower_count || info.followers_count,
+        following_count: info.following_count,
+        post_count: info.media_count || info.posts_count,
+        profile_pic_url: info.profile_pic_url_hd || info.profile_pic_url,
+      });
+    }
+  }
+}

--- a/src/service/poldaService.js
+++ b/src/service/poldaService.js
@@ -1,0 +1,12 @@
+import provinces from '../data/polda.json' assert { type: 'json' };
+import * as model from '../model/poldaModel.js';
+
+export async function initPolda() {
+  for (const item of provinces) {
+    const polda = await model.upsertPolda(item.polda);
+    if (!polda) continue;
+    for (const kota of item.kota) {
+      await model.upsertKota(polda.id, kota);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add province and city dataset
- create models for polda, kota and search results
- add services and controller for initializing polda data, searching Instagram and fetching info
- expose new `/polda` routes
- update DB schema with new tables

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e79df9d8832796a196c52d063f27