### PR TITLE
Fix WA menu handling for menu command

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -169,7 +169,8 @@ waClient.on("message", async (msg) => {
   if (
     userMenuContext[chatId] &&
     userMenuContext[chatId].step === "main" &&
-    !["1", "2", "3", "4"].includes(text.trim())
+    !["1", "2", "3", "4"].includes(text.trim()) &&
+    text.trim().toLowerCase() !== "menu"
   ) {
     await waClient.sendMessage(
       chatId,


### PR DESCRIPTION
## Summary
- fix invalid selection message in `waService` when user sends `menu`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6865f43f9c408327b3aff44de89359d2