### PR TITLE
Add premium subscription API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Cicero_V2/
 
 ## API Overview
 
-The API exposes endpoints for managing clients and users, fetching Instagram and TikTok data, handling OAuth callbacks, and providing dashboard statistics. Detailed documentation for each route is available in the source code comments.
+The API exposes endpoints for managing clients and users, fetching Instagram and TikTok data, handling OAuth callbacks, and providing dashboard statistics. Endpoints are also available for premium subscription management. Detailed documentation for each route is available in the source code comments.
 
 ## Deployment & Environment
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -240,3 +240,12 @@ CREATE TABLE IF NOT EXISTS link_report (
     created_at TIMESTAMP DEFAULT NOW(),
     PRIMARY KEY (shortcode, user_id)
 );
+
+CREATE TABLE IF NOT EXISTS premium_subscription (
+    subscription_id SERIAL PRIMARY KEY,
+    client_id VARCHAR REFERENCES clients(client_id),
+    start_date DATE NOT NULL,
+    end_date DATE,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/controller/premiumSubscriptionController.js
+++ b/src/controller/premiumSubscriptionController.js
@@ -1,0 +1,56 @@
+import * as service from '../service/premiumSubscriptionService.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function getAllSubscriptions(req, res, next) {
+  try {
+    const rows = await service.getSubscriptions();
+    sendSuccess(res, rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getSubscriptionById(req, res, next) {
+  try {
+    const row = await service.findSubscriptionById(req.params.id);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createSubscription(req, res, next) {
+  try {
+    const row = await service.createSubscription(req.body);
+    sendSuccess(res, row, 201);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateSubscription(req, res, next) {
+  try {
+    const row = await service.updateSubscription(req.params.id, req.body);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteSubscription(req, res, next) {
+  try {
+    const row = await service.deleteSubscription(req.params.id);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getActiveSubscription(req, res, next) {
+  try {
+    const row = await service.findActiveSubscriptionByClient(req.params.client_id);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/model/premiumSubscriptionModel.js
+++ b/src/model/premiumSubscriptionModel.js
@@ -1,0 +1,73 @@
+import { query } from '../repository/db.js';
+
+export async function createSubscription(data) {
+  const res = await query(
+    `INSERT INTO premium_subscription (
+        client_id, start_date, end_date, is_active, created_at
+     ) VALUES ($1,$2,$3,$4,COALESCE($5, NOW()))
+     RETURNING *`,
+    [
+      data.client_id,
+      data.start_date,
+      data.end_date || null,
+      data.is_active ?? true,
+      data.created_at || null,
+    ],
+  );
+  return res.rows[0];
+}
+
+export async function getSubscriptions() {
+  const res = await query(
+    'SELECT * FROM premium_subscription ORDER BY created_at DESC',
+  );
+  return res.rows;
+}
+
+export async function findSubscriptionById(id) {
+  const res = await query(
+    'SELECT * FROM premium_subscription WHERE subscription_id=$1',
+    [id],
+  );
+  return res.rows[0] || null;
+}
+
+export async function findActiveSubscriptionByClient(client_id) {
+  const res = await query(
+    `SELECT * FROM premium_subscription
+     WHERE client_id=$1 AND is_active = true
+     ORDER BY start_date DESC LIMIT 1`,
+    [client_id],
+  );
+  return res.rows[0] || null;
+}
+
+export async function updateSubscription(id, data) {
+  const old = await findSubscriptionById(id);
+  if (!old) return null;
+  const merged = { ...old, ...data };
+  const res = await query(
+    `UPDATE premium_subscription SET
+       client_id=$2,
+       start_date=$3,
+       end_date=$4,
+       is_active=$5
+     WHERE subscription_id=$1 RETURNING *`,
+    [
+      id,
+      merged.client_id,
+      merged.start_date,
+      merged.end_date || null,
+      merged.is_active,
+    ],
+  );
+  return res.rows[0];
+}
+
+export async function deleteSubscription(id) {
+  const res = await query(
+    'DELETE FROM premium_subscription WHERE subscription_id=$1 RETURNING *',
+    [id],
+  );
+  return res.rows[0] || null;
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ import tiktokRoutes from "./tiktokRoutes.js";
 import metaRoutes from './metaRoutes.js';
 import logRoutes from './logRoutes.js';
 import linkReportRoutes from './linkReportRoutes.js';
+import premiumSubscriptionRoutes from './premiumSubscriptionRoutes.js';
 
 const router = express.Router();
 
@@ -22,6 +23,7 @@ router.use('/oauth', oauthRoutes);
 router.use('/metadata', metaRoutes);
 router.use('/logs', logRoutes);
 router.use('/link-reports', linkReportRoutes);
+router.use('/premium-subscriptions', premiumSubscriptionRoutes);
 
 
 export default router;

--- a/src/routes/premiumSubscriptionRoutes.js
+++ b/src/routes/premiumSubscriptionRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import * as controller from '../controller/premiumSubscriptionController.js';
+
+const router = express.Router();
+
+router.get('/', controller.getAllSubscriptions);
+router.get('/client/:client_id/active', controller.getActiveSubscription);
+router.get('/:id', controller.getSubscriptionById);
+router.post('/', controller.createSubscription);
+router.put('/:id', controller.updateSubscription);
+router.delete('/:id', controller.deleteSubscription);
+
+export default router;

--- a/src/service/premiumSubscriptionService.js
+++ b/src/service/premiumSubscriptionService.js
@@ -1,0 +1,15 @@
+import * as model from '../model/premiumSubscriptionModel.js';
+
+export const createSubscription = async data => model.createSubscription(data);
+
+export const getSubscriptions = async () => model.getSubscriptions();
+
+export const findSubscriptionById = async id => model.findSubscriptionById(id);
+
+export const findActiveSubscriptionByClient = async clientId =>
+  model.findActiveSubscriptionByClient(clientId);
+
+export const updateSubscription = async (id, data) =>
+  model.updateSubscription(id, data);
+
+export const deleteSubscription = async id => model.deleteSubscription(id);

--- a/tests/premiumSubscriptionModel.test.js
+++ b/tests/premiumSubscriptionModel.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery,
+}));
+
+let createSubscription;
+let getSubscriptions;
+let findActiveSubscriptionByClient;
+
+beforeAll(async () => {
+  const mod = await import('../src/model/premiumSubscriptionModel.js');
+  createSubscription = mod.createSubscription;
+  getSubscriptions = mod.getSubscriptions;
+  findActiveSubscriptionByClient = mod.findActiveSubscriptionByClient;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('createSubscription inserts row', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
+  const data = { client_id: 'abc', start_date: '2024-01-01' };
+  const res = await createSubscription(data);
+  expect(res).toEqual({ subscription_id: 1 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO premium_subscription'),
+    ['abc', '2024-01-01', null, true, null]
+  );
+});
+
+test('getSubscriptions selects all', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
+  const rows = await getSubscriptions();
+  expect(rows).toEqual([{ subscription_id: 1 }]);
+  expect(mockQuery).toHaveBeenCalledWith(
+    'SELECT * FROM premium_subscription ORDER BY created_at DESC'
+  );
+});
+
+test('findActiveSubscriptionByClient selects active record', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
+  const row = await findActiveSubscriptionByClient('abc');
+  expect(row).toEqual({ subscription_id: 1 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('WHERE client_id=$1 AND is_active = true'),
+    ['abc']
+  );
+});


### PR DESCRIPTION
## Summary
- support managing premium subscriptions
- create premium_subscription table in SQL schema
- document the new API
- add model, service, controller, route and tests

## Testing
- `npm run lint` *(fails: Parsing error: Cannot use keyword 'await' outside an async function)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eda596d9883279103dd4445e59429