### PR TITLE
Add dedicated Instagram data mining handlers

### DIFF
--- a/src/cron/cronInstaDataMining.js
+++ b/src/cron/cronInstaDataMining.js
@@ -2,12 +2,11 @@ import cron from 'node-cron';
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { fetchAndStoreInstaContent } from '../handler/fetchpost/instaFetchPost.js';
-import { fetchPostInfoForClient } from '../handler/fetchpost/instaFetchPostInfo.js';
-import { handleFetchLikesInstagram } from '../handler/fetchengagement/fetchLikesInstagram.js';
-import { handleFetchKomentarInstagram } from '../handler/fetchengagement/fetchCommentInstagram.js';
-import { fetchInstagramHashtag } from '../service/instagramApi.js';
-import { upsertHashtagInfo } from '../model/instaHashtagModel.js';
+import { fetchDmPosts } from '../handler/datamining/fetchDmPosts.js';
+import { fetchDmPostInfoForUser } from '../handler/datamining/fetchDmPostInfo.js';
+import { handleFetchLikesInstagramDM } from '../handler/datamining/fetchDmLikes.js';
+import { handleFetchKomentarInstagramDM } from '../handler/datamining/fetchDmComments.js';
+import { fetchDmHashtagsForUser } from '../handler/datamining/fetchDmHashtags.js';
 import { query } from '../db/index.js';
 import { sendDebug } from '../middleware/debugHandler.js';
 
@@ -18,43 +17,6 @@ async function getActiveClientsIG() {
   return res.rows;
 }
 
-function extractTopHashtags(captions) {
-  const count = {};
-  for (const text of captions) {
-    const matches = text ? text.match(/#[A-Za-z0-9_]+/g) : null;
-    if (!matches) continue;
-    for (const m of matches) {
-      const tag = m.replace('#', '').toLowerCase();
-      count[tag] = (count[tag] || 0) + 1;
-    }
-  }
-  return Object.entries(count)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 3)
-    .map(([t]) => t);
-}
-
-async function fetchTopHashtagsForClient(client_id) {
-  const today = new Date();
-  const yyyy = today.getFullYear();
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const dd = String(today.getDate()).padStart(2, '0');
-  const { rows } = await query(
-    `SELECT caption FROM insta_post WHERE client_id = $1 AND DATE(created_at) = $2`,
-    [client_id, `${yyyy}-${mm}-${dd}`]
-  );
-  const captions = rows.map(r => r.caption || '');
-  const topTags = extractTopHashtags(captions);
-  for (const tag of topTags) {
-    try {
-      const { info } = await fetchInstagramHashtag(tag);
-      if (info) await upsertHashtagInfo({ id: info.id, name: info.name, ...info });
-      sendDebug({ tag: 'IG DM', msg: `Hashtag ${tag} disimpan`, client_id });
-    } catch (err) {
-      sendDebug({ tag: 'IG DM', msg: `Gagal hashtag ${tag}: ${(err && err.message) || String(err)}`, client_id });
-    }
-  }
-}
 
 cron.schedule(
   '0 23 * * *',
@@ -62,13 +24,13 @@ cron.schedule(
     sendDebug({ tag: 'IG DM', msg: 'Mulai cron data mining Instagram' });
     try {
       const clients = await getActiveClientsIG();
-      const keys = ['code', 'caption', 'like_count', 'taken_at', 'comment_count'];
-      await fetchAndStoreInstaContent(keys);
       for (const client of clients) {
-        await fetchPostInfoForClient(client.client_id);
-        await fetchTopHashtagsForClient(client.client_id);
-        await handleFetchLikesInstagram(null, null, client.client_id);
-        await handleFetchKomentarInstagram(null, null, client.client_id);
+        const username = client.client_insta;
+        await fetchDmPosts(username);
+        await fetchDmPostInfoForUser(username);
+        await fetchDmHashtagsForUser(username);
+        await handleFetchLikesInstagramDM(username);
+        await handleFetchKomentarInstagramDM(username);
       }
       sendDebug({ tag: 'IG DM', msg: 'Cron data mining IG selesai' });
     } catch (err) {

--- a/src/handler/datamining/fetchDmComments.js
+++ b/src/handler/datamining/fetchDmComments.js
@@ -1,0 +1,33 @@
+import pLimit from 'p-limit';
+import { fetchAllInstagramComments } from '../../service/instagramApi.js';
+import { upsertInstaComments } from '../../model/instaCommentModel.js';
+import { getPostIdsTodayByUsername } from '../../model/instaPostExtendedModel.js';
+import { sendDebug } from '../../middleware/debugHandler.js';
+
+const limit = pLimit(3);
+
+export async function handleFetchKomentarInstagramDM(username) {
+  try {
+    const ids = await getPostIdsTodayByUsername(username);
+    if (!ids.length) {
+      sendDebug({ tag: 'IG DM COMMENT', msg: `Tidak ada post IG hari ini untuk @${username}` });
+      return;
+    }
+    let sukses = 0, gagal = 0;
+    for (const id of ids) {
+      await limit(async () => {
+        try {
+          const comments = await fetchAllInstagramComments(id);
+          await upsertInstaComments(id, comments);
+          sukses++;
+        } catch (err) {
+          gagal++;
+          sendDebug({ tag: 'IG DM COMMENT ERROR', msg: `Gagal ${id}: ${err.message}` });
+        }
+      });
+    }
+    sendDebug({ tag: 'IG DM COMMENT', msg: `Selesai komentar @${username}. Berhasil: ${sukses}, Gagal: ${gagal}` });
+  } catch (err) {
+    sendDebug({ tag: 'IG DM COMMENT ERROR', msg: err.message });
+  }
+}

--- a/src/handler/datamining/fetchDmHashtags.js
+++ b/src/handler/datamining/fetchDmHashtags.js
@@ -1,0 +1,42 @@
+import { query } from '../../db/index.js';
+import { fetchInstagramHashtag } from '../../service/instagramApi.js';
+import { upsertHashtagInfo } from '../../model/instaHashtagModel.js';
+import { sendDebug } from '../../middleware/debugHandler.js';
+
+function extractTopHashtags(captions) {
+  const count = {};
+  for (const text of captions) {
+    const matches = text ? text.match(/#[A-Za-z0-9_]+/g) : null;
+    if (!matches) continue;
+    for (const m of matches) {
+      const tag = m.replace('#', '').toLowerCase();
+      count[tag] = (count[tag] || 0) + 1;
+    }
+  }
+  return Object.entries(count)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([t]) => t);
+}
+
+export async function fetchDmHashtagsForUser(username) {
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const dd = String(today.getDate()).padStart(2, '0');
+  const { rows } = await query(
+    `SELECT p.caption_text FROM ig_ext_posts p JOIN ig_ext_users u ON u.user_id = p.user_id WHERE u.username = $1 AND DATE(p.created_at) = $2`,
+    [username, `${yyyy}-${mm}-${dd}`]
+  );
+  const captions = rows.map(r => r.caption_text || '');
+  const topTags = extractTopHashtags(captions);
+  for (const tag of topTags) {
+    try {
+      const { info } = await fetchInstagramHashtag(tag);
+      if (info) await upsertHashtagInfo({ id: info.id, name: info.name, ...info });
+      sendDebug({ tag: 'IG DM', msg: `Hashtag ${tag} disimpan`, username });
+    } catch (err) {
+      sendDebug({ tag: 'IG DM', msg: `Gagal hashtag ${tag}: ${err.message}`, username });
+    }
+  }
+}

--- a/src/handler/datamining/fetchDmLikes.js
+++ b/src/handler/datamining/fetchDmLikes.js
@@ -1,0 +1,33 @@
+import pLimit from 'p-limit';
+import { fetchAllInstagramLikes } from '../../service/instagramApi.js';
+import { upsertInstaLike } from '../../model/instaLikeModel.js';
+import { getPostIdsTodayByUsername } from '../../model/instaPostExtendedModel.js';
+import { sendDebug } from '../../middleware/debugHandler.js';
+
+const limit = pLimit(3);
+
+export async function handleFetchLikesInstagramDM(username) {
+  try {
+    const ids = await getPostIdsTodayByUsername(username);
+    if (!ids.length) {
+      sendDebug({ tag: 'IG DM LIKES', msg: `Tidak ada post IG hari ini untuk @${username}` });
+      return;
+    }
+    let sukses = 0, gagal = 0;
+    for (const id of ids) {
+      await limit(async () => {
+        try {
+          const likes = await fetchAllInstagramLikes(id);
+          await upsertInstaLike(id, likes);
+          sukses++;
+        } catch (err) {
+          gagal++;
+          sendDebug({ tag: 'IG DM LIKES ERROR', msg: `[${id}] ${err.message}` });
+        }
+      });
+    }
+    sendDebug({ tag: 'IG DM LIKES', msg: `Selesai likes @${username}. Berhasil: ${sukses}, Gagal: ${gagal}` });
+  } catch (err) {
+    sendDebug({ tag: 'IG DM LIKES ERROR', msg: err.message });
+  }
+}

--- a/src/handler/datamining/fetchDmPostInfo.js
+++ b/src/handler/datamining/fetchDmPostInfo.js
@@ -1,0 +1,43 @@
+import { fetchInstagramPostInfo } from '../../service/instagramApi.js';
+import { sendDebug } from '../../middleware/debugHandler.js';
+import {
+  upsertIgUser,
+  upsertIgPost,
+  upsertIgMedia,
+  insertHashtags,
+  upsertTaggedUsers,
+  getPostIdsTodayByUsername
+} from '../../model/instaPostExtendedModel.js';
+import { upsertPostMetrics } from '../../model/instaPostMetricsModel.js';
+
+export async function fetchAndStoreDmPostInfo(postId) {
+  try {
+    const info = await fetchInstagramPostInfo(postId);
+    if (!info) return;
+    await upsertIgUser(info.user);
+    await upsertIgPost(info, info.user?.id);
+    if (info.metrics) {
+      await upsertPostMetrics(info.id, info.metrics);
+    }
+    if (Array.isArray(info.hashtags)) {
+      await insertHashtags(info.id, info.hashtags);
+    }
+    const medias = info.carousel_media || [info];
+    for (const m of medias) {
+      await upsertIgMedia(m, info.id);
+      if (Array.isArray(m.tagged_users)) {
+        await upsertTaggedUsers(m.id, m.tagged_users);
+      }
+    }
+    sendDebug({ tag: 'IG DM POST INFO', msg: `Fetched info for ${postId}` });
+  } catch (err) {
+    sendDebug({ tag: 'IG DM POST INFO', msg: `[${postId}] ${err.message}` });
+  }
+}
+
+export async function fetchDmPostInfoForUser(username) {
+  const ids = await getPostIdsTodayByUsername(username);
+  for (const id of ids) {
+    await fetchAndStoreDmPostInfo(id);
+  }
+}

--- a/src/handler/datamining/fetchDmPosts.js
+++ b/src/handler/datamining/fetchDmPosts.js
@@ -1,0 +1,35 @@
+import { fetchInstagramPosts } from '../../service/instagramApi.js';
+import { sendDebug } from '../../middleware/debugHandler.js';
+import {
+  upsertIgUser,
+  upsertIgPost,
+  upsertIgMedia,
+  insertHashtags,
+  upsertTaggedUsers
+} from '../../model/instaPostExtendedModel.js';
+
+export async function fetchDmPosts(username, limit = 50) {
+  if (!username) return [];
+  try {
+    const posts = await fetchInstagramPosts(username, limit);
+    for (const post of posts) {
+      await upsertIgUser(post.user);
+      await upsertIgPost(post, post.user?.id);
+      if (Array.isArray(post.hashtags)) {
+        await insertHashtags(post.id, post.hashtags);
+      }
+      const medias = post.carousel_media || [post];
+      for (const m of medias) {
+        await upsertIgMedia(m, post.id);
+        if (Array.isArray(m.tagged_users)) {
+          await upsertTaggedUsers(m.id, m.tagged_users);
+        }
+      }
+    }
+    sendDebug({ tag: 'IG DM POST', msg: `Fetched ${posts.length} posts for @${username}` });
+    return posts.map(p => p.id);
+  } catch (err) {
+    sendDebug({ tag: 'IG DM POST ERROR', msg: err.message });
+    return [];
+  }
+}

--- a/src/model/instaPostExtendedModel.js
+++ b/src/model/instaPostExtendedModel.js
@@ -95,3 +95,17 @@ export async function upsertTaggedUsers(mediaId, tags=[]) {
     );
   }
 }
+
+export async function getPostIdsTodayByUsername(username) {
+  if (!username) return [];
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, "0");
+  const dd = String(today.getDate()).padStart(2, "0");
+  const res = await query(
+    `SELECT p.post_id FROM ig_ext_posts p JOIN ig_ext_users u ON u.user_id = p.user_id WHERE u.username = $1 AND DATE(p.created_at) = $2`,
+    [username, `${yyyy}-${mm}-${dd}`]
+  );
+  return res.rows.map(r => r.post_id);
+}
+


### PR DESCRIPTION
## Summary
- add new helper to get today's IG post IDs by username
- create handlers to fetch posts, post info, likes, comments and hashtags specifically for data mining
- update Instagram data mining cron to use the new handlers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e41bc99c8327ad9bfe21feabd90c