### PR TITLE
Add premium subscription docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Cicero_V2** is an automation system for monitoring, social media attendance, and content analytics (Instagram & TikTok) aimed at organizations and institutions. The backend supports multiple clients, automatically records likes and comments, and sends reports to WhatsApp administrators.
 
-The full architecture is described in [docs/enterprise_architecture.md](docs/enterprise_architecture.md). Scheduled activities are listed in [docs/activity_schedule.md](docs/activity_schedule.md). See [docs/metadata_flow.md](docs/metadata_flow.md) for the metadata flow. Additional guides are available for [server migration](docs/server_migration.md), [RabbitMQ](docs/rabbitmq.md), [Redis](docs/redis.md), [database structure](docs/database_structure.md), [Nginx configuration](docs/reverse_proxy_config.md), [PostgreSQL backups](docs/pg_backup_gdrive.md), and [naming conventions](docs/naming_conventions.md).
+The full architecture is described in [docs/enterprise_architecture.md](docs/enterprise_architecture.md). Scheduled activities are listed in [docs/activity_schedule.md](docs/activity_schedule.md). See [docs/metadata_flow.md](docs/metadata_flow.md) for the metadata flow. Additional guides are available for [server migration](docs/server_migration.md), [RabbitMQ](docs/rabbitmq.md), [Redis](docs/redis.md), [database structure](docs/database_structure.md), [premium subscriptions](docs/premium_subscription.md), [Nginx configuration](docs/reverse_proxy_config.md), [PostgreSQL backups](docs/pg_backup_gdrive.md), and [naming conventions](docs/naming_conventions.md).
 
 ## Requirements
 - Node.js 20 or newer

--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -39,6 +39,7 @@ for PostgreSQL but can work with MySQL or SQLite via the DB adapter.
 | ig_post_comments | stored comments per post |
 | visitor_logs | record of API access |
 | link_report | links submitted from the mobile app |
+| premium_subscription | tracks premium status per user |
 
 ## Tables
 
@@ -151,13 +152,23 @@ Location information if available.
 - `address_street`, `city_id`, `city_name`
 - `instagram_location_id`, `latitude`, `longitude`, `zip`
 
--### `link_report`
-Stores social media links submitted from the mobile app.
+### `link_report`
+  Stores social media links submitted from the mobile app.
 - `shortcode` – foreign key to `insta_post`
 - `user_id` – foreign key to `user`
 - `shortcode` and `user_id` form the primary key
 - `instagram_link`, `facebook_link`, `twitter_link`, `tiktok_link`, `youtube_link`
 - `created_at` – timestamp when the report was submitted
+
+### `premium_subscription`
+Tracks premium subscriptions for the Android app.
+- `subscription_id` – primary key
+- `user_id` – foreign key to `user`
+- `client_id` – foreign key to `clients`
+- `status` – `pending`, `active`, `expired` or `cancelled`
+- `start_date`, `end_date` – subscription validity
+- `order_id`, `snap_token` – Midtrans identifiers
+- `created_at`, `updated_at`
 
 ## Relationships
 

--- a/docs/premium_subscription.md
+++ b/docs/premium_subscription.md
@@ -1,0 +1,71 @@
+# Premium Subscription Workflow
+*Last updated: 2026-04-01*
+
+This document outlines how the Android app can restrict the Instagram page to paying customers.
+It covers the suggested API endpoints, database structure and how Midtrans is used for payments.
+
+## Database Table
+
+Create a new table called `premium_subscription`:
+
+```sql
+CREATE TABLE premium_subscription (
+  subscription_id SERIAL PRIMARY KEY,
+  user_id VARCHAR REFERENCES "user"(user_id),
+  client_id VARCHAR REFERENCES clients(client_id),
+  status VARCHAR NOT NULL,
+  start_date DATE,
+  end_date DATE,
+  order_id VARCHAR,
+  snap_token VARCHAR,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+- `status` values should be `pending`, `active`, `expired` or `cancelled`.
+- `order_id` and `snap_token` store the Midtrans transaction identifiers.
+- Rows are updated when Midtrans sends payment notifications.
+
+## API Scenario
+
+1. **Initiate Checkout**
+   - `POST /api/subscription/checkout`
+   - Body: `{ user_id, client_id, plan }`
+   - Server calls Midtrans Snap API and returns a `snap_token` and `order_id`.
+2. **Midtrans Callback**
+   - `POST /api/subscription/webhook`
+   - Midtrans sends transaction status. Verify the signature then update `premium_subscription.status`.
+3. **Check Status**
+   - `GET /api/subscription/status`
+   - Returns the active subscription record for the authenticated user.
+4. **Protect Routes**
+   - Middleware `premiumRequired` queries `premium_subscription` and only allows access when `status='active'` and `end_date` is in the future. Apply this middleware to `/api/insta/*` routes for the mobile app.
+
+## Midtrans Integration
+
+Use the [Midtrans Snap API](https://docs.midtrans.com/docs/snap-overview) for payment processing:
+
+```javascript
+import midtransClient from 'midtrans-client';
+
+const snap = new midtransClient.Snap({
+  isProduction: process.env.MIDTRANS_PROD === 'true',
+  serverKey: process.env.MIDTRANS_SERVER_KEY,
+  clientKey: process.env.MIDTRANS_CLIENT_KEY,
+});
+
+export async function createTransaction(orderId, amount, customer){
+  const parameters = {
+    transaction_details: { order_id: orderId, gross_amount: amount },
+    customer_details: customer,
+  };
+  const { token } = await snap.createTransaction(parameters);
+  return token;
+}
+```
+
+- Store `MIDTRANS_SERVER_KEY` and `MIDTRANS_CLIENT_KEY` in `.env`.
+- After payment Midtrans will hit the webhook URL to confirm the status.
+
+With this setup the backend can determine whether the user has an active subscription before serving Instagram data.


### PR DESCRIPTION
## Summary
- document workflow for Android premium subscriptions
- outline new `premium_subscription` table in database docs
- reference subscription docs in README

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ed72863f08327b62c5778387bf796