### PR TITLE
Fix client name in rekap link message

### DIFF
--- a/src/cron/cronRekapLink.js
+++ b/src/cron/cronRekapLink.js
@@ -13,7 +13,7 @@ import { getGreeting } from "../utils/utilsHelper.js";
 async function getActiveClients() {
   const { query } = await import("../db/index.js");
   const rows = await query(
-    `SELECT client_id, client_operator, client_super, client_group
+    `SELECT client_id, nama, client_operator, client_super, client_group
      FROM clients
      WHERE client_status=true AND client_insta_status=true
      ORDER BY client_id`
@@ -99,7 +99,8 @@ cron.schedule(
         );
 
         let msg = `${salam}\n\n`;
-        msg += `Mohon Ijin Melaporkan Pelaksanaan Tugas Amplifikasi (nama client_id : ${client.client_id}) pada hari :\n`;
+        const clientName = client.nama || client.client_id;
+        msg += `Mohon Ijin Melaporkan Pelaksanaan Tugas Amplifikasi (nama client : ${clientName}) pada hari :\n`;
         msg += `Hari : ${hari}\n`;
         msg += `Tanggal : ${tanggal}\n`;
         msg += `Pukul : ${jam}\n\n`;

--- a/src/handler/menu/oprRequestHandlers.js
+++ b/src/handler/menu/oprRequestHandlers.js
@@ -343,12 +343,18 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     const jam = now.toLocaleTimeString("id-ID", { hour12: false });
     const salam = getGreeting();
 
+    const { rows: nameRows } = await pool.query(
+      "SELECT nama FROM clients WHERE client_id=$1 LIMIT 1",
+      [clientId]
+    );
+    const clientName = nameRows[0]?.nama || clientId;
+
     const kontenLinks = shortcodes.map(
       sc => `https://www.instagram.com/p/${sc}`
     );
 
     let msg = `${salam}\n\n`;
-    msg += `Mohon Ijin Melaporkan Pelaksanaan Tugas Amplifikasi (nama client_id : ${clientId}) pada hari :\n`;
+    msg += `Mohon Ijin Melaporkan Pelaksanaan Tugas Amplifikasi (nama client : ${clientName}) pada hari :\n`;
     msg += `Hari : ${hari}\n`;
     msg += `Tanggal : ${tanggal}\n`;
     msg += `Pukul : ${jam}\n\n`;


### PR DESCRIPTION
## Summary
- include `nama` field when gathering active clients
- use client name in the daily rekap link cron job
- show client name in operator rekap link report

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_686f8399265c8327b70577c6395c083e