### PR TITLE
Add visitor log table and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ dengan memilih *Instagram Data Mining*.
 | `/auth/login` | POST   | Login client (sukses atau gagal) akan memicu notifikasi WhatsApp |
 | `/auth/open`  | GET    | Dipanggil saat dashboard dibuka untuk pemberitahuan WA   |
 
+### 10. Visitor Log API
+
+| Endpoint | Method | Deskripsi |
+|----------|--------|-----------|
+| `/logs/visitors` | GET | Ambil daftar log kunjungan dashboard |
+
 ---
 
 ## Fitur & Flow Bisnis Utama
@@ -392,6 +398,14 @@ CREATE TABLE polres_insta (
   username VARCHAR PRIMARY KEY,
   last_post_at TIMESTAMP,
   checked_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Log kunjungan dashboard
+CREATE TABLE visitor_logs (
+  id SERIAL PRIMARY KEY,
+  ip VARCHAR,
+  user_agent TEXT,
+  visited_at TIMESTAMP DEFAULT NOW()
 );
 ```
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -229,3 +229,10 @@ CREATE TABLE IF NOT EXISTS ig_ext_hashtags (
     hashtag VARCHAR(100),
     PRIMARY KEY (post_id, hashtag)
 );
+
+CREATE TABLE visitor_logs (
+    id SERIAL PRIMARY KEY,
+    ip VARCHAR,
+    user_agent TEXT,
+    visited_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/model/visitorLogModel.js
+++ b/src/model/visitorLogModel.js
@@ -1,0 +1,15 @@
+import { query } from '../repository/db.js';
+
+export async function insertVisitorLog({ ip, userAgent }) {
+  await query(
+    'INSERT INTO visitor_logs (ip, user_agent, visited_at) VALUES ($1, $2, NOW())',
+    [ip || '', userAgent || '']
+  );
+}
+
+export async function getVisitorLogs() {
+  const { rows } = await query(
+    'SELECT * FROM visitor_logs ORDER BY visited_at DESC'
+  );
+  return rows;
+}

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -8,6 +8,7 @@ import {
 } from "../utils/waHelper.js";
 import redis from "../config/redis.js";
 import waClient, { waReady } from "../service/waService.js";
+import { insertVisitorLog } from "../model/visitorLogModel.js";
 
 function notifyAdmin(message) {
   if (!waReady) return;
@@ -107,14 +108,16 @@ router.post("/login", async (req, res) => {
   return res.json({ success: true, token, client: payload });
 });
 
-router.get('/open', (req, res) => {
+router.get('/open', async (req, res) => {
   const time = new Date().toLocaleString('id-ID', { timeZone: 'Asia/Jakarta' });
   const ip = req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress;
   const ua = req.headers['user-agent'] || '';
+  await insertVisitorLog({ ip, userAgent: ua });
   notifyAdmin(
     `\uD83D\uDD0D Web dibuka\nIP: ${ip}\nUA: ${ua}\nWaktu: ${time}`
   );
   return res.json({ success: true });
 });
+
 
 export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ import tiktokRoutes from "./tiktokRoutes.js";
 import polresRoutes from './polresRoutes.js';
 import poldaRoutes from './poldaRoutes.js';
 import metaRoutes from './metaRoutes.js';
+import logRoutes from './logRoutes.js';
 
 const router = express.Router();
 
@@ -22,6 +23,7 @@ router.use('/oauth', oauthRoutes);
 router.use('/polres', polresRoutes);
 router.use('/polda', poldaRoutes);
 router.use('/metadata', metaRoutes);
+router.use('/logs', logRoutes);
 
 
 export default router;

--- a/src/routes/logRoutes.js
+++ b/src/routes/logRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { getVisitorLogs } from '../model/visitorLogModel.js';
+
+const router = express.Router();
+
+router.get('/visitors', async (_req, res) => {
+  const logs = await getVisitorLogs();
+  res.json(logs);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- track dashboard visitors in new `visitor_logs` table
- add visitor log model with insert/retrieve helpers
- record visits when `/auth/open` is hit
- expose `/logs/visitors` to read visitor logs
- document new table and endpoint in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6852838dd55083279ecfcdc3230ac59c