### PR TITLE
Update premium_subscription to reference username

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -163,8 +163,8 @@ Location information if available.
 
 ### `premium_subscription`
 Tracks premium subscriptions for the Android app.
-- `subscription_id` – primary key
-- `user_id` – foreign key to `instagram_user`
+ - `subscription_id` – primary key
+ - `username` – foreign key to `instagram_user`
 - `status` – `pending`, `active`, `expired` or `cancelled`
 - `start_date`, `end_date` – subscription validity
 - `order_id`, `snap_token` – Midtrans identifiers

--- a/docs/premium_subscription.md
+++ b/docs/premium_subscription.md
@@ -11,7 +11,7 @@ Create a new table called `premium_subscription`:
 ```sql
 CREATE TABLE premium_subscription (
   subscription_id SERIAL PRIMARY KEY,
-  user_id VARCHAR REFERENCES instagram_user(user_id),
+  username VARCHAR REFERENCES instagram_user(username),
   status VARCHAR NOT NULL,
   start_date DATE,
   end_date DATE,
@@ -30,7 +30,7 @@ CREATE TABLE premium_subscription (
 
 1. **Initiate Checkout**
    - `POST /api/subscription/checkout`
-   - Body: `{ user_id, plan }`
+   - Body: `{ username, plan }`
    - Server calls Midtrans Snap API and returns a `snap_token` and `order_id`.
 2. **Midtrans Callback**
    - `POST /api/subscription/webhook`

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -231,7 +231,7 @@ CREATE TABLE IF NOT EXISTS link_report (
 
 CREATE TABLE IF NOT EXISTS premium_subscription (
     subscription_id SERIAL PRIMARY KEY,
-    user_id VARCHAR REFERENCES instagram_user(user_id),
+    username VARCHAR REFERENCES instagram_user(username),
     start_date DATE NOT NULL,
     end_date DATE,
     is_active BOOLEAN DEFAULT TRUE,

--- a/src/controller/premiumSubscriptionController.js
+++ b/src/controller/premiumSubscriptionController.js
@@ -48,7 +48,7 @@ export async function deleteSubscription(req, res, next) {
 
 export async function getActiveSubscription(req, res, next) {
   try {
-    const row = await service.findActiveSubscriptionByUser(req.params.user_id);
+    const row = await service.findActiveSubscriptionByUser(req.params.username);
     sendSuccess(res, row);
   } catch (err) {
     next(err);

--- a/src/model/premiumSubscriptionModel.js
+++ b/src/model/premiumSubscriptionModel.js
@@ -3,11 +3,11 @@ import { query } from '../repository/db.js';
 export async function createSubscription(data) {
   const res = await query(
     `INSERT INTO premium_subscription (
-        user_id, start_date, end_date, is_active, created_at
+        username, start_date, end_date, is_active, created_at
      ) VALUES ($1,$2,$3,$4,COALESCE($5, NOW()))
      RETURNING *`,
     [
-      data.user_id,
+      data.username,
       data.start_date,
       data.end_date || null,
       data.is_active ?? true,
@@ -32,12 +32,12 @@ export async function findSubscriptionById(id) {
   return res.rows[0] || null;
 }
 
-export async function findActiveSubscriptionByUser(user_id) {
+export async function findActiveSubscriptionByUser(username) {
   const res = await query(
     `SELECT * FROM premium_subscription
-     WHERE user_id=$1 AND is_active = true
+     WHERE username=$1 AND is_active = true
      ORDER BY start_date DESC LIMIT 1`,
-    [user_id],
+    [username],
   );
   return res.rows[0] || null;
 }
@@ -48,14 +48,14 @@ export async function updateSubscription(id, data) {
   const merged = { ...old, ...data };
   const res = await query(
     `UPDATE premium_subscription SET
