### PR TITLE
Fix link report image & caption

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -20,12 +20,23 @@ export async function createLinkReport(data) {
 }
 
 export async function getLinkReports() {
-  const res = await query('SELECT * FROM link_report ORDER BY created_at DESC');
+  const res = await query(
+    `SELECT r.*, p.caption, p.image_url, p.thumbnail_url
+     FROM link_report r
+     LEFT JOIN insta_post p ON p.shortcode = r.shortcode
+     ORDER BY r.created_at DESC`
+  );
   return res.rows;
 }
 
 export async function findLinkReportByShortcode(shortcode) {
-  const res = await query('SELECT * FROM link_report WHERE shortcode = $1', [shortcode]);
+  const res = await query(
+    `SELECT r.*, p.caption, p.image_url, p.thumbnail_url
+     FROM link_report r
+     LEFT JOIN insta_post p ON p.shortcode = r.shortcode
+     WHERE r.shortcode = $1`,
+    [shortcode]
+  );
   return res.rows[0] || null;
 }
 

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -7,10 +7,18 @@ jest.unstable_mockModule('../src/repository/db.js', () => ({
 }));
 
 let createLinkReport;
+let getLinkReports;
+let findLinkReportByShortcode;
 
 beforeAll(async () => {
   const mod = await import('../src/model/linkReportModel.js');
   createLinkReport = mod.createLinkReport;
+  getLinkReports = mod.getLinkReports;
+  findLinkReportByShortcode = mod.findLinkReportByShortcode;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
 });
 
 test('createLinkReport inserts row', async () => {
@@ -21,5 +29,24 @@ test('createLinkReport inserts row', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('INSERT INTO link_report'),
     ['abc', '1', 'a', null, null, null, null, null]
+  );
+});
+
+test('getLinkReports joins with insta_post', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc', caption: 'c' }] });
+  const rows = await getLinkReports();
+  expect(rows).toEqual([{ shortcode: 'abc', caption: 'c' }]);
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('FROM link_report r')
+  );
+});
+
+test('findLinkReportByShortcode joins with insta_post', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc', caption: 'c' }] });
+  const row = await findLinkReportByShortcode('abc');
+  expect(row).toEqual({ shortcode: 'abc', caption: 'c' });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('WHERE r.shortcode = $1'),
+    ['abc']
   );
 });


### PR DESCRIPTION
## Summary
- join `link_report` with `insta_post` so report entries expose caption and image
- extend unit tests for link report model

## Testing
- `npm run lint` *(fails: cannot use await outside async, unused vars, etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a13a29b848327a97154dba5a73517