### PR TITLE
Change premium_subscription to use instagram user id

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -163,8 +163,7 @@ Location information if available.
 ### `premium_subscription`
 Tracks premium subscriptions for the Android app.
 - `subscription_id` – primary key
-- `user_id` – foreign key to `user`
-- `client_id` – foreign key to `clients`
+- `user_id` – foreign key to `instagram_user`
 - `status` – `pending`, `active`, `expired` or `cancelled`
 - `start_date`, `end_date` – subscription validity
 - `order_id`, `snap_token` – Midtrans identifiers

--- a/docs/premium_subscription.md
+++ b/docs/premium_subscription.md
@@ -11,8 +11,7 @@ Create a new table called `premium_subscription`:
 ```sql
 CREATE TABLE premium_subscription (
   subscription_id SERIAL PRIMARY KEY,
-  user_id VARCHAR REFERENCES "user"(user_id),
-  client_id VARCHAR REFERENCES clients(client_id),
+  user_id VARCHAR REFERENCES instagram_user(user_id),
   status VARCHAR NOT NULL,
   start_date DATE,
   end_date DATE,
@@ -31,7 +30,7 @@ CREATE TABLE premium_subscription (
 
 1. **Initiate Checkout**
    - `POST /api/subscription/checkout`
-   - Body: `{ user_id, client_id, plan }`
+   - Body: `{ user_id, plan }`
    - Server calls Midtrans Snap API and returns a `snap_token` and `order_id`.
 2. **Midtrans Callback**
    - `POST /api/subscription/webhook`

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -231,7 +231,7 @@ CREATE TABLE IF NOT EXISTS link_report (
 
 CREATE TABLE IF NOT EXISTS premium_subscription (
     subscription_id SERIAL PRIMARY KEY,
-    client_id VARCHAR REFERENCES clients(client_id),
+    user_id VARCHAR REFERENCES instagram_user(user_id),
     start_date DATE NOT NULL,
     end_date DATE,
     is_active BOOLEAN DEFAULT TRUE,

--- a/src/controller/premiumSubscriptionController.js
+++ b/src/controller/premiumSubscriptionController.js
@@ -48,7 +48,7 @@ export async function deleteSubscription(req, res, next) {
 
 export async function getActiveSubscription(req, res, next) {
   try {
-    const row = await service.findActiveSubscriptionByClient(req.params.client_id);
+    const row = await service.findActiveSubscriptionByUser(req.params.user_id);
     sendSuccess(res, row);
   } catch (err) {
     next(err);

--- a/src/model/premiumSubscriptionModel.js
+++ b/src/model/premiumSubscriptionModel.js
@@ -3,11 +3,11 @@ import { query } from '../repository/db.js';
 export async function createSubscription(data) {
   const res = await query(
     `INSERT INTO premium_subscription (
-        client_id, start_date, end_date, is_active, created_at
+        user_id, start_date, end_date, is_active, created_at
      ) VALUES ($1,$2,$3,$4,COALESCE($5, NOW()))
      RETURNING *`,
     [
-      data.client_id,
+      data.user_id,
       data.start_date,
       data.end_date || null,
       data.is_active ?? true,
@@ -32,12 +32,12 @@ export async function findSubscriptionById(id) {
   return res.rows[0] || null;
 }
 
-export async function findActiveSubscriptionByClient(client_id) {
+export async function findActiveSubscriptionByUser(user_id) {
   const res = await query(
     `SELECT * FROM premium_subscription
-     WHERE client_id=$1 AND is_active = true
+     WHERE user_id=$1 AND is_active = true
      ORDER BY start_date DESC LIMIT 1`,
-    [client_id],
+    [user_id],
   );
   return res.rows[0] || null;
 }
@@ -48,14 +48,14 @@ export async function updateSubscription(id, data) {
   const merged = { ...old, ...data };
   const res = await query(
     `UPDATE premium_subscription SET
-       client_id=$2,
-       start_date=$3,
-       end_date=$4,
-       is_active=$5
+      user_id=$2,
+      start_date=$3,
+      end_date=$4,
+      is_active=$5
      WHERE subscription_id=$1 RETURNING *`,
     [
       id,
-      merged.client_id,
+      merged.user_id,
       merged.start_date,
       merged.end_date || null,
       merged.is_active,

--- a/src/routes/premiumSubscriptionRoutes.js
+++ b/src/routes/premiumSubscriptionRoutes.js
@@ -4,7 +4,7 @@ import * as controller from '../controller/premiumSubscriptionController.js';
 const router = express.Router();
 
 router.get('/', controller.getAllSubscriptions);
-router.get('/client/:client_id/active', controller.getActiveSubscription);
+router.get('/user/:user_id/active', controller.getActiveSubscription);
 router.get('/:id', controller.getSubscriptionById);
 router.post('/', controller.createSubscription);
 router.put('/:id', controller.updateSubscription);

--- a/src/service/premiumSubscriptionService.js
+++ b/src/service/premiumSubscriptionService.js
@@ -6,8 +6,8 @@ export const getSubscriptions = async () => model.getSubscriptions();
 
 export const findSubscriptionById = async id => model.findSubscriptionById(id);
 
-export const findActiveSubscriptionByClient = async clientId =>
-  model.findActiveSubscriptionByClient(clientId);
+export const findActiveSubscriptionByUser = async userId =>
+  model.findActiveSubscriptionByUser(userId);
 
 export const updateSubscription = async (id, data) =>
   model.updateSubscription(id, data);

--- a/tests/premiumSubscriptionModel.test.js
+++ b/tests/premiumSubscriptionModel.test.js
@@ -8,13 +8,13 @@ jest.unstable_mockModule('../src/repository/db.js', () => ({
 
 let createSubscription;
 let getSubscriptions;
-let findActiveSubscriptionByClient;
+let findActiveSubscriptionByUser;
 
 beforeAll(async () => {
   const mod = await import('../src/model/premiumSubscriptionModel.js');
   createSubscription = mod.createSubscription;
   getSubscriptions = mod.getSubscriptions;
-  findActiveSubscriptionByClient = mod.findActiveSubscriptionByClient;
+  findActiveSubscriptionByUser = mod.findActiveSubscriptionByUser;
 });
 
 beforeEach(() => {
@@ -23,7 +23,7 @@ beforeEach(() => {
 
 test('createSubscription inserts row', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
-  const data = { client_id: 'abc', start_date: '2024-01-01' };
+  const data = { user_id: 'abc', start_date: '2024-01-01' };
   const res = await createSubscription(data);
   expect(res).toEqual({ subscription_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(
@@ -41,12 +41,12 @@ test('getSubscriptions selects all', async () => {
   );
 });
 
-test('findActiveSubscriptionByClient selects active record', async () => {
+test('findActiveSubscriptionByUser selects active record', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
-  const row = await findActiveSubscriptionByClient('abc');
+  const row = await findActiveSubscriptionByUser('abc');
   expect(row).toEqual({ subscription_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(
-    expect.stringContaining('WHERE client_id=$1 AND is_active = true'),
+    expect.stringContaining('WHERE user_id=$1 AND is_active = true'),
     ['abc']
   );
 });


### PR DESCRIPTION
## Summary
- adjust schema to reference `instagram_user`
- rename queries and routes for premium subscription
- update docs
- update unit tests

## Testing
- `npm run lint` *(fails: cannot use keyword await outside async function and many unused-vars)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f3e9726dc8327944e726425222a5e