### PR TITLE
Add IG mining tables and models

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -128,4 +128,22 @@ The diagram shows how each `client` owns many `user`, `insta_post` and
 `tiktok_post` records. Instagram and TikTok posts have one-to-one tables for
 likes and comments. `polda` tables are independent of client data.
 
+## PostgreSQL Table Management
+
+Use the SQL scripts inside the [`sql`](../sql) directory to create the tables:
+
+```bash
+psql -U <dbuser> -d <dbname> -f sql/schema.sql
+```
+
+To remove tables no longer in use, run `DROP TABLE` via `psql` (add `IF EXISTS`
+to avoid errors):
+
+```bash
+psql -U <dbuser> -d <dbname> -c "DROP TABLE IF EXISTS old_table_name;"
+```
+
+Repeat the command for each unused table. Always ensure a recent backup exists
+before dropping tables.
+
 Petunjuk penamaan kode dapat ditemukan di [docs/naming_conventions.md](naming_conventions.md).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,20 @@ export default [
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'module',
+      globals: {
+        process: 'readonly',
+        Buffer: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        console: 'readonly',
+        URL: 'readonly',
+        describe: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeAll: 'readonly'
+      }
     },
     rules: {},
   },

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -129,6 +129,7 @@ CREATE TABLE IF NOT EXISTS ig_ext_users (
 
 CREATE TABLE IF NOT EXISTS ig_ext_posts (
     post_id VARCHAR(50) PRIMARY KEY,
+    shortcode VARCHAR(50) UNIQUE REFERENCES insta_post(shortcode),
     user_id VARCHAR(50) REFERENCES ig_ext_users(user_id),
     caption_text TEXT,
     created_at TIMESTAMP,
@@ -198,6 +199,23 @@ CREATE TABLE IF NOT EXISTS ig_post_likes (
     post_id VARCHAR(50) PRIMARY KEY REFERENCES ig_ext_posts(post_id),
     likes JSONB,
     updated_at TIMESTAMP
+);
+
+-- Relational table for individual likes
+CREATE TABLE IF NOT EXISTS ig_post_like_users (
+    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id),
+    user_id VARCHAR(50) REFERENCES ig_ext_users(user_id),
+    username VARCHAR(100),
+    PRIMARY KEY (post_id, user_id)
+);
+
+-- Store individual comments for a post
+CREATE TABLE IF NOT EXISTS ig_post_comments (
+    comment_id VARCHAR(50) PRIMARY KEY,
+    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id),
+    user_id VARCHAR(50) REFERENCES ig_ext_users(user_id),
+    text TEXT,
+    created_at TIMESTAMP
 );
 
 CREATE TABLE visitor_logs (

--- a/src/handler/datamining/fetchDmComments.js
+++ b/src/handler/datamining/fetchDmComments.js
@@ -2,6 +2,8 @@ import pLimit from 'p-limit';
 import { fetchAllInstagramComments } from '../../service/instagramApi.js';
 import { upsertInstaComments } from '../../model/instaCommentModel.js';
 import { getShortcodesTodayByUsername } from '../../model/instaPostModel.js';
+import { insertIgPostComments } from '../../model/igPostCommentModel.js';
+import { upsertIgUser } from '../../model/instaPostExtendedModel.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
 
 const limit = pLimit(3);
@@ -19,6 +21,10 @@ export async function handleFetchKomentarInstagramDM(username) {
         try {
           const comments = await fetchAllInstagramComments(sc);
           await upsertInstaComments(sc, comments);
+          for (const c of comments) {
+            if (c.user) await upsertIgUser(c.user);
+          }
+          await insertIgPostComments(sc, comments);
           sukses++;
         } catch (err) {
           gagal++;

--- a/src/handler/datamining/fetchDmLikes.js
+++ b/src/handler/datamining/fetchDmLikes.js
@@ -1,6 +1,8 @@
 import pLimit from 'p-limit';
 import { fetchAllInstagramLikesItems } from '../../service/instagramApi.js';
 import { upsertInstaLike } from '../../model/instaLikeModel.js';
+import { insertIgPostLikeUsers } from '../../model/igPostLikeUserModel.js';
+import { upsertIgUser } from '../../model/instaPostExtendedModel.js';
 import { getShortcodesTodayByUsername } from '../../model/instaPostModel.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
 
@@ -19,6 +21,10 @@ export async function handleFetchLikesInstagramDM(username) {
         try {
           const likes = await fetchAllInstagramLikesItems(sc);
           await upsertInstaLike(sc, likes);
+          for (const u of likes) {
+            await upsertIgUser(u);
+          }
+          await insertIgPostLikeUsers(sc, likes);
           sukses++;
         } catch (err) {
           gagal++;

--- a/src/model/igPostCommentModel.js
+++ b/src/model/igPostCommentModel.js
@@ -1,0 +1,21 @@
+import { query } from '../repository/db.js';
+
+export async function insertIgPostComments(postId, comments = []) {
+  if (!postId || !Array.isArray(comments)) return;
+  for (const c of comments) {
+    const cid = c?.id || c?.pk;
+    if (!cid) continue;
+    const userId = c.user_id || c.user?.id || null;
+    const text = c.text || null;
+    const createdAt = c.created_at || null;
+    await query(
+      `INSERT INTO ig_post_comments (comment_id, post_id, user_id, text, created_at)
+       VALUES ($1,$2,$3,$4,to_timestamp($5))
+       ON CONFLICT (comment_id) DO UPDATE
+         SET user_id=EXCLUDED.user_id,
+             text=EXCLUDED.text,
+             created_at=to_timestamp($5)`,
+      [cid, postId, userId, text, createdAt]
+    );
+  }
+}

--- a/src/model/igPostLikeUserModel.js
+++ b/src/model/igPostLikeUserModel.js
@@ -1,0 +1,17 @@
+import { query } from '../repository/db.js';
+
+export async function insertIgPostLikeUsers(postId, likes = []) {
+  if (!postId || !Array.isArray(likes)) return;
+  for (const u of likes) {
+    const userId = u?.id || null;
+    const username = u?.username || (typeof u === 'string' ? u : null);
+    if (!userId && !username) continue;
+    await query(
+      `INSERT INTO ig_post_like_users (post_id, user_id, username)
+       VALUES ($1,$2,$3)
+       ON CONFLICT (post_id, user_id) DO UPDATE
+         SET username = EXCLUDED.username`,
+      [postId, userId, username]
+    );
+  }
+}

--- a/src/model/instaPostExtendedModel.js
+++ b/src/model/instaPostExtendedModel.js
@@ -17,18 +17,20 @@ export async function upsertIgUser(user) {
 
 export async function upsertIgPost(post, userId) {
   await query(
-    `INSERT INTO ig_ext_posts (post_id, user_id, caption_text, created_at, like_count, comment_count, is_video, media_type, is_pinned)
-     VALUES ($1,$2,$3,to_timestamp($4),$5,$6,$7,$8,$9)
+    `INSERT INTO ig_ext_posts (post_id, shortcode, user_id, caption_text, created_at, like_count, comment_count, is_video, media_type, is_pinned)
+     VALUES ($1,$2,$3,$4,to_timestamp($5),$6,$7,$8,$9,$10)
      ON CONFLICT (post_id) DO UPDATE SET
+       shortcode=EXCLUDED.shortcode,
        caption_text=EXCLUDED.caption_text,
        like_count=EXCLUDED.like_count,
        comment_count=EXCLUDED.comment_count,
        is_video=EXCLUDED.is_video,
        media_type=EXCLUDED.media_type,
        is_pinned=EXCLUDED.is_pinned,
-       created_at=to_timestamp($4)`,
+       created_at=to_timestamp($5)`,
     [
       post.id,
+      post.code || post.shortcode || null,
       userId,
       post.caption?.text || null,
       post.taken_at || post.taken_at_ts || null,
@@ -36,7 +38,7 @@ export async function upsertIgPost(post, userId) {
       post.comment_count || 0,
       post.is_video || false,
       post.media_type || null,
-      post.is_pinned || false,
+      post.is_pinned || false
     ]
   );
 }


### PR DESCRIPTION
## Summary
- extend `ig_ext_posts` with `shortcode` link
- store per-user likes and comments via new tables
- add models for inserting relational likes/comments
- update DM handlers to populate new tables
- expose Node globals for ESLint
- add example psql commands for creating and dropping tables

## Testing
- `npm run lint` *(fails: 126 errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685406419d648327bcbaf063204b56be