### PR TITLE
Add subscription registration module

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -40,6 +40,7 @@ for PostgreSQL but can work with MySQL or SQLite via the DB adapter.
 | visitor_logs | record of API access |
 | link_report | links submitted from the mobile app |
 | premium_subscription | tracks premium status per user |
+| subscription_registration | user-initiated subscription signups |
 
 ## Tables
 
@@ -168,6 +169,15 @@ Tracks premium subscriptions for the Android app.
 - `start_date`, `end_date` – subscription validity
 - `order_id`, `snap_token` – Midtrans identifiers
 - `created_at`, `updated_at`
+
+### `subscription_registration`
+Records raw signup data before payment is processed.
+- `registration_id` – primary key
+- `user_id` – foreign key to `instagram_user`
+- `nama_rekening`, `nomor_rekening` – bank account details
+- `phone` – contact phone number
+- `amount` – requested payment amount
+- `created_at` – timestamp when the user submitted the form
 
 ## Relationships
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -237,3 +237,13 @@ CREATE TABLE IF NOT EXISTS premium_subscription (
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS subscription_registration (
+    registration_id SERIAL PRIMARY KEY,
+    user_id VARCHAR REFERENCES instagram_user(user_id),
+    nama_rekening VARCHAR,
+    nomor_rekening VARCHAR,
+    phone VARCHAR,
+    amount INT,
+    created_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/controller/subscriptionRegistrationController.js
+++ b/src/controller/subscriptionRegistrationController.js
@@ -1,0 +1,47 @@
+import * as service from '../service/subscriptionRegistrationService.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function getAllRegistrations(req, res, next) {
+  try {
+    const rows = await service.getRegistrations();
+    sendSuccess(res, rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getRegistrationById(req, res, next) {
+  try {
+    const row = await service.findRegistrationById(req.params.id);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createRegistration(req, res, next) {
+  try {
+    const row = await service.createRegistration(req.body);
+    sendSuccess(res, row, 201);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateRegistration(req, res, next) {
+  try {
+    const row = await service.updateRegistration(req.params.id, req.body);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteRegistration(req, res, next) {
+  try {
+    const row = await service.deleteRegistration(req.params.id);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/model/subscriptionRegistrationModel.js
+++ b/src/model/subscriptionRegistrationModel.js
@@ -1,0 +1,66 @@
+import { query } from '../repository/db.js';
+
+export async function createRegistration(data) {
+  const res = await query(
+    `INSERT INTO subscription_registration (
+        user_id, nama_rekening, nomor_rekening, phone, amount, created_at
+     ) VALUES ($1,$2,$3,$4,$5,COALESCE($6, NOW()))
+     RETURNING *`,
+    [
+      data.user_id,
+      data.nama_rekening || null,
+      data.nomor_rekening || null,
+      data.phone || null,
+      data.amount || null,
+      data.created_at || null,
+    ],
+  );
+  return res.rows[0];
+}
+
+export async function getRegistrations() {
+  const res = await query(
+    'SELECT * FROM subscription_registration ORDER BY created_at DESC',
+  );
+  return res.rows;
+}
+
+export async function findRegistrationById(id) {
+  const res = await query(
+    'SELECT * FROM subscription_registration WHERE registration_id=$1',
+    [id],
+  );
+  return res.rows[0] || null;
+}
+
+export async function updateRegistration(id, data) {
+  const old = await findRegistrationById(id);
+  if (!old) return null;
+  const merged = { ...old, ...data };
+  const res = await query(
+    `UPDATE subscription_registration SET
+      user_id=$2,
+      nama_rekening=$3,
+      nomor_rekening=$4,
+      phone=$5,
+      amount=$6
+     WHERE registration_id=$1 RETURNING *`,
+    [
+      id,
+      merged.user_id,
+      merged.nama_rekening || null,
+      merged.nomor_rekening || null,
+      merged.phone || null,
+      merged.amount || null,
+    ],
+  );
+  return res.rows[0];
+}
+
+export async function deleteRegistration(id) {
+  const res = await query(
+    'DELETE FROM subscription_registration WHERE registration_id=$1 RETURNING *',
+    [id],
+  );
+  return res.rows[0] || null;
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,6 +10,7 @@ import metaRoutes from './metaRoutes.js';
 import logRoutes from './logRoutes.js';
 import linkReportRoutes from './linkReportRoutes.js';
 import premiumSubscriptionRoutes from './premiumSubscriptionRoutes.js';
+import subscriptionRegistrationRoutes from './subscriptionRegistrationRoutes.js';
 
 const router = express.Router();
 
@@ -24,6 +25,7 @@ router.use('/metadata', metaRoutes);
 router.use('/logs', logRoutes);
 router.use('/link-reports', linkReportRoutes);
 router.use('/premium-subscriptions', premiumSubscriptionRoutes);
+router.use('/subscription-registrations', subscriptionRegistrationRoutes);
 
 
 export default router;

--- a/src/routes/subscriptionRegistrationRoutes.js
+++ b/src/routes/subscriptionRegistrationRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import * as controller from '../controller/subscriptionRegistrationController.js';
+
+const router = express.Router();
+
+router.get('/', controller.getAllRegistrations);
+router.get('/:id', controller.getRegistrationById);
+router.post('/', controller.createRegistration);
+router.put('/:id', controller.updateRegistration);
+router.delete('/:id', controller.deleteRegistration);
+
+export default router;

--- a/src/service/subscriptionRegistrationService.js
+++ b/src/service/subscriptionRegistrationService.js
@@ -1,0 +1,12 @@
+import * as model from '../model/subscriptionRegistrationModel.js';
+
+export const createRegistration = async data => model.createRegistration(data);
+
+export const getRegistrations = async () => model.getRegistrations();
+
+export const findRegistrationById = async id => model.findRegistrationById(id);
+
+export const updateRegistration = async (id, data) =>
+  model.updateRegistration(id, data);
+
+export const deleteRegistration = async id => model.deleteRegistration(id);

--- a/tests/subscriptionRegistrationModel.test.js
+++ b/tests/subscriptionRegistrationModel.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery,
+}));
+
+let createRegistration;
+let getRegistrations;
+
+beforeAll(async () => {
+  const mod = await import('../src/model/subscriptionRegistrationModel.js');
+  createRegistration = mod.createRegistration;
+  getRegistrations = mod.getRegistrations;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('createRegistration inserts row', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ registration_id: 1 }] });
+  const data = { user_id: 'u1', nama_rekening: 'A', nomor_rekening: 'B', amount: 10 };
+  const res = await createRegistration(data);
+  expect(res).toEqual({ registration_id: 1 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO subscription_registration'),
+    ['u1', 'A', 'B', null, 10, null]
+  );
+});
+
+test('getRegistrations selects all', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ registration_id: 1 }] });
+  const rows = await getRegistrations();
+  expect(rows).toEqual([{ registration_id: 1 }]);
+  expect(mockQuery).toHaveBeenCalledWith(
+    'SELECT * FROM subscription_registration ORDER BY created_at DESC'
+  );
+});


### PR DESCRIPTION
## Summary
- create subscription_registration table
- document table in database_structure
- add model/controller/service/routes for subscription registration
- register route
- add unit tests for model

## Testing
- `npm run lint` *(fails: Cannot use keyword 'await' outside an async function)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f4aac4070832798ea0dec98eca66f