### PR TITLE
Add Instagram user storage

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -8,6 +8,7 @@ import {
   fetchInstagramPostsByMonthToken,
 } from "../service/instagramApi.js";
 import * as instaProfileService from "../service/instaProfileService.js";
+import * as instagramUserService from "../service/instagramUserService.js";
 import * as instaPostCacheService from "../service/instaPostCacheService.js";
 import * as profileCache from "../service/profileCacheService.js";
 import { sendSuccess } from "../utils/response.js";
@@ -221,6 +222,40 @@ export async function getRapidInstagramProfile(req, res) {
         post_count: profile.media_count ?? profile.posts_count,
         profile_pic_url: profile.profile_pic_url,
       });
+
+      const userId = profile.pk || profile.id || profile.user_id;
+      if (userId) {
+        await instagramUserService.upsertInstagramUser({
+          user_id: String(userId),
+          username: profile.username,
+          full_name: profile.full_name,
+          biography: profile.biography,
+          business_contact_method: profile.business_contact_method,
+          category: profile.category_name || profile.category,
+          category_id: profile.category_id,
+          account_type: profile.account_type,
+          contact_phone_number: profile.contact_phone_number,
+          external_url: profile.external_url,
+          fbid_v2: profile.fbid_v2,
+          is_business: profile.is_business,
+          is_private: profile.is_private,
+          is_verified: profile.is_verified,
+          public_email: profile.public_email,
+          public_phone_country_code: profile.public_phone_country_code,
+          public_phone_number: profile.public_phone_number,
+          profile_pic_url: profile.profile_pic_url,
+          profile_pic_url_hd: profile.profile_pic_url_hd
+        });
+
+        await instagramUserService.upsertInstagramUserMetrics({
+          user_id: String(userId),
+          follower_count: profile.followers_count ?? profile.follower_count,
+          following_count: profile.following_count,
+          media_count: profile.media_count ?? profile.posts_count,
+          total_igtv_videos: profile.total_igtv_videos,
+          latest_reel_media: profile.latest_reel_media
+        });
+      }
     }
     sendSuccess(res, profile);
   } catch (err) {
@@ -260,6 +295,28 @@ export async function getInstagramProfile(req, res) {
     sendSuccess(res, profile);
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstagramProfile: ${err.message}` });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
+  }
+}
+
+export async function getInstagramUser(req, res) {
+  try {
+    const user_id = req.query.user_id;
+    const username = req.query.username;
+    if (!user_id && !username) {
+      return res.status(400).json({ success: false, message: 'username atau user_id wajib diisi' });
+    }
+    sendConsoleDebug({ tag: 'INSTA', msg: `getInstagramUser ${user_id || username}` });
+    let profile;
+    if (user_id) profile = await instagramUserService.findByUserId(user_id);
+    else profile = await instagramUserService.findByUsername(username);
+    if (!profile) {
+      return res.status(404).json({ success: false, message: 'profile not found' });
+    }
+    sendSuccess(res, profile);
+  } catch (err) {
+    sendConsoleDebug({ tag: 'INSTA', msg: `Error getInstagramUser: ${err.message}` });
     const code = err.statusCode || err.response?.status || 500;
     res.status(code).json({ success: false, message: err.message });
   }

--- a/src/model/instagramUserModel.js
+++ b/src/model/instagramUserModel.js
@@ -1,0 +1,121 @@
+import { query } from '../repository/db.js';
+
+export async function upsertInstagramUser(data) {
+  const {
+    user_id,
+    username,
+    full_name = null,
+    biography = null,
+    business_contact_method = null,
+    category = null,
+    category_id = null,
+    account_type = null,
+    contact_phone_number = null,
+    external_url = null,
+    fbid_v2 = null,
+    is_business = null,
+    is_private = null,
+    is_verified = null,
+    public_email = null,
+    public_phone_country_code = null,
+    public_phone_number = null,
+    profile_pic_url = null,
+    profile_pic_url_hd = null
+  } = data;
+  if (!user_id || !username) return;
+  await query(
+    `INSERT INTO instagram_user (
+      user_id, username, full_name, biography,
+      business_contact_method, category, category_id, account_type,
+      contact_phone_number, external_url, fbid_v2,
+      is_business, is_private, is_verified,
+      public_email, public_phone_country_code, public_phone_number,
+      profile_pic_url, profile_pic_url_hd
+    ) VALUES (
+      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,
+      $12,$13,$14,$15,$16,$17,$18,$19
+    )
+    ON CONFLICT (user_id) DO UPDATE SET
+      username = EXCLUDED.username,
+      full_name = EXCLUDED.full_name,
+      biography = EXCLUDED.biography,
+      business_contact_method = EXCLUDED.business_contact_method,
+      category = EXCLUDED.category,
+      category_id = EXCLUDED.category_id,
+      account_type = EXCLUDED.account_type,
+      contact_phone_number = EXCLUDED.contact_phone_number,
+      external_url = EXCLUDED.external_url,
+      fbid_v2 = EXCLUDED.fbid_v2,
+      is_business = EXCLUDED.is_business,
+      is_private = EXCLUDED.is_private,
+      is_verified = EXCLUDED.is_verified,
+      public_email = EXCLUDED.public_email,
+      public_phone_country_code = EXCLUDED.public_phone_country_code,
+      public_phone_number = EXCLUDED.public_phone_number,
+      profile_pic_url = EXCLUDED.profile_pic_url,
+      profile_pic_url_hd = EXCLUDED.profile_pic_url_hd`,
+    [
+      user_id,
+      username,
+      full_name,
+      biography,
+      business_contact_method,
+      category,
+      category_id,
+      account_type,
+      contact_phone_number,
+      external_url,
+      fbid_v2,
+      is_business,
+      is_private,
+      is_verified,
+      public_email,
+      public_phone_country_code,
+      public_phone_number,
+      profile_pic_url,
+      profile_pic_url_hd
+    ]
+  );
+}
+
+export async function upsertInstagramUserMetrics(data) {
+  const {
+    user_id,
+    follower_count = null,
+    following_count = null,
+    media_count = null,
+    total_igtv_videos = null,
+    latest_reel_media = null
+  } = data;
+  if (!user_id) return;
+  await query(
+    `INSERT INTO instagram_user_metrics (
+      user_id, follower_count, following_count, media_count,
+      total_igtv_videos, latest_reel_media
+    ) VALUES ($1,$2,$3,$4,$5,$6)
+     ON CONFLICT (user_id) DO UPDATE SET
+      follower_count = EXCLUDED.follower_count,
+      following_count = EXCLUDED.following_count,
+      media_count = EXCLUDED.media_count,
+      total_igtv_videos = EXCLUDED.total_igtv_videos,
+      latest_reel_media = EXCLUDED.latest_reel_media`,
+    [
+      user_id,
+      follower_count,
+      following_count,
+      media_count,
+      total_igtv_videos,
+      latest_reel_media
+    ]
+  );
+}
+
+export async function findByUserId(user_id) {
+  const res = await query('SELECT * FROM instagram_user WHERE user_id = $1', [user_id]);
+  return res.rows[0] || null;
+}
+
+export async function findByUsername(username) {
+  const res = await query('SELECT * FROM instagram_user WHERE username = $1', [username]);
+  return res.rows[0] || null;
+}

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -7,6 +7,7 @@ import {
   getRapidInstagramProfile,
   getRapidInstagramInfo,
   getInstagramProfile,
+  getInstagramUser,
   getRapidInstagramPostsStore,
   getRapidInstagramPostsByMonth,
 } from "../controller/instaController.js";
@@ -22,5 +23,6 @@ router.get("/rapid-posts-store", authRequired, getRapidInstagramPostsStore);
 router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
 router.get("/rapid-info", authRequired, getRapidInstagramInfo);
 router.get("/profile", authRequired, getInstagramProfile);
+router.get("/instagram-user", authRequired, getInstagramUser);
 
 export default router;

--- a/src/service/instagramUserService.js
+++ b/src/service/instagramUserService.js
@@ -1,0 +1,6 @@
+import * as model from '../model/instagramUserModel.js';
+
+export const upsertInstagramUser = model.upsertInstagramUser;
+export const upsertInstagramUserMetrics = model.upsertInstagramUserMetrics;
+export const findByUserId = model.findByUserId;
+export const findByUsername = model.findByUsername;


### PR DESCRIPTION
## Summary
- add `instagramUserModel` and service for new DB tables
- store additional profile info from RapidAPI responses
- expose `/instagram-user` route to fetch saved profiles

## Testing
- `npm test`
- `npm run lint` *(fails: lots of "no-undef" errors)*

------
https://chatgpt.com/codex/tasks/task_e_685227e76adc8327ab912c3c70b7f07b