### PR TITLE
Update DM modules to use today's posts

### DIFF
--- a/src/handler/datamining/fetchDmComments.js
+++ b/src/handler/datamining/fetchDmComments.js
@@ -1,28 +1,28 @@
 import pLimit from 'p-limit';
 import { fetchAllInstagramComments } from '../../service/instagramApi.js';
 import { upsertInstaComments } from '../../model/instaCommentModel.js';
-import { getPostIdsTodayByUsername } from '../../model/instaPostExtendedModel.js';
+import { getShortcodesTodayByUsername } from '../../model/instaPostModel.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
 
 const limit = pLimit(3);
 
 export async function handleFetchKomentarInstagramDM(username) {
   try {
-    const ids = await getPostIdsTodayByUsername(username);
-    if (!ids.length) {
+    const shortcodes = await getShortcodesTodayByUsername(username);
+    if (!shortcodes.length) {
       sendDebug({ tag: 'IG DM COMMENT', msg: `Tidak ada post IG hari ini untuk @${username}` });
       return;
     }
     let sukses = 0, gagal = 0;
-    for (const id of ids) {
+    for (const sc of shortcodes) {
       await limit(async () => {
         try {
-          const comments = await fetchAllInstagramComments(id);
-          await upsertInstaComments(id, comments);
+          const comments = await fetchAllInstagramComments(sc);
+          await upsertInstaComments(sc, comments);
           sukses++;
         } catch (err) {
           gagal++;
-          sendDebug({ tag: 'IG DM COMMENT ERROR', msg: `Gagal ${id}: ${err.message}` });
+          sendDebug({ tag: 'IG DM COMMENT ERROR', msg: `Gagal ${sc}: ${err.message}` });
         }
       });
     }

--- a/src/handler/datamining/fetchDmLikes.js
+++ b/src/handler/datamining/fetchDmLikes.js
@@ -1,28 +1,28 @@
 import pLimit from 'p-limit';
-import { fetchAllInstagramLikes } from '../../service/instagramApi.js';
-import { upsertIgPostLike } from '../../model/igPostLikeModel.js';
-import { getPostIdsTodayByUsername } from '../../model/instaPostExtendedModel.js';
+import { fetchAllInstagramLikesItems } from '../../service/instagramApi.js';
+import { upsertInstaLike } from '../../model/instaLikeModel.js';
+import { getShortcodesTodayByUsername } from '../../model/instaPostModel.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
 
 const limit = pLimit(3);
 
 export async function handleFetchLikesInstagramDM(username) {
   try {
-    const ids = await getPostIdsTodayByUsername(username);
-    if (!ids.length) {
+    const shortcodes = await getShortcodesTodayByUsername(username);
+    if (!shortcodes.length) {
       sendDebug({ tag: 'IG DM LIKES', msg: `Tidak ada post IG hari ini untuk @${username}` });
       return;
     }
     let sukses = 0, gagal = 0;
-    for (const id of ids) {
+    for (const sc of shortcodes) {
       await limit(async () => {
         try {
-          const likes = await fetchAllInstagramLikes(id);
-          await upsertIgPostLike(id, likes);
+          const likes = await fetchAllInstagramLikesItems(sc);
+          await upsertInstaLike(sc, likes);
           sukses++;
         } catch (err) {
           gagal++;
-          sendDebug({ tag: 'IG DM LIKES ERROR', msg: `[${id}] ${err.message}` });
+          sendDebug({ tag: 'IG DM LIKES ERROR', msg: `[${sc}] ${err.message}` });
         }
       });
     }

--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -36,6 +36,20 @@ export async function getShortcodesTodayByClient(client_id) {
   return res.rows.map(r => r.shortcode);
 }
 
+export async function getShortcodesTodayByUsername(username) {
+  if (!username) return [];
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const dd = String(today.getDate()).padStart(2, '0');
+  const res = await query(
+    `SELECT p.shortcode FROM insta_post p JOIN clients c ON c.client_id = p.client_id
+     WHERE c.client_insta = $1 AND DATE(p.created_at) = $2`,
+    [username, `${yyyy}-${mm}-${dd}`]
+  );
+  return res.rows.map(r => r.shortcode);
+}
+
 
 export async function getPostsTodayByClient(client_id) {
   const res = await query(

--- a/src/service/instagramApi.js
+++ b/src/service/instagramApi.js
@@ -5,6 +5,7 @@ export {
   fetchInstagramPostsByMonthToken,
   fetchInstagramLikesPage,
   fetchAllInstagramLikes,
+  fetchAllInstagramLikesItems,
   fetchInstagramCommentsPage,
   fetchAllInstagramComments,
   fetchInstagramHashtag,


### PR DESCRIPTION
## Summary
- add helper to fetch today's shortcodes by Instagram username
- store full like item JSON for each post
- update DM comment/likes handlers to use shortcodes from `insta_post`
- extend RapidAPI Instagram service with `fetchAllInstagramLikesItems`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ef0d83508327a7dc2202955acd81