### PR TITLE
Add link report table and API

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -38,6 +38,7 @@ for PostgreSQL but can work with MySQL or SQLite via the DB adapter.
 | ig_post_like_users | relational table of likes |
 | ig_post_comments | stored comments per post |
 | visitor_logs | record of API access |
+| link_report | links submitted from the mobile app |
 
 ## Tables
 
@@ -149,6 +150,13 @@ Location information if available.
 - `user_id` – primary key referencing `instagram_user`
 - `address_street`, `city_id`, `city_name`
 - `instagram_location_id`, `latitude`, `longitude`, `zip`
+
+### `link_report`
+Stores social media links submitted from the mobile app.
+- `shortcode` – primary key referencing `insta_post`
+- `user_id` – foreign key to `user`
+- `instagram_link`, `facebook_link`, `twitter_link`, `tiktok_link`, `youtube_link`
+- `created_at` – timestamp when the report was submitted
 
 ## Relationships
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -228,3 +228,14 @@ CREATE TABLE visitor_logs (
     user_agent TEXT,
     visited_at TIMESTAMP DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS link_report (
+    shortcode VARCHAR PRIMARY KEY REFERENCES insta_post(shortcode),
+    user_id INTEGER REFERENCES "user"(user_id),
+    instagram_link TEXT,
+    facebook_link TEXT,
+    twitter_link TEXT,
+    tiktok_link TEXT,
+    youtube_link TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/controller/linkReportController.js
+++ b/src/controller/linkReportController.js
@@ -1,0 +1,47 @@
+import * as linkReportModel from '../model/linkReportModel.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function getAllLinkReports(req, res, next) {
+  try {
+    const data = await linkReportModel.getLinkReports();
+    sendSuccess(res, data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getLinkReportByShortcode(req, res, next) {
+  try {
+    const report = await linkReportModel.findLinkReportByShortcode(req.params.shortcode);
+    sendSuccess(res, report);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createLinkReport(req, res, next) {
+  try {
+    const report = await linkReportModel.createLinkReport(req.body);
+    sendSuccess(res, report, 201);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateLinkReport(req, res, next) {
+  try {
+    const report = await linkReportModel.updateLinkReport(req.params.shortcode, req.body);
+    sendSuccess(res, report);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteLinkReport(req, res, next) {
+  try {
+    const report = await linkReportModel.deleteLinkReport(req.params.shortcode);
+    sendSuccess(res, report);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -1,0 +1,63 @@
+import { query } from '../repository/db.js';
+
+export async function createLinkReport(data) {
+  const res = await query(
+    `INSERT INTO link_report (shortcode, user_id, instagram_link, facebook_link, twitter_link, tiktok_link, youtube_link, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7, COALESCE($8, NOW()))
+     RETURNING *`,
+    [
+      data.shortcode,
+      data.user_id || null,
+      data.instagram_link || null,
+      data.facebook_link || null,
+      data.twitter_link || null,
+      data.tiktok_link || null,
+      data.youtube_link || null,
+      data.created_at || null
+    ]
+  );
+  return res.rows[0];
+}
+
+export async function getLinkReports() {
+  const res = await query('SELECT * FROM link_report ORDER BY created_at DESC');
+  return res.rows;
+}
+
+export async function findLinkReportByShortcode(shortcode) {
+  const res = await query('SELECT * FROM link_report WHERE shortcode = $1', [shortcode]);
+  return res.rows[0] || null;
+}
+
+export async function updateLinkReport(shortcode, data) {
+  const old = await findLinkReportByShortcode(shortcode);
+  if (!old) return null;
+  const merged = { ...old, ...data };
+  const res = await query(
+    `UPDATE link_report SET
+      user_id=$2,
+      instagram_link=$3,
+      facebook_link=$4,
+      twitter_link=$5,
+      tiktok_link=$6,
+      youtube_link=$7,
+      created_at=$8
+     WHERE shortcode=$1 RETURNING *`,
+    [
+      shortcode,
+      merged.user_id || null,
+      merged.instagram_link || null,
+      merged.facebook_link || null,
+      merged.twitter_link || null,
+      merged.tiktok_link || null,
+      merged.youtube_link || null,
+      merged.created_at || null
+    ]
+  );
+  return res.rows[0];
+}
+
+export async function deleteLinkReport(shortcode) {
+  const res = await query('DELETE FROM link_report WHERE shortcode=$1 RETURNING *', [shortcode]);
+  return res.rows[0] || null;
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ import oauthRoutes from './oauthRoutes.js';
 import tiktokRoutes from "./tiktokRoutes.js";
 import metaRoutes from './metaRoutes.js';
 import logRoutes from './logRoutes.js';
+import linkReportRoutes from './linkReportRoutes.js';
 
 const router = express.Router();
 
@@ -20,6 +21,7 @@ router.use("/tiktok", tiktokRoutes);
 router.use('/oauth', oauthRoutes);
 router.use('/metadata', metaRoutes);
 router.use('/logs', logRoutes);
+router.use('/link-reports', linkReportRoutes);
 
 
 export default router;

--- a/src/routes/linkReportRoutes.js
+++ b/src/routes/linkReportRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import * as controller from '../controller/linkReportController.js';
+
+const router = express.Router();
+
+router.get('/', controller.getAllLinkReports);
+router.get('/:shortcode', controller.getLinkReportByShortcode);
+router.post('/', controller.createLinkReport);
+router.put('/:shortcode', controller.updateLinkReport);
+router.delete('/:shortcode', controller.deleteLinkReport);
+
+export default router;

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -1,0 +1,25 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery
+}));
+
+let createLinkReport;
+
+beforeAll(async () => {
+  const mod = await import('../src/model/linkReportModel.js');
+  createLinkReport = mod.createLinkReport;
+});
+
+test('createLinkReport inserts row', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc' }] });
+  const data = { shortcode: 'abc', user_id: 1, instagram_link: 'a' };
+  const res = await createLinkReport(data);
+  expect(res).toEqual({ shortcode: 'abc' });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO link_report'),
+    ['abc', 1, 'a', null, null, null, null, null]
+  );
+});


### PR DESCRIPTION
## Summary
- create `link_report` table
- implement model and controller for link reports
- expose `/link-reports` route for CRUD
- document the new table
- add unit test for model

## Testing
- `npm run lint` *(fails: Cannot use keyword 'await' outside an async function, plus many unused variables)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a25b474c8327b075a66cdf3589e5