### PR TITLE
Fix Instagram category_id overflow

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -113,7 +113,7 @@ CREATE TABLE instagram_user (
     biography               TEXT,
     business_contact_method VARCHAR(50),
     category                VARCHAR(100),
-    category_id             INT,
+    category_id             BIGINT,
     account_type            SMALLINT,
     contact_phone_number    VARCHAR(30),
     external_url            TEXT,


### PR DESCRIPTION
## Summary
- use BIGINT for instagram_user.category_id in SQL schema

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68522dbbd4208327a6cadb3811728770