### PR TITLE
Add post info fetch to Instagram cron

### DIFF
--- a/src/cron/cronInstaDataMining.js
+++ b/src/cron/cronInstaDataMining.js
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 import { fetchAndStoreInstaContent } from '../handler/fetchpost/instaFetchPost.js';
+import { fetchPostInfoForClient } from '../handler/fetchpost/instaFetchPostInfo.js';
 import { handleFetchLikesInstagram } from '../handler/fetchengagement/fetchLikesInstagram.js';
 import { handleFetchKomentarInstagram } from '../handler/fetchengagement/fetchCommentInstagram.js';
 import { fetchInstagramHashtag } from '../service/instagramApi.js';
@@ -64,9 +65,10 @@ cron.schedule(
       const keys = ['code', 'caption', 'like_count', 'taken_at', 'comment_count'];
       await fetchAndStoreInstaContent(keys);
       for (const client of clients) {
+        await fetchPostInfoForClient(client.client_id);
+        await fetchTopHashtagsForClient(client.client_id);
         await handleFetchLikesInstagram(null, null, client.client_id);
         await handleFetchKomentarInstagram(null, null, client.client_id);
-        await fetchTopHashtagsForClient(client.client_id);
       }
       sendDebug({ tag: 'IG DM', msg: 'Cron data mining IG selesai' });
     } catch (err) {

--- a/src/handler/fetchpost/instaFetchPostInfo.js
+++ b/src/handler/fetchpost/instaFetchPostInfo.js
@@ -1,0 +1,43 @@
+import { fetchInstagramPostInfo } from '../../service/instagramApi.js';
+import { getShortcodesTodayByClient } from '../../model/instaPostModel.js';
+import {
+  upsertIgUser,
+  upsertIgPost,
+  upsertIgMedia,
+  insertHashtags,
+  upsertTaggedUsers
+} from '../../model/instaPostExtendedModel.js';
+import { upsertPostMetrics } from '../../model/instaPostMetricsModel.js';
+import { sendDebug } from '../../middleware/debugHandler.js';
+
+export async function fetchAndStorePostInfo(shortcode) {
+  try {
+    const info = await fetchInstagramPostInfo(shortcode);
+    if (!info) return;
+    await upsertIgUser(info.user);
+    await upsertIgPost(info, info.user?.id);
+    if (info.metrics) {
+      await upsertPostMetrics(info.id, info.metrics);
+    }
+    if (Array.isArray(info.hashtags)) {
+      await insertHashtags(info.id, info.hashtags);
+    }
+    const medias = info.carousel_media || [info];
+    for (const m of medias) {
+      await upsertIgMedia(m, info.id);
+      if (Array.isArray(m.tagged_users)) {
+        await upsertTaggedUsers(m.id, m.tagged_users);
+      }
+    }
+    sendDebug({ tag: 'IG POST INFO', msg: `Fetched info for ${shortcode}` });
+  } catch (err) {
+    sendDebug({ tag: 'IG POST INFO', msg: `[${shortcode}] ${err.message}` });
+  }
+}
+
+export async function fetchPostInfoForClient(clientId) {
+  const shortcodes = await getShortcodesTodayByClient(clientId);
+  for (const sc of shortcodes) {
+    await fetchAndStorePostInfo(sc);
+  }
+}

--- a/src/model/instaPostMetricsModel.js
+++ b/src/model/instaPostMetricsModel.js
@@ -1,0 +1,26 @@
+import { query } from '../repository/db.js';
+
+export async function upsertPostMetrics(postId, metrics = {}) {
+  if (!postId) return;
+  const {
+    play_count = null,
+    save_count = null,
+    share_count = null,
+    view_count = null,
+    fb_like_count = null,
+    fb_play_count = null
+  } = metrics;
+  await query(
+    `INSERT INTO ig_post_metrics (
+      post_id, play_count, save_count, share_count, view_count, fb_like_count, fb_play_count
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7)
+     ON CONFLICT (post_id) DO UPDATE SET
+      play_count=EXCLUDED.play_count,
+      save_count=EXCLUDED.save_count,
+      share_count=EXCLUDED.share_count,
+      view_count=EXCLUDED.view_count,
+      fb_like_count=EXCLUDED.fb_like_count,
+      fb_play_count=EXCLUDED.fb_play_count`,
+    [postId, play_count, save_count, share_count, view_count, fb_like_count, fb_play_count]
+  );
+}

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -380,3 +380,16 @@ export async function fetchInstagramHashtag(tag, token = null) {
   const has_more = (data?.has_more || false) || (next_token && next_token !== '');
   return { info, items, next_token, has_more };
 }
+
+export async function fetchInstagramPostInfo(code) {
+  if (!code) return null;
+  const params = new URLSearchParams({ code_or_id_or_url: code });
+  const res = await axios.get(`https://${RAPIDAPI_HOST}/v1/post_info`, {
+    params,
+    headers: {
+      'X-RapidAPI-Key': RAPIDAPI_KEY,
+      'X-RapidAPI-Host': RAPIDAPI_HOST
+    }
+  });
+  return res.data?.data || null;
+}

--- a/src/service/instagramApi.js
+++ b/src/service/instagramApi.js
@@ -7,6 +7,7 @@ export {
   fetchAllInstagramLikes,
   fetchInstagramCommentsPage,
   fetchAllInstagramComments,
-  fetchInstagramHashtag
+  fetchInstagramHashtag,
+  fetchInstagramPostInfo
 } from './instaRapidService.js';
 


### PR DESCRIPTION
## Summary
- add a service to fetch Instagram post info from RapidAPI
- create model to store post metrics
- handle saving post info and metrics
- include new post info step in cronInstaDataMining

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852d251b7d8832799f5ff1a464db719