### PR TITLE
Update link_report primary key

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -151,10 +151,11 @@ Location information if available.
 - `address_street`, `city_id`, `city_name`
 - `instagram_location_id`, `latitude`, `longitude`, `zip`
 
-### `link_report`
+-### `link_report`
 Stores social media links submitted from the mobile app.
-- `shortcode` – primary key referencing `insta_post`
+- `shortcode` – foreign key to `insta_post`
 - `user_id` – foreign key to `user`
+- `shortcode` and `user_id` form the primary key
 - `instagram_link`, `facebook_link`, `twitter_link`, `tiktok_link`, `youtube_link`
 - `created_at` – timestamp when the report was submitted
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -230,12 +230,13 @@ CREATE TABLE visitor_logs (
 );
 
 CREATE TABLE IF NOT EXISTS link_report (
-    shortcode VARCHAR PRIMARY KEY REFERENCES insta_post(shortcode),
+    shortcode VARCHAR REFERENCES insta_post(shortcode),
     user_id VARCHAR REFERENCES "user"(user_id),
     instagram_link TEXT,
     facebook_link TEXT,
     twitter_link TEXT,
     tiktok_link TEXT,
     youtube_link TEXT,
-    created_at TIMESTAMP DEFAULT NOW()
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (shortcode, user_id)
 );

--- a/src/controller/linkReportController.js
+++ b/src/controller/linkReportController.js
@@ -12,7 +12,10 @@ export async function getAllLinkReports(req, res, next) {
 
 export async function getLinkReportByShortcode(req, res, next) {
   try {
-    const report = await linkReportModel.findLinkReportByShortcode(req.params.shortcode);
+    const report = await linkReportModel.findLinkReportByShortcode(
+      req.params.shortcode,
+      req.query.user_id
+    );
     sendSuccess(res, report);
   } catch (err) {
     next(err);
@@ -30,7 +33,11 @@ export async function createLinkReport(req, res, next) {
 
 export async function updateLinkReport(req, res, next) {
   try {
-    const report = await linkReportModel.updateLinkReport(req.params.shortcode, req.body);
+    const report = await linkReportModel.updateLinkReport(
+      req.params.shortcode,
+      req.body.user_id,
+      req.body
+    );
     sendSuccess(res, report);
   } catch (err) {
     next(err);
@@ -39,7 +46,10 @@ export async function updateLinkReport(req, res, next) {
 
 export async function deleteLinkReport(req, res, next) {
   try {
-    const report = await linkReportModel.deleteLinkReport(req.params.shortcode);
+    const report = await linkReportModel.deleteLinkReport(
+      req.params.shortcode,
+      req.query.user_id
+    );
     sendSuccess(res, report);
   } catch (err) {
     next(err);

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -34,7 +34,7 @@ test('createLinkReport inserts row', async () => {
   expect(res).toEqual({ shortcode: 'abc' });
   expect(mockFindPost).toHaveBeenCalledWith('abc');
   expect(mockQuery).toHaveBeenCalledWith(
-    expect.stringContaining('INSERT INTO link_report'),
+    expect.stringContaining('ON CONFLICT (shortcode, user_id)'),
     ['abc', '1', 'a', null, null, null, null, null]
   );
 });
@@ -57,10 +57,10 @@ test('getLinkReports joins with insta_post', async () => {
 
 test('findLinkReportByShortcode joins with insta_post', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc', caption: 'c' }] });
-  const row = await findLinkReportByShortcode('abc');
+  const row = await findLinkReportByShortcode('abc', '1');
   expect(row).toEqual({ shortcode: 'abc', caption: 'c' });
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('WHERE r.shortcode = $1'),
-    ['abc']
+    ['abc', '1']
   );
 });


### PR DESCRIPTION
## Summary
- make `link_report` table keyed by `(shortcode, user_id)`
- upsert records when same user reports same post
- accept `user_id` for finding, updating and deleting link reports
- update documentation and unit tests

## Testing
- `npm run lint` *(fails: Parsing error: Cannot use keyword 'await' outside an async function)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685cbbae209c832793bd373af2b43c8b