### PR TITLE
Change subscription registration to use username

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -173,7 +173,7 @@ Tracks premium subscriptions for the Android app.
 ### `subscription_registration`
 Records raw signup data before payment is processed.
 - `registration_id` – primary key
-- `user_id` – foreign key to `instagram_user`
+- `username` – foreign key to `instagram_user`
 - `nama_rekening`, `nomor_rekening` – bank account details
 - `phone` – contact phone number
 - `amount` – requested payment amount

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -79,7 +79,7 @@ CREATE TABLE tiktok_comment (
 -- Tabel utama dengan informasi profil dasar
 CREATE TABLE instagram_user (
     user_id                 VARCHAR(30) PRIMARY KEY,
-    username                VARCHAR(100) NOT NULL,
+    username                VARCHAR(100) UNIQUE NOT NULL,
     full_name               VARCHAR(100),
     biography               TEXT,
     business_contact_method VARCHAR(50),
@@ -240,7 +240,7 @@ CREATE TABLE IF NOT EXISTS premium_subscription (
 
 CREATE TABLE IF NOT EXISTS subscription_registration (
     registration_id SERIAL PRIMARY KEY,
-    user_id VARCHAR REFERENCES instagram_user(user_id),
+    username VARCHAR REFERENCES instagram_user(username),
     nama_rekening VARCHAR,
     nomor_rekening VARCHAR,
     phone VARCHAR,

--- a/src/handler/menu/subscriptionRequestHandlers.js
+++ b/src/handler/menu/subscriptionRequestHandlers.js
@@ -8,11 +8,11 @@ export const subscriptionRequestHandlers = {
       session.step = null;
       return waClient.sendMessage(chatId, '❎ Permintaan dibatalkan.');
     }
-    const nrp = text.trim().replace(/[^0-9a-zA-Z]/g, '');
-    if (!nrp) {
-      return waClient.sendMessage(chatId, 'Masukkan *NRP/NIP* yang valid:');
+    const username = text.trim().replace(/[^0-9a-zA-Z_.]/g, '');
+    if (!username) {
+      return waClient.sendMessage(chatId, 'Masukkan *Username Instagram* yang valid:');
     }
-    session.user_id = nrp;
+    session.username = username;
     session.step = 'namaRekening';
     await waClient.sendMessage(chatId, 'Masukkan *Nama Rekening*:');
   },
@@ -55,7 +55,7 @@ export const subscriptionRequestHandlers = {
     session.amount = amount;
     session.step = 'confirm';
     let msg = '*Konfirmasi Pendaftaran Premium*\n';
-    msg += `NRP/NIP : *${session.user_id}*\n`;
+    msg += `Username Instagram : *${session.username}*\n`;
     msg += `Nama Rekening : *${session.nama_rekening}*\n`;
     msg += `Nomor Rekening : *${session.nomor_rekening}*\n`;
     msg += `Telepon : *${session.phone}*\n`;
@@ -73,7 +73,7 @@ export const subscriptionRequestHandlers = {
       return waClient.sendMessage(chatId, 'Balas *ya* untuk konfirmasi atau *batal* untuk membatalkan.');
     }
     const reg = await registrationService.createRegistration({
-      user_id: session.user_id,
+      username: session.username,
       nama_rekening: session.nama_rekening,
       nomor_rekening: session.nomor_rekening,
       phone: session.phone,
@@ -83,7 +83,7 @@ export const subscriptionRequestHandlers = {
     const adminIds = getAdminWAIds();
     let notif = '*Permintaan Subscription Premium*\n';
     notif += `ID Permintaan: *${reg.registration_id}*\n`;
-    notif += `NRP/NIP : *${reg.user_id}*\n`;
+    notif += `Username Instagram : *${reg.username}*\n`;
     notif += `Nominal : *${reg.amount}*\n`;
     notif += `Balas *GRANTSUB#${reg.registration_id}* untuk memberi akses atau *DENYSUB#${reg.registration_id}* untuk menolak.`;
     for (const adminId of adminIds) {

--- a/src/model/subscriptionRegistrationModel.js
+++ b/src/model/subscriptionRegistrationModel.js
@@ -3,12 +3,12 @@ import { query } from '../repository/db.js';
 export async function createRegistration(data) {
   const res = await query(
     `INSERT INTO subscription_registration (
-        user_id, nama_rekening, nomor_rekening, phone, amount,
+        username, nama_rekening, nomor_rekening, phone, amount,
         status, reviewed_at, created_at
      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8, NOW()))
      RETURNING *`,
     [
-      data.user_id,
+      data.username,
       data.nama_rekening || null,
       data.nomor_rekening || null,
       data.phone || null,
@@ -42,7 +42,7 @@ export async function updateRegistration(id, data) {
   const merged = { ...old, ...data };
   const res = await query(
     `UPDATE subscription_registration SET
-      user_id=$2,
+      username=$2,
       nama_rekening=$3,
       nomor_rekening=$4,
       phone=$5,
@@ -52,7 +52,7 @@ export async function updateRegistration(id, data) {
      WHERE registration_id=$1 RETURNING *`,
     [
       id,
-      merged.user_id,
+      merged.username,
       merged.nama_rekening || null,
       merged.nomor_rekening || null,
       merged.phone || null,

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -426,7 +426,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
     setSession(chatId, { menu: "premiumreq", step: "main" });
     await waClient.sendMessage(
       chatId,
-      "📝 *Pendaftaran Premium*\nMasukkan NRP/NIP Anda:"
+      "📝 *Pendaftaran Premium*\nMasukkan Username Instagram Anda:"
     );
     return;
   }

--- a/tests/subscriptionRegistrationModel.test.js
+++ b/tests/subscriptionRegistrationModel.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
 
 test('createRegistration inserts row', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ registration_id: 1 }] });
-  const data = { user_id: 'u1', nama_rekening: 'A', nomor_rekening: 'B', amount: 10 };
+  const data = { username: 'u1', nama_rekening: 'A', nomor_rekening: 'B', amount: 10 };
   const res = await createRegistration(data);
   expect(res).toEqual({ registration_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- adjust subscription registration to use `username`
- update whatsapp flow to ask for Instagram username
- update docs and SQL schema

## Testing
- `npm run lint` *(fails: cannot use keyword 'await' outside async)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f90b3a1e0832792f6a5bd62c63cf7