### PR TITLE
Fix RapidAPI profile fetch on older Node versions

### DIFF
--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import fetch from 'node-fetch';
 import { env } from '../config/env.js';
 
 const RAPIDAPI_KEY = env.RAPIDAPI_KEY;


### PR DESCRIPTION
## Summary
- ensure `fetch` is available in `instaRapidService`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68522fb011c08327930a7c9b404866ad