### PR TITLE
Add Instagram data mining cron

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ import './src/cron/cronTiktokService.js';
 import './src/cron/cronInstaLaphar.js';
 import './src/cron/cronTiktokLaphar.js';
 import './src/cron/cronNotifikasiLikesDanKomentar.js';
+import './src/cron/cronInstaDataMining.js';
 
 const app = express();
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -38,6 +38,12 @@ CREATE TABLE insta_like (
   updated_at TIMESTAMP
 );
 
+CREATE TABLE insta_comment (
+  shortcode VARCHAR PRIMARY KEY REFERENCES insta_post(shortcode),
+  comments JSONB,
+  updated_at TIMESTAMP
+);
+
 CREATE TABLE insta_profile (
   username VARCHAR PRIMARY KEY,
   full_name VARCHAR,

--- a/src/cron/cronInstaDataMining.js
+++ b/src/cron/cronInstaDataMining.js
@@ -1,0 +1,79 @@
+import cron from 'node-cron';
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { fetchAndStoreInstaContent } from '../handler/fetchpost/instaFetchPost.js';
+import { handleFetchLikesInstagram } from '../handler/fetchengagement/fetchLikesInstagram.js';
+import { handleFetchKomentarInstagram } from '../handler/fetchengagement/fetchCommentInstagram.js';
+import { fetchInstagramHashtag } from '../service/instagramApi.js';
+import { upsertHashtagInfo } from '../model/instaHashtagModel.js';
+import { query } from '../db/index.js';
+import { sendDebug } from '../middleware/debugHandler.js';
+
+async function getActiveClientsIG() {
+  const res = await query(
+    `SELECT client_id, client_insta FROM clients WHERE client_status = true AND client_insta_status = true`
+  );
+  return res.rows;
+}
+
+function extractTopHashtags(captions) {
+  const count = {};
+  for (const text of captions) {
+    const matches = text ? text.match(/#[A-Za-z0-9_]+/g) : null;
+    if (!matches) continue;
+    for (const m of matches) {
+      const tag = m.replace('#', '').toLowerCase();
+      count[tag] = (count[tag] || 0) + 1;
+    }
+  }
+  return Object.entries(count)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([t]) => t);
+}
+
+async function fetchTopHashtagsForClient(client_id) {
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const dd = String(today.getDate()).padStart(2, '0');
+  const { rows } = await query(
+    `SELECT caption FROM insta_post WHERE client_id = $1 AND DATE(created_at) = $2`,
+    [client_id, `${yyyy}-${mm}-${dd}`]
+  );
+  const captions = rows.map(r => r.caption || '');
+  const topTags = extractTopHashtags(captions);
+  for (const tag of topTags) {
+    try {
+      const { info } = await fetchInstagramHashtag(tag);
+      if (info) await upsertHashtagInfo({ id: info.id, name: info.name, ...info });
+      sendDebug({ tag: 'IG DM', msg: `Hashtag ${tag} disimpan`, client_id });
+    } catch (err) {
+      sendDebug({ tag: 'IG DM', msg: `Gagal hashtag ${tag}: ${(err && err.message) || String(err)}`, client_id });
+    }
+  }
+}
+
+cron.schedule(
+  '0 22 * * *',
+  async () => {
+    sendDebug({ tag: 'IG DM', msg: 'Mulai cron data mining Instagram' });
+    try {
+      const clients = await getActiveClientsIG();
+      const keys = ['code', 'caption', 'like_count', 'taken_at', 'comment_count'];
+      await fetchAndStoreInstaContent(keys);
+      for (const client of clients) {
+        await handleFetchLikesInstagram(null, null, client.client_id);
+        await handleFetchKomentarInstagram(null, null, client.client_id);
+        await fetchTopHashtagsForClient(client.client_id);
+      }
+      sendDebug({ tag: 'IG DM', msg: 'Cron data mining IG selesai' });
+    } catch (err) {
+      sendDebug({ tag: 'IG DM', msg: (err && err.message) || String(err) });
+    }
+  },
+  { timezone: 'Asia/Jakarta' }
+);
+
+export default null;

--- a/src/handler/fetchengagement/fetchCommentInstagram.js
+++ b/src/handler/fetchengagement/fetchCommentInstagram.js
@@ -1,0 +1,48 @@
+import pLimit from 'p-limit';
+import { query } from '../../db/index.js';
+import { sendDebug } from '../../middleware/debugHandler.js';
+import { fetchAllInstagramComments } from '../../service/instagramApi.js';
+import { upsertInstaComments } from '../../model/instaCommentModel.js';
+
+const limit = pLimit(3);
+
+export async function handleFetchKomentarInstagram(waClient = null, chatId = null, client_id = null) {
+  try {
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    const { rows } = await query(
+      `SELECT shortcode FROM insta_post WHERE client_id = $1 AND DATE(created_at) = $2`,
+      [client_id, `${yyyy}-${mm}-${dd}`]
+    );
+    const shortcodes = rows.map(r => r.shortcode);
+    if (!shortcodes.length) {
+      if (waClient && chatId) await waClient.sendMessage(chatId, `Tidak ada konten IG hari ini untuk client ${client_id}.`);
+      sendDebug({ tag: 'IG COMMENT', msg: `Tidak ada post IG client ${client_id} hari ini.` });
+      return;
+    }
+    let sukses = 0, gagal = 0;
+    for (const sc of shortcodes) {
+      await limit(async () => {
+        try {
+          const comments = await fetchAllInstagramComments(sc);
+          await upsertInstaComments(sc, comments);
+          sukses++;
+          sendDebug({ tag: 'IG COMMENT', msg: `Shortcode ${sc} berhasil simpan komentar (${comments.length})`, client_id });
+        } catch (err) {
+          gagal++;
+          sendDebug({ tag: 'IG COMMENT ERROR', msg: `Gagal shortcode ${sc}: ${(err && err.message) || String(err)}`, client_id });
+        }
+      });
+    }
+    if (waClient && chatId) {
+      await waClient.sendMessage(chatId, `✅ Selesai fetch komentar IG client ${client_id}. Berhasil: ${sukses}, Gagal: ${gagal}`);
+    }
+  } catch (err) {
+    if (waClient && chatId) {
+      await waClient.sendMessage(chatId, `❌ Error utama fetch komentar IG: ${(err && err.message) || String(err)}`);
+    }
+    sendDebug({ tag: 'IG COMMENT ERROR', msg: (err && err.message) || String(err), client_id });
+  }
+}

--- a/src/model/instaCommentModel.js
+++ b/src/model/instaCommentModel.js
@@ -1,0 +1,39 @@
+import { query } from '../repository/db.js';
+
+export async function upsertInstaComments(shortcode, commentsArr = []) {
+  if (!shortcode) return;
+  const usernames = [];
+  for (const c of commentsArr) {
+    let uname = null;
+    if (c && c.user && typeof c.user.username === 'string') {
+      uname = c.user.username;
+    } else if (c && typeof c.username === 'string') {
+      uname = c.username;
+    }
+    if (uname) {
+      usernames.push(uname.toLowerCase().replace(/^@/, ''));
+    }
+  }
+  const uniq = [...new Set(usernames)];
+  const res = await query('SELECT comments FROM insta_comment WHERE shortcode = $1', [shortcode]);
+  let existing = [];
+  if (res.rows[0] && Array.isArray(res.rows[0].comments)) {
+    existing = res.rows[0].comments
+      .map(u => (typeof u === 'string' ? u.toLowerCase().replace(/^@/, '') : null))
+      .filter(Boolean);
+  }
+  const finalUsernames = [...new Set([...existing, ...uniq])];
+  const sql = `
+    INSERT INTO insta_comment (shortcode, comments, updated_at)
+    VALUES ($1,$2,NOW())
+    ON CONFLICT (shortcode) DO UPDATE SET comments = $2, updated_at = NOW()
+  `;
+  await query(sql, [shortcode, JSON.stringify(finalUsernames)]);
+}
+
+export async function getCommentsByShortcode(shortcode) {
+  const res = await query('SELECT comments FROM insta_comment WHERE shortcode = $1', [shortcode]);
+  return res.rows[0] ? { comments: res.rows[0].comments } : { comments: [] };
+}
+
+export const findByShortcode = getCommentsByShortcode;

--- a/src/model/instaHashtagModel.js
+++ b/src/model/instaHashtagModel.js
@@ -1,0 +1,54 @@
+import { query } from '../repository/db.js';
+
+export async function upsertHashtagInfo(data) {
+  if (!data || !data.id || !data.name) return;
+  const {
+    id,
+    name,
+    profile_pic_url = null,
+    media_count = null,
+    formatted_media_count = null,
+    is_trending = null,
+    allow_muting_story = null,
+    hide_use_hashtag_button = null,
+    show_follow_drop_down = null,
+    content_advisory = null,
+    subtitle = null,
+    warning_message = null
+  } = data;
+  await query(
+    `INSERT INTO ig_hashtag_info (
+      hashtag_id, name, profile_pic_url, media_count, formatted_media_count,
+      is_trending, allow_muting_story, hide_use_hashtag_button,
+      show_follow_drop_down, content_advisory, subtitle, warning_message
+    ) VALUES (
+      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12
+    )
+    ON CONFLICT (hashtag_id) DO UPDATE SET
+      name=EXCLUDED.name,
+      profile_pic_url=EXCLUDED.profile_pic_url,
+      media_count=EXCLUDED.media_count,
+      formatted_media_count=EXCLUDED.formatted_media_count,
+      is_trending=EXCLUDED.is_trending,
+      allow_muting_story=EXCLUDED.allow_muting_story,
+      hide_use_hashtag_button=EXCLUDED.hide_use_hashtag_button,
+      show_follow_drop_down=EXCLUDED.show_follow_drop_down,
+      content_advisory=EXCLUDED.content_advisory,
+      subtitle=EXCLUDED.subtitle,
+      warning_message=EXCLUDED.warning_message`,
+    [
+      id,
+      name,
+      profile_pic_url,
+      media_count,
+      formatted_media_count,
+      is_trending,
+      allow_muting_story,
+      hide_use_hashtag_button,
+      show_follow_drop_down,
+      content_advisory,
+      subtitle,
+      warning_message
+    ]
+  );
+}

--- a/src/service/instagramApi.js
+++ b/src/service/instagramApi.js
@@ -5,5 +5,8 @@ export {
   fetchInstagramPostsByMonthToken,
   fetchInstagramLikesPage,
   fetchAllInstagramLikes,
+  fetchInstagramCommentsPage,
+  fetchAllInstagramComments,
+  fetchInstagramHashtag
 } from './instaRapidService.js';
 


### PR DESCRIPTION
## Summary
- create `insta_comment` table for storing comment usernames
- support saving hashtag info in DB
- add RapidAPI helpers for fetching comments and hashtags
- create handler to fetch Instagram comments
- schedule a new cron job to run data mining at 22:00 daily
- load the cron job from `app.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6852cef10d188327af6d7f4e98e4d2f1