### PR TITLE
Fix undefined helper in user creation flow

### DIFF
--- a/src/handler/menu/oprRequestHandlers.js
+++ b/src/handler/menu/oprRequestHandlers.js
@@ -1,7 +1,7 @@
 // src/handler/menu/oprRequestHandlers.js
 import { isAdminWhatsApp } from "../../utils/waHelper.js";
 import { hariIndo } from "../../utils/constants.js";
-import { getGreeting } from "../../utils/utilsHelper.js";
+import { getGreeting, sortDivisionKeys } from "../../utils/utilsHelper.js";
 
 export const oprRequestHandlers = {
  main: async (session, chatId, text, waClient, pool, userModel) => {


### PR DESCRIPTION
## Summary
- import `sortDivisionKeys` in operator request handlers to prevent a crash when selecting a user's rank

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_687064c1fb688327b192ec04e07efb05