### PR TITLE
Allow numeric satfung selection

### DIFF
--- a/docs/wa_operator_request.md
+++ b/docs/wa_operator_request.md
@@ -16,7 +16,9 @@ Dokumen ini menjelaskan cara menggunakan perintah `oprrequest` pada Bot WhatsApp
 ## Alur Singkat Setiap Menu
 - **Tambah User Baru**
   1. Masukkan NRP/NIP yang belum terdaftar.
-  2. Isi nama, pangkat, satfung, dan jabatan sesuai instruksi.
+  2. Isi nama, pangkat, satfung, dan jabatan sesuai instruksi. Untuk satfung,
+     Anda dapat mengetik *nomor urut* pada daftar atau menuliskan namanya secara
+     lengkap. Daftar satfung yang ditampilkan hanya berasal dari client Anda.
   3. Bot akan menyimpan data dan mengirim ringkasan user.
 - **Ubah Status User**
   1. Masukkan NRP/NIP yang ingin diubah.

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -184,11 +184,19 @@ export async function getAvailableTitles() {
 }
 
 // Ambil daftar Satfung unik dari database
-export async function getAvailableSatfung() {
+export async function getAvailableSatfung(clientId = null) {
   // Gunakan "user" (pakai kutip dua) karena user adalah reserved word di Postgres
-  const res = await query(
-    'SELECT DISTINCT divisi FROM "user" WHERE divisi IS NOT NULL ORDER BY divisi'
-  );
+  let res;
+  if (clientId) {
+    res = await query(
+      'SELECT DISTINCT divisi FROM "user" WHERE divisi IS NOT NULL AND client_id = $1 ORDER BY divisi',
+      [clientId]
+    );
+  } else {
+    res = await query(
+      'SELECT DISTINCT divisi FROM "user" WHERE divisi IS NOT NULL ORDER BY divisi'
+    );
+  }
   return res.rows.map((r) => r.divisi).filter(Boolean);
 }
 


### PR DESCRIPTION
## Summary
- allow operators to choose a satfung by number when adding a user
- support numeric input when updating a user's satfung
- note numeric satfung selection in the operator guide
- filter satfung choices by client ID so each operator only sees their own list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_686f78b23e548327b7f18cf92872f4ce