### PR TITLE
Handle premium subscription lifecycle

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ import './src/cron/cronInstaLaphar.js';
 import './src/cron/cronTiktokLaphar.js';
 import './src/cron/cronNotifikasiLikesDanKomentar.js';
 import './src/cron/cronInstaDataMining.js';
+import './src/cron/cronPremiumSubscription.js';
 
 const app = express();
 

--- a/src/controller/subscriptionRegistrationController.js
+++ b/src/controller/subscriptionRegistrationController.js
@@ -23,6 +23,12 @@ export async function getRegistrationById(req, res, next) {
 
 export async function createRegistration(req, res, next) {
   try {
+    const existing = await service.findPendingByUsername(req.body.username);
+    if (existing)
+      return res
+        .status(400)
+        .json({ error: 'Masih ada pendaftaran menunggu review' });
+
     const row = await service.createRegistration(req.body);
     sendSuccess(res, row, 201);
 

--- a/src/cron/cronPremiumSubscription.js
+++ b/src/cron/cronPremiumSubscription.js
@@ -1,0 +1,49 @@
+import cron from 'node-cron';
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { query } from '../db/index.js';
+import waClient from '../service/waService.js';
+import { getAdminWAIds } from '../utils/waHelper.js';
+
+cron.schedule(
+  '0 0 * * *',
+  async () => {
+    await query(
+      `UPDATE premium_subscription
+       SET is_active=false, end_date=NOW()
+       WHERE is_active=true AND start_date <= NOW() - INTERVAL '30 days'`,
+    );
+  },
+  { timezone: 'Asia/Jakarta' },
+);
+
+cron.schedule(
+  '*/5 * * * *',
+  async () => {
+    await query(
+      `UPDATE subscription_registration
+       SET status='expired', reviewed_at=NOW()
+       WHERE status='pending' AND created_at <= NOW() - INTERVAL '24 hours'`,
+    );
+    const pending = await query(
+      `SELECT registration_id, username, amount
+       FROM subscription_registration
+       WHERE status='pending'
+       ORDER BY created_at`,
+    );
+    if (pending.rows.length === 0) return;
+    let msg = '*Reminder Pendaftaran Premium*\n';
+    for (const r of pending.rows) {
+      msg += `ID *${r.registration_id}* - ${r.username}`;
+      if (r.amount) msg += ` (Rp${r.amount})`;
+      msg += '\n';
+    }
+    msg +=
+      'Balas GRANTSUB#ID untuk memberi akses atau DENYSUB#ID untuk menolak.';
+    for (const admin of getAdminWAIds()) {
+      waClient.sendMessage(admin, msg).catch(() => {});
+    }
+  },
+  { timezone: 'Asia/Jakarta' },
+);

--- a/src/model/premiumSubscriptionModel.js
+++ b/src/model/premiumSubscriptionModel.js
@@ -42,6 +42,16 @@ export async function findActiveSubscriptionByUser(username) {
   return res.rows[0] || null;
 }
 
+export async function findLatestSubscriptionByUser(username) {
+  const res = await query(
+    `SELECT * FROM premium_subscription
+     WHERE username=$1
+     ORDER BY start_date DESC LIMIT 1`,
+    [username],
+  );
+  return res.rows[0] || null;
+}
+
 export async function updateSubscription(id, data) {
   const old = await findSubscriptionById(id);
   if (!old) return null;

--- a/src/model/subscriptionRegistrationModel.js
+++ b/src/model/subscriptionRegistrationModel.js
@@ -36,6 +36,16 @@ export async function findRegistrationById(id) {
   return res.rows[0] || null;
 }
 
+export async function findPendingByUsername(username) {
+  const res = await query(
+    `SELECT * FROM subscription_registration
+     WHERE username=$1 AND status='pending'
+     ORDER BY created_at DESC LIMIT 1`,
+    [username],
+  );
+  return res.rows[0] || null;
+}
+
 export async function updateRegistration(id, data) {
   const old = await findRegistrationById(id);
   if (!old) return null;

--- a/src/service/premiumSubscriptionService.js
+++ b/src/service/premiumSubscriptionService.js
@@ -9,6 +9,9 @@ export const findSubscriptionById = async id => model.findSubscriptionById(id);
 export const findActiveSubscriptionByUser = async username =>
   model.findActiveSubscriptionByUser(username);
 
+export const findLatestSubscriptionByUser = async username =>
+  model.findLatestSubscriptionByUser(username);
+
 export const updateSubscription = async (id, data) =>
   model.updateSubscription(id, data);
 

--- a/src/service/subscriptionRegistrationService.js
+++ b/src/service/subscriptionRegistrationService.js
@@ -6,6 +6,9 @@ export const getRegistrations = async () => model.getRegistrations();
 
 export const findRegistrationById = async id => model.findRegistrationById(id);
 
+export const findPendingByUsername = async username =>
+  model.findPendingByUsername(username);
+
 export const updateRegistration = async (id, data) =>
   model.updateRegistration(id, data);
 

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1603,11 +1603,22 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       status: 'approved',
       reviewed_at: new Date(),
     });
-    await premiumService.createSubscription({
-      username: reg.username,
-      start_date: new Date(),
-      is_active: true,
-    });
+    const existing = await premiumService.findLatestSubscriptionByUser(
+      reg.username,
+    );
+    if (existing) {
+      await premiumService.updateSubscription(existing.subscription_id, {
+        start_date: new Date(),
+        end_date: null,
+        is_active: true,
+      });
+    } else {
+      await premiumService.createSubscription({
+        username: reg.username,
+        start_date: new Date(),
+        is_active: true,
+      });
+    }
     const user = await userModel.findUserById(reg.username);
     if (user?.whatsapp) {
       await waClient.sendMessage(

--- a/tests/premiumSubscriptionModel.test.js
+++ b/tests/premiumSubscriptionModel.test.js
@@ -9,12 +9,14 @@ jest.unstable_mockModule('../src/repository/db.js', () => ({
 let createSubscription;
 let getSubscriptions;
 let findActiveSubscriptionByUser;
+let findLatestSubscriptionByUser;
 
 beforeAll(async () => {
   const mod = await import('../src/model/premiumSubscriptionModel.js');
   createSubscription = mod.createSubscription;
   getSubscriptions = mod.getSubscriptions;
   findActiveSubscriptionByUser = mod.findActiveSubscriptionByUser;
+  findLatestSubscriptionByUser = mod.findLatestSubscriptionByUser;
 });
 
 beforeEach(() => {
@@ -48,5 +50,15 @@ test('findActiveSubscriptionByUser selects active record', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('WHERE username=$1 AND is_active = true'),
     ['abc']
+  );
+});
+
+test('findLatestSubscriptionByUser selects last record', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 2 }] });
+  const row = await findLatestSubscriptionByUser('def');
+  expect(row).toEqual({ subscription_id: 2 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('WHERE username=$1'),
+    ['def']
   );
 });

--- a/tests/subscriptionRegistrationController.test.js
+++ b/tests/subscriptionRegistrationController.test.js
@@ -1,10 +1,12 @@
 import { jest } from '@jest/globals';
 
 const mockCreateRegistration = jest.fn();
+const mockFindPending = jest.fn();
 const mockSendMessage = jest.fn();
 
 jest.unstable_mockModule('../src/service/subscriptionRegistrationService.js', () => ({
   createRegistration: mockCreateRegistration,
+  findPendingByUsername: mockFindPending,
 }));
 
 jest.unstable_mockModule('../src/service/waService.js', () => ({
@@ -24,10 +26,13 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockCreateRegistration.mockReset();
+  mockFindPending.mockReset();
   mockSendMessage.mockReset();
+  mockSendMessage.mockResolvedValue();
 });
 
 test('sends WhatsApp notification when registration created', async () => {
+  mockFindPending.mockResolvedValueOnce(null);
   mockCreateRegistration.mockResolvedValueOnce({ registration_id: 1, username: 'user', amount: 50 });
   const req = { body: { username: 'user', amount: 50 } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -40,4 +45,16 @@ test('sends WhatsApp notification when registration created', async () => {
   expect(mockSendMessage).toHaveBeenCalledTimes(2);
   expect(mockSendMessage).toHaveBeenCalledWith('admin1@c.us', expect.any(String));
   expect(mockSendMessage).toHaveBeenCalledWith('admin2@c.us', expect.any(String));
+});
+
+test('returns 400 when pending registration exists', async () => {
+  mockFindPending.mockResolvedValueOnce({ registration_id: 2 });
+  const req = { body: { username: 'user' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+
+  await createRegistration(req, res, next);
+
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(mockCreateRegistration).not.toHaveBeenCalled();
 });

--- a/tests/subscriptionRegistrationModel.test.js
+++ b/tests/subscriptionRegistrationModel.test.js
@@ -8,11 +8,13 @@ jest.unstable_mockModule('../src/repository/db.js', () => ({
 
 let createRegistration;
 let getRegistrations;
+let findPendingByUsername;
 
 beforeAll(async () => {
   const mod = await import('../src/model/subscriptionRegistrationModel.js');
   createRegistration = mod.createRegistration;
   getRegistrations = mod.getRegistrations;
+  findPendingByUsername = mod.findPendingByUsername;
 });
 
 beforeEach(() => {
@@ -36,5 +38,15 @@ test('getRegistrations selects all', async () => {
   expect(rows).toEqual([{ registration_id: 1 }]);
   expect(mockQuery).toHaveBeenCalledWith(
     'SELECT * FROM subscription_registration ORDER BY created_at DESC'
+  );
+});
+
+test('findPendingByUsername selects pending record', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ registration_id: 2 }] });
+  const row = await findPendingByUsername('user');
+  expect(row).toEqual({ registration_id: 2 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('status='),
+    ['user']
   );
 });


### PR DESCRIPTION
## Summary
- enforce one active registration per username
- reactivate existing subscriptions instead of inserting new rows
- expire subscriptions after 30 days
- remind admins of pending registrations every 5 minutes
- add tests for new model functions and controller behaviour

## Testing
- `npm run lint` *(fails: Cannot use keyword 'await' outside an async function and other lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd4bcb8f483278900233d219ac33b