### PR TITLE
Add IG data mining likes table

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -193,6 +193,13 @@ CREATE TABLE IF NOT EXISTS ig_post_metrics (
     fb_play_count INT
 );
 
+-- Store full list of usernames who liked a post (Data Mining)
+CREATE TABLE IF NOT EXISTS ig_post_likes (
+    post_id VARCHAR(50) PRIMARY KEY REFERENCES ig_ext_posts(post_id),
+    likes JSONB,
+    updated_at TIMESTAMP
+);
+
 CREATE TABLE visitor_logs (
     id SERIAL PRIMARY KEY,
     ip VARCHAR,

--- a/src/handler/datamining/fetchDmLikes.js
+++ b/src/handler/datamining/fetchDmLikes.js
@@ -1,6 +1,6 @@
 import pLimit from 'p-limit';
 import { fetchAllInstagramLikes } from '../../service/instagramApi.js';
-import { upsertInstaLike } from '../../model/instaLikeModel.js';
+import { upsertIgPostLike } from '../../model/igPostLikeModel.js';
 import { getPostIdsTodayByUsername } from '../../model/instaPostExtendedModel.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
 
@@ -18,7 +18,7 @@ export async function handleFetchLikesInstagramDM(username) {
       await limit(async () => {
         try {
           const likes = await fetchAllInstagramLikes(id);
-          await upsertInstaLike(id, likes);
+          await upsertIgPostLike(id, likes);
           sukses++;
         } catch (err) {
           gagal++;

--- a/src/model/igPostLikeModel.js
+++ b/src/model/igPostLikeModel.js
@@ -1,0 +1,35 @@
+// src/model/igPostLikeModel.js
+import { query } from '../repository/db.js';
+
+// Upsert like usernames for a post_id
+export async function upsertIgPostLike(postId, likes = []) {
+  if (!postId) return;
+  await query(
+    `INSERT INTO ig_post_likes (post_id, likes, updated_at)
+     VALUES ($1, $2, NOW())
+     ON CONFLICT (post_id) DO UPDATE
+     SET likes = EXCLUDED.likes, updated_at = NOW()`,
+    [postId, JSON.stringify(likes)]
+  );
+}
+
+// Get likes array by post_id
+export async function getLikesByPostId(postId) {
+  if (!postId) return [];
+  const { rows } = await query(
+    'SELECT likes FROM ig_post_likes WHERE post_id = $1',
+    [postId]
+  );
+  if (!rows.length) return [];
+  const val = rows[0].likes;
+  if (!val) return [];
+  if (Array.isArray(val)) return val;
+  if (typeof val === 'string') {
+    try {
+      return JSON.parse(val) || [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- extend SQL schema with `ig_post_likes`
- create new `igPostLikeModel`
- update DM likes handler to store likes in the new table

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6852e9207c5c832797d22713b3e0b3cd