### PR TITLE
Update whatsapp-web.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "pg": "^8.16.0",
         "qrcode-terminal": "^0.12.0",
         "redis": "^4.6.7",
-        "whatsapp-web.js": "^1.28.0"
+        "whatsapp-web.js": "^1.31.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -7013,9 +7013,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/whatsapp-web.js": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.28.0.tgz",
-      "integrity": "sha512-rNIgtjjUzCFkOF2prypdkJv3tJw+vToOLjvmlRoMxyyEVlFzJvlvqpicbb5sE9ys4+vY10OzZRQscwC6rjo96w==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.31.0.tgz",
+      "integrity": "sha512-oUfrgSx7s906flFmATA0Hqb8DJYv0tdB28KMQ7dWiua8NqcO1+8IFHE278YvSuFkBqRqH+fSfQrGmwh/4Mx/LQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@pedroslopez/moduleraid": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pg": "^8.16.0",
     "qrcode-terminal": "^0.12.0",
     "redis": "^4.6.7",
-    "whatsapp-web.js": "^1.28.0"
+    "whatsapp-web.js": "^1.31.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary
- update whatsapp-web.js from 1.28 to 1.31

## Testing
- `npm run lint` *(fails: 130 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860215c343083279b0c33c7fa76068c