### PR TITLE
Implement link amplification recap API

### DIFF
--- a/src/controller/amplifyController.js
+++ b/src/controller/amplifyController.js
@@ -1,0 +1,19 @@
+import { getRekapLinkByClient } from '../model/linkReportModel.js';
+import { sendConsoleDebug } from '../middleware/debugHandler.js';
+
+export async function getAmplifyRekap(req, res) {
+  const client_id = req.query.client_id;
+  const periode = req.query.periode || 'harian';
+  if (!client_id) {
+    return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
+  }
+  try {
+    sendConsoleDebug({ tag: 'AMPLIFY', msg: `getAmplifyRekap ${client_id} ${periode}` });
+    const data = await getRekapLinkByClient(client_id, periode);
+    res.json({ success: true, data });
+  } catch (err) {
+    sendConsoleDebug({ tag: 'AMPLIFY', msg: `Error getAmplifyRekap: ${err.message}` });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
+  }
+}

--- a/src/routes/amplifyRoutes.js
+++ b/src/routes/amplifyRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getAmplifyRekap } from '../controller/amplifyController.js';
+import { authRequired } from '../middleware/authMiddleware.js';
+
+const router = Router();
+
+router.get('/rekap', authRequired, getAmplifyRekap);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -12,6 +12,7 @@ import logRoutes from './logRoutes.js';
 import linkReportRoutes from './linkReportRoutes.js';
 import premiumSubscriptionRoutes from './premiumSubscriptionRoutes.js';
 import subscriptionRegistrationRoutes from './subscriptionRegistrationRoutes.js';
+import amplifyRoutes from './amplifyRoutes.js';
 
 const router = express.Router();
 
@@ -28,6 +29,7 @@ router.use('/logs', logRoutes);
 router.use('/link-reports', linkReportRoutes);
 router.use('/premium-subscriptions', premiumSubscriptionRoutes);
 router.use('/subscription-registrations', subscriptionRegistrationRoutes);
+router.use('/amplify', amplifyRoutes);
 
 export default router;
 


### PR DESCRIPTION
## Summary
- aggregate link reports by client and date range
- expose new `/api/amplify/rekap` endpoint
- wire the new route into the router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686fd950a7e083279ef2a665cac786fd