### PR TITLE
Allow super admin and admin WA access to oprrequest

### DIFF
--- a/src/model/clientModel.js
+++ b/src/model/clientModel.js
@@ -28,6 +28,20 @@ export const findByOperator = async (waNumber) => {
   return rows[0] || null;
 };
 
+// Ambil client berdasarkan nomor WhatsApp super admin
+export const findBySuperAdmin = async (waNumber) => {
+  if (!waNumber) return null;
+  const normalized = String(waNumber).replace(/\D/g, "");
+  const waId = normalized.startsWith("62")
+    ? normalized
+    : "62" + normalized.replace(/^0/, "");
+  const { rows } = await query(
+    "SELECT * FROM clients WHERE client_super = $1 LIMIT 1",
+    [waId]
+  );
+  return rows[0] || null;
+};
+
 // Buat client baru
 export const create = async (client) => {
   const q = `

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -11,7 +11,7 @@ const pool = { query };
 // Service & Utility Imports
 import * as clientService from "./clientService.js";
 import * as userModel from "../model/userModel.js";
-import { findByOperator } from "../model/clientModel.js";
+import { findByOperator, findBySuperAdmin } from "../model/clientModel.js";
 import * as registrationService from "./subscriptionRegistrationService.js";
 import * as premiumService from "./premiumSubscriptionService.js";
 import { migrateUsersFromFolder } from "./userMigrationService.js";
@@ -231,15 +231,15 @@ waClient.on("message", async (msg) => {
     }
     if (/^2$/.test(text.trim())) {
       delete adminOptionSessions[chatId];
-      const operator = await findByOperator(
-        userWaNum.startsWith("62")
-          ? userWaNum
-          : "62" + userWaNum.replace(/^0/, "")
-      );
-      if (!operator) {
+      const waId = userWaNum.startsWith("62")
+        ? userWaNum
+        : "62" + userWaNum.replace(/^0/, "");
+      const operator = await findByOperator(waId);
+      const superAdmin = await findBySuperAdmin(waId);
+      if (!operator && !superAdmin && !isAdmin) {
         await waClient.sendMessage(
           chatId,
-          "❌ Nomor Anda bukan operator yang terdaftar pada client manapun."
+          "❌ Nomor Anda bukan operator atau super admin yang terdaftar."
         );
         return;
       }
@@ -293,13 +293,14 @@ waClient.on("message", async (msg) => {
 
   // ===== MULAI Menu Operator dari command manual =====
   if (text.toLowerCase() === "oprrequest") {
-    const operator = await findByOperator(
-      userWaNum.startsWith("62") ? userWaNum : "62" + userWaNum.replace(/^0/, "")
-    );
-    if (!operator) {
+    const waId =
+      userWaNum.startsWith("62") ? userWaNum : "62" + userWaNum.replace(/^0/, "");
+    const operator = await findByOperator(waId);
+    const superAdmin = await findBySuperAdmin(waId);
+    if (!operator && !superAdmin && !isAdmin) {
       await waClient.sendMessage(
         chatId,
-        "❌ Menu ini hanya dapat diakses oleh operator yang terdaftar pada client."
+        "❌ Menu ini hanya dapat diakses oleh operator atau super admin yang terdaftar."
       );
       return;
     }


### PR DESCRIPTION
## Summary
- add `findBySuperAdmin` model helper
- permit admin WhatsApp numbers and super admins to access `oprrequest`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686f51ac1fb08327b9e0d146a7f25dc8