### PR TITLE
Add per-post recap menu

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -102,3 +102,15 @@ export async function getReportsTodayByClient(client_id) {
   );
   return res.rows;
 }
+
+export async function getReportsTodayByShortcode(client_id, shortcode) {
+  const res = await query(
+    `SELECT r.* FROM link_report r
+     JOIN "user" u ON u.user_id = r.user_id
+     WHERE u.client_id = $1 AND r.shortcode = $2
+       AND r.created_at::date = NOW()::date
+     ORDER BY r.created_at ASC`,
+    [client_id, shortcode]
+  );
+  return res.rows;
+}

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -14,6 +14,7 @@ let createLinkReport;
 let getLinkReports;
 let findLinkReportByShortcode;
 let getReportsTodayByClient;
+let getReportsTodayByShortcode;
 
 beforeAll(async () => {
   const mod = await import('../src/model/linkReportModel.js');
@@ -21,6 +22,7 @@ beforeAll(async () => {
   getLinkReports = mod.getLinkReports;
   findLinkReportByShortcode = mod.findLinkReportByShortcode;
   getReportsTodayByClient = mod.getReportsTodayByClient;
+  getReportsTodayByShortcode = mod.getReportsTodayByShortcode;
 });
 
 beforeEach(() => {
@@ -74,5 +76,15 @@ test('getReportsTodayByClient filters by client', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('JOIN "user" u ON u.user_id = r.user_id'),
     ['POLRES']
+  );
+});
+
+test('getReportsTodayByShortcode filters by client and shortcode', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc' }] });
+  const rows = await getReportsTodayByShortcode('POLRES', 'abc');
+  expect(rows).toEqual([{ shortcode: 'abc' }]);
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('r.shortcode = $2'),
+    ['POLRES', 'abc']
   );
 });


### PR DESCRIPTION
## Summary
- support fetching link reports by shortcode
- extend linkReportModel tests for new helper
- add `Rekap link per post` option to operator menu
- implement workflow to choose post and show recap

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686f81cbc1e88327b00c43e069149437