### PR TITLE
Fix user table types

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ CREATE TABLE clients (
 );
 
 CREATE TABLE "user" (
-  user_id SERIAL PRIMARY KEY,
+  user_id VARCHAR PRIMARY KEY,
   nama VARCHAR,
   title VARCHAR,
   divisi VARCHAR,

--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -53,7 +53,7 @@ Represents each organisation using the system.
 
 ### `user`
 Holds users belonging to a client.
-- `user_id` – serial primary key
+- `user_id` – primary key (NRP/NIP string)
 - `nama`, `title`, `divisi` – user info fields
 - `insta`, `tiktok` – social media handles
 - `client_id` – foreign key referencing `clients(client_id)`

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE clients (
 );
 
 CREATE TABLE "user" (
-  user_id SERIAL PRIMARY KEY,
+  user_id VARCHAR PRIMARY KEY,
   nama VARCHAR,
   title VARCHAR,
   divisi VARCHAR,
@@ -231,7 +231,7 @@ CREATE TABLE visitor_logs (
 
 CREATE TABLE IF NOT EXISTS link_report (
     shortcode VARCHAR PRIMARY KEY REFERENCES insta_post(shortcode),
-    user_id INTEGER REFERENCES "user"(user_id),
+    user_id VARCHAR REFERENCES "user"(user_id),
     instagram_link TEXT,
     facebook_link TEXT,
     twitter_link TEXT,

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -15,11 +15,11 @@ beforeAll(async () => {
 
 test('createLinkReport inserts row', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc' }] });
-  const data = { shortcode: 'abc', user_id: 1, instagram_link: 'a' };
+  const data = { shortcode: 'abc', user_id: '1', instagram_link: 'a' };
   const res = await createLinkReport(data);
   expect(res).toEqual({ shortcode: 'abc' });
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('INSERT INTO link_report'),
-    ['abc', 1, 'a', null, null, null, null, null]
+    ['abc', '1', 'a', null, null, null, null, null]
   );
 });


### PR DESCRIPTION
## Summary
- use `VARCHAR` user_id columns
- update docs for non-numeric `user_id`
- adjust link report schema
- update link report model tests

## Testing
- `npm run lint` *(fails: Cannot use keyword 'await' outside an async function)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d4c9ddec83278df6757c02e2a084