-      user_id=$2,
+      username=$2,
       start_date=$3,
       end_date=$4,
       is_active=$5
      WHERE subscription_id=$1 RETURNING *`,
     [
       id,
-      merged.user_id,
+      merged.username,
       merged.start_date,
       merged.end_date || null,
       merged.is_active,

--- a/src/routes/premiumSubscriptionRoutes.js
+++ b/src/routes/premiumSubscriptionRoutes.js
@@ -4,7 +4,7 @@ import * as controller from '../controller/premiumSubscriptionController.js';
 const router = express.Router();
 
 router.get('/', controller.getAllSubscriptions);
-router.get('/user/:user_id/active', controller.getActiveSubscription);
+router.get('/user/:username/active', controller.getActiveSubscription);
 router.get('/:id', controller.getSubscriptionById);
 router.post('/', controller.createSubscription);
 router.put('/:id', controller.updateSubscription);

--- a/src/service/premiumSubscriptionService.js
+++ b/src/service/premiumSubscriptionService.js
@@ -6,8 +6,8 @@ export const getSubscriptions = async () => model.getSubscriptions();
 
 export const findSubscriptionById = async id => model.findSubscriptionById(id);
 
-export const findActiveSubscriptionByUser = async userId =>
-  model.findActiveSubscriptionByUser(userId);
+export const findActiveSubscriptionByUser = async username =>
+  model.findActiveSubscriptionByUser(username);
 
 export const updateSubscription = async (id, data) =>
   model.updateSubscription(id, data);

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1604,18 +1604,18 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       reviewed_at: new Date(),
     });
     await premiumService.createSubscription({
-      user_id: reg.user_id,
+      username: reg.username,
       start_date: new Date(),
       is_active: true,
     });
-    const user = await userModel.findUserById(reg.user_id);
+    const user = await userModel.findUserById(reg.username);
     if (user?.whatsapp) {
       await waClient.sendMessage(
         formatToWhatsAppId(user.whatsapp),
         '🎉 Permintaan premium Anda telah disetujui.'
       );
     }
-    await waClient.sendMessage(chatId, `✅ Akses premium diberikan untuk ${reg.user_id}.`);
+    await waClient.sendMessage(chatId, `✅ Akses premium diberikan untuk ${reg.username}.`);
     return;
   }
 
@@ -1634,14 +1634,14 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       status: 'rejected',
       reviewed_at: new Date(),
     });
-    const user = await userModel.findUserById(reg.user_id);
+    const user = await userModel.findUserById(reg.username);
     if (user?.whatsapp) {
       await waClient.sendMessage(
         formatToWhatsAppId(user.whatsapp),
         'Mohon maaf, permintaan premium Anda ditolak.'
       );
     }
-    await waClient.sendMessage(chatId, `❌ Permintaan ${reg.user_id} ditolak.`);
+    await waClient.sendMessage(chatId, `❌ Permintaan ${reg.username} ditolak.`);
     return;
   }
 

--- a/tests/premiumSubscriptionModel.test.js
+++ b/tests/premiumSubscriptionModel.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
 
 test('createSubscription inserts row', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
-  const data = { user_id: 'abc', start_date: '2024-01-01' };
+  const data = { username: 'abc', start_date: '2024-01-01' };
   const res = await createSubscription(data);
   expect(res).toEqual({ subscription_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(
@@ -46,7 +46,7 @@ test('findActiveSubscriptionByUser selects active record', async () => {
   const row = await findActiveSubscriptionByUser('abc');
   expect(row).toEqual({ subscription_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(
-    expect.stringContaining('WHERE user_id=$1 AND is_active = true'),
+    expect.stringContaining('WHERE username=$1 AND is_active = true'),
     ['abc']
   );
 });


### PR DESCRIPTION
## Summary
- change `premium_subscription.user_id` to `username` referencing `instagram_user`
- update models, controllers, routes and WA service for new column
- adjust docs and tests for username-based subscriptions

## Testing
- `npm run lint` *(fails: Parsing error: Cannot use keyword 'await' outside an async function)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f94ec71108327b9f5696937911045