### PR TITLE
Fix integer overflow errors by capping limit

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -58,6 +58,7 @@ export async function getRapidInstagramPosts(req, res) {
     const username = req.query.username;
     let limit = parseInt(req.query.limit);
     if (Number.isNaN(limit) || limit <= 0) limit = 10;
+    else if (limit > 100) limit = 100;
     if (!username) {
       return res.status(400).json({ success: false, message: 'username wajib diisi' });
     }
@@ -104,6 +105,7 @@ export async function getRapidInstagramPostsStore(req, res) {
     const username = req.query.username;
     let limit = parseInt(req.query.limit);
     if (Number.isNaN(limit) || limit <= 0) limit = 10;
+    else if (limit > 100) limit = 100;
     if (!username) {
       return res.status(400).json({ success: false, message: 'username wajib diisi' });
     }

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -131,6 +131,7 @@ export async function getRapidTiktokPosts(req, res) {
     let { username, secUid } = req.query;
     let limit = parseInt(req.query.limit);
     if (Number.isNaN(limit) || limit <= 0) limit = 10;
+    else if (limit > 100) limit = 100;
 
     if (!username && !secUid) {
       if (!client_id) {


### PR DESCRIPTION
## Summary
- cap `limit` query parameter to 100 in Instagram and TikTok controllers

## Testing
- `npm test`
- `npm run lint` *(fails: 'console' is not defined and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68523116130483279974da0e6d4341b5