### PR TITLE
Restrict operator menu access

### DIFF
--- a/docs/wa_operator_request.md
+++ b/docs/wa_operator_request.md
@@ -1,7 +1,7 @@
 # Panduan Operator WA Bot
 *Last updated: 2026-04-01*
 
-Dokumen ini menjelaskan cara menggunakan perintah `oprrequest` pada Bot WhatsApp **Cicero_V2**. Menu ini hanya untuk operator client dan berguna untuk mengelola data user serta update tugas harian.
+Dokumen ini menjelaskan cara menggunakan perintah `oprrequest` pada Bot WhatsApp **Cicero_V2**. Menu ini hanya untuk operator client dan berguna untuk mengelola data user serta update tugas harian. Hanya nomor operator yang terdaftar pada data client yang dapat mengakses menu ini.
 
 ## Cara Masuk Menu Operator
 1. Kirim perintah `oprrequest` ke Bot WhatsApp.

--- a/src/model/clientModel.js
+++ b/src/model/clientModel.js
@@ -14,6 +14,20 @@ export const findById = async (client_id) => {
   return res.rows[0] || null;
 };
 
+// Ambil client berdasarkan nomor WhatsApp operator
+export const findByOperator = async (waNumber) => {
+  if (!waNumber) return null;
+  const normalized = String(waNumber).replace(/\D/g, '');
+  const waId = normalized.startsWith('62')
+    ? normalized
+    : '62' + normalized.replace(/^0/, '');
+  const { rows } = await query(
+    'SELECT * FROM clients WHERE client_operator = $1 LIMIT 1',
+    [waId]
+  );
+  return rows[0] || null;
+};
+
 // Buat client baru
 export const create = async (client) => {
   const q = `

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -11,6 +11,7 @@ const pool = { query };
 // Service & Utility Imports
 import * as clientService from "./clientService.js";
 import * as userModel from "../model/userModel.js";
+import { findByOperator } from "../model/clientModel.js";
 import * as registrationService from "./subscriptionRegistrationService.js";
 import * as premiumService from "./premiumSubscriptionService.js";
 import { migrateUsersFromFolder } from "./userMigrationService.js";
@@ -230,6 +231,18 @@ waClient.on("message", async (msg) => {
     }
     if (/^2$/.test(text.trim())) {
       delete adminOptionSessions[chatId];
+      const operator = await findByOperator(
+        userWaNum.startsWith("62")
+          ? userWaNum
+          : "62" + userWaNum.replace(/^0/, "")
+      );
+      if (!operator) {
+        await waClient.sendMessage(
+          chatId,
+          "❌ Nomor Anda bukan operator yang terdaftar pada client manapun."
+        );
+        return;
+      }
       setSession(chatId, { menu: "oprrequest", step: "main" });
       await oprRequestHandlers.main(
         getSession(chatId),
@@ -280,6 +293,16 @@ waClient.on("message", async (msg) => {
 
   // ===== MULAI Menu Operator dari command manual =====
   if (text.toLowerCase() === "oprrequest") {
+    const operator = await findByOperator(
+      userWaNum.startsWith("62") ? userWaNum : "62" + userWaNum.replace(/^0/, "")
+    );
+    if (!operator) {
+      await waClient.sendMessage(
+        chatId,
+        "❌ Menu ini hanya dapat diakses oleh operator yang terdaftar pada client."
+      );
+      return;
+    }
     setSession(chatId, { menu: "oprrequest", step: "main" });
     await oprRequestHandlers.main(
       getSession(chatId),


### PR DESCRIPTION
## Summary
- restrict `oprrequest` command to registered operator numbers
- prevent admin option from opening operator menu unless chat ID is operator
- add helper `findByOperator` in `clientModel`
- clarify doc that only registered operator numbers may use `oprrequest`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_686f4ed905fc832786736246f82e33e0