### PR TITLE
Add Nginx reverse proxy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Dokumentasi arsitektur lengkap tersedia pada [docs/enterprise_architecture.md](d
 Dokumentasi jadwal aktivitas sistem terdapat pada [docs/activity_schedule.md](docs/activity_schedule.md).
 Dokumentasi alur metadata tersedia pada [docs/metadata_flow.md](docs/metadata_flow.md).
 Panduan migrasi server tersedia pada [docs/server_migration.md](docs/server_migration.md).
+Contoh konfigurasi Nginx dapat dilihat pada [docs/reverse_proxy_config.md](docs/reverse_proxy_config.md).
 
 ---
 

--- a/docs/reverse_proxy_config.md
+++ b/docs/reverse_proxy_config.md
@@ -1,0 +1,43 @@
+# Konfigurasi Nginx/Reverse Proxy
+
+Dokumen ini memberikan contoh konfigurasi dasar untuk menjalankan aplikasi **Cicero_V2** di balik `nginx` atau reverse proxy lainnya. Pengaturan ini opsional namun berguna agar port aplikasi tidak diakses langsung oleh klien.
+
+## 1. Prasyarat
+
+- Aplikasi telah dijalankan dengan `npm start` pada port yang ditentukan di `.env` (default `3000`).
+- Nginx terpasang di server.
+
+## 2. Contoh Konfigurasi
+
+Buat file konfigurasi baru misalnya `/etc/nginx/sites-available/cicero` kemudian isi seperti berikut:
+
+```nginx
+server {
+    listen 80;
+    server_name contoh.domain.com;
+
+    location / {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_pass http://127.0.0.1:3000;
+    }
+}
+```
+
+Aktifkan konfigurasi tersebut dengan:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/cicero /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+Konfigurasi di atas meneruskan seluruh permintaan pada port 80 ke aplikasi Node.js yang berjalan pada `localhost:3000`.
+
+## 3. HTTPS (Opsional)
+
+Jika menggunakan HTTPS, sertifikat dapat diatur via `certbot` atau penyedia lain. Pastikan bagian `server` diperbarui dengan `listen 443 ssl;` dan `ssl_certificate` yang sesuai.
+
+## 4. Referensi Lain
+
+Lihat [docs/server_migration.md](server_migration.md) untuk panduan lengkap menyiapkan server baru.

--- a/docs/server_migration.md
+++ b/docs/server_migration.md
@@ -22,7 +22,8 @@ Panduan ditujukan bagi admin sistem agar proses migrasi berlangsung aman tanpa k
    ```bash
    psql -U <user> -d <dbname> -f backup.sql
    ```
-6. Sesuaikan konfigurasi `nginx`/`reverse proxy` bila digunakan.
+6. Sesuaikan konfigurasi `nginx`/`reverse proxy` bila digunakan (lihat
+   [docs/reverse_proxy_config.md](reverse_proxy_config.md)).
 
 ## 3. Deploy Aplikasi
 


### PR DESCRIPTION
## Summary
- document example Nginx config for running Cicero behind a reverse proxy
- link the guide from the server migration doc and README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685119d338588327963e37edce76ab78