### PR TITLE
Add metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ Endpoint terkait:
 Proses lengkap juga dapat dijalankan lewat menu WhatsApp `clientrequest`
 dengan memilih *Instagram Data Mining*.
 
+### 7. Metadata API
+
+| Endpoint    | Method | Deskripsi                               |
+|-------------|--------|-----------------------------------------|
+| `/metadata` | GET    | Menampilkan informasi versi aplikasi API |
+
+**Contoh Response:**
+```json
+{
+  "name": "cicero-clean-build",
+  "version": "1.0.0",
+  "description": "Cicero V2 with postgresql",
+  "uptime": 123.456
+}
+```
+
 ---
 
 ## Fitur & Flow Bisnis Utama

--- a/src/controller/metaController.js
+++ b/src/controller/metaController.js
@@ -1,0 +1,29 @@
+import { readFile } from 'fs/promises';
+import { sendSuccess } from '../utils/response.js';
+
+let cached;
+
+async function getPackage() {
+  if (!cached) {
+    const data = await readFile(new URL('../../package.json', import.meta.url), 'utf-8');
+    cached = JSON.parse(data);
+  }
+  return cached;
+}
+
+export const getMetadata = async (req, res, next) => {
+  try {
+    const pkg = await getPackage();
+    const metadata = {
+      name: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      repository: pkg.repository?.url,
+      uptime: process.uptime(),
+      node: process.version,
+    };
+    sendSuccess(res, metadata);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ import oauthRoutes from './oauthRoutes.js';
 import tiktokRoutes from "./tiktokRoutes.js";
 import polresRoutes from './polresRoutes.js';
 import poldaRoutes from './poldaRoutes.js';
+import metaRoutes from './metaRoutes.js';
 
 const router = express.Router();
 
@@ -20,6 +21,7 @@ router.use("/tiktok", tiktokRoutes);
 router.use('/oauth', oauthRoutes);
 router.use('/polres', polresRoutes);
 router.use('/polda', poldaRoutes);
+router.use('/metadata', metaRoutes);
 
 
 export default router;

--- a/src/routes/metaRoutes.js
+++ b/src/routes/metaRoutes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getMetadata } from '../controller/metaController.js';
+
+const router = Router();
+
+router.get('/', getMetadata);
+
+export default router;

--- a/tests/metadata.test.js
+++ b/tests/metadata.test.js
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+
+let getMetadata;
+
+beforeAll(async () => {
+  const mod = await import('../src/controller/metaController.js');
+  getMetadata = mod.getMetadata;
+});
+
+describe('getMetadata', () => {
+  test('returns package info', async () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const res = { status, json };
+
+    await getMetadata({}, res, () => {});
+
+    expect(status).toHaveBeenCalledWith(200);
+    const payload = json.mock.calls[0][0];
+    expect(payload.success).toBe(true);
+    expect(payload.data.name).toBeDefined();
+    expect(payload.data.version).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add metadata endpoint and controller
- document new endpoint in README
- test metadata controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850ee9011f08327b09dcf75d4aac88c