### PR TITLE
Improve WA binding prompts

### DIFF
--- a/src/handler/menu/oprRequestHandlers.js
+++ b/src/handler/menu/oprRequestHandlers.js
@@ -157,7 +157,7 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
     }
     await waClient.sendMessage(
       chatId,
-      "❗ Menu tidak dikenali. Pilih *1-8* atau ketik *batal* untuk keluar."
+      "Menu tidak dikenal. Balas angka 1-8 atau ketik *batal* untuk keluar."
     );
   },
 
@@ -170,7 +170,7 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
     }
     const nrp = text.trim().replace(/[^0-9a-zA-Z]/g, "");
     if (!nrp) {
-      await waClient.sendMessage(chatId, "❌ NRP/NIP tidak valid. Masukkan ulang atau ketik *batal*.");
+      await waClient.sendMessage(chatId, "❌ NRP yang Anda masukkan tidak valid. Silakan masukkan ulang atau ketik *batal*.");
       return;
     }
     const existing = await userModel.findUserById(nrp);

--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -90,10 +90,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
         return;
       } else {
         session.step = "inputUserId";
-        await waClient.sendMessage(
-          chatId,
-          "Ketik NRP/NIP Anda untuk melihat data. (contoh: 75070206)"
-        );
+        await waClient.sendMessage(chatId, "Ketik NRP Anda untuk melihat data. (contoh: 75070206)");
         return;
       }
     }
@@ -127,10 +124,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
         return;
       } else {
         session.step = "updateAskUserId";
-        await waClient.sendMessage(
-          chatId,
-          "Ketik NRP/NIP Anda yang ingin diupdate:"
-        );
+        await waClient.sendMessage(chatId, "Ketik NRP Anda yang ingin diupdate:");
         return;
       }
     }
@@ -188,19 +182,19 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
   inputUserId: async (session, chatId, text, waClient, pool, userModel) => {
     const user_id = text.replace(/[^0-9a-zA-Z]/g, "");
     if (!user_id) {
-      await waClient.sendMessage(chatId, "NRP/NIP tidak valid. Coba lagi atau ketik *batal*.");
+      await waClient.sendMessage(chatId, "NRP yang Anda masukkan tidak valid. Silakan coba lagi atau ketik *batal*.");
       return;
     }
     try {
       const user = await userModel.findUserById(user_id);
       if (!user) {
-        await waClient.sendMessage(chatId, `❌ User dengan NRP/NIP ${user_id} tidak ditemukan. Hubungi Opr Humas Polres Anda.`);
+        await waClient.sendMessage(chatId, `❌ User dengan NRP ${user_id} tidak ditemukan. Hubungi Opr Humas Polres Anda.`);
       } else {
         session.step = "confirmBindUser";
         session.bindUserId = user_id;
         await waClient.sendMessage(
           chatId,
-          `NRP/NIP *${user_id}* ditemukan. Nomor WhatsApp ini belum terdaftar.\n` +
+          `NRP *${user_id}* ditemukan. Nomor WhatsApp ini belum terdaftar.\n` +
             "Apakah Anda ingin menghubungkannya dengan akun tersebut?\n" +
             "Balas *ya* untuk menghubungkan atau *tidak* untuk membatalkan."
         );
@@ -222,7 +216,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
       const user = await userModel.findUserById(user_id);
       await waClient.sendMessage(
         chatId,
-        `✅ Nomor WhatsApp telah dihubungkan ke NRP/NIP *${user_id}*. Berikut datanya:\n` +
+        `✅ Nomor WhatsApp telah dihubungkan ke NRP *${user_id}*. Berikut datanya:\n` +
           formatUserReport(user)
       );
       session.identityConfirmed = true;
@@ -244,12 +238,12 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
   updateAskUserId: async (session, chatId, text, waClient, pool, userModel) => {
     const nrp = text.replace(/[^0-9a-zA-Z]/g, "");
     if (!nrp) {
-      await waClient.sendMessage(chatId, "NRP/NIP tidak valid. Coba lagi atau ketik *batal*.");
+      await waClient.sendMessage(chatId, "NRP yang Anda masukkan tidak valid. Silakan coba lagi atau ketik *batal*.");
       return;
     }
     const user = await userModel.findUserById(nrp);
     if (!user) {
-      await waClient.sendMessage(chatId, `❌ User dengan NRP/NIP *${nrp}* tidak ditemukan. Hubungi Opr Humas Polres Anda.`);
+      await waClient.sendMessage(chatId, `❌ User dengan NRP *${nrp}* tidak ditemukan. Hubungi Opr Humas Polres Anda.`);
       session.step = "main";
       await waClient.sendMessage(chatId, menuUtama());
       return;
@@ -258,7 +252,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
     session.step = "confirmBindUpdate";
     await waClient.sendMessage(
       chatId,
-      `NRP/NIP *${nrp}* ditemukan. Nomor WhatsApp ini belum terdaftar.\n` +
+      `NRP *${nrp}* ditemukan. Nomor WhatsApp ini belum terdaftar.\n` +
         "Apakah Anda ingin menghubungkannya dan melanjutkan update?\n" +
         "Balas *ya* untuk menghubungkan atau *tidak* untuk membatalkan."
     );
@@ -270,7 +264,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
     if (ans === "ya") {
       const nrp = session.updateUserId;
       await userModel.updateUserField(nrp, "whatsapp", waNum);
-      await waClient.sendMessage(chatId, `✅ Nomor berhasil dihubungkan ke NRP/NIP *${nrp}*.`);
+      await waClient.sendMessage(chatId, `✅ Nomor berhasil dihubungkan ke NRP *${nrp}*.`);
       session.identityConfirmed = true;
       session.user_id = nrp;
       session.step = "updateAskField";
@@ -366,7 +360,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
       await userModel.updateUserField(user_id, "whatsapp", "");
       await waClient.sendMessage(
         chatId,
-        `✅ Nomor WhatsApp untuk NRP/NIP ${user_id} berhasil dihapus dari database.`
+        `✅ Nomor WhatsApp untuk NRP ${user_id} berhasil dihapus dari database.`
       );
       session.step = "main";
       await waClient.sendMessage(chatId, menuUtama());
@@ -470,7 +464,7 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
     await userModel.updateUserField(user_id, field, value);
     await waClient.sendMessage(
       chatId,
-      `✅ Data *${field === "title" ? "pangkat" : field === "divisi" ? "satfung" : field}* untuk NRP/NIP ${user_id} berhasil diupdate menjadi *${value}*.`
+      `✅ Data *${field === "title" ? "pangkat" : field === "divisi" ? "satfung" : field}* untuk NRP ${user_id} berhasil diupdate menjadi *${value}*.`
     );
     delete session.availableTitles;
     delete session.availableSatfung;

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -205,8 +205,10 @@ waClient.on("message", async (msg) => {
       } else {
         userMenuContext[chatId] = { step: "inputUserId" };
         setMenuTimeout(chatId);
-        const msg = `${salam}! Nomor WhatsApp Anda belum terdaftar.\nSilakan ketik NRP/NIP Anda untuk melihat data, atau ketik *userrequest* untuk panduan.`;
+        const msg = `${salam}! Nomor WhatsApp Anda belum terdaftar.`;
         await waClient.sendMessage(chatId, msg.trim());
+        await waClient.sendMessage(chatId, "Silakan masukkan NRP Anda untuk melihat data.");
+        await waClient.sendMessage(chatId, "Ketik *userrequest* jika membutuhkan panduan.");
       }
       return;
     }
@@ -264,8 +266,10 @@ waClient.on("message", async (msg) => {
       } else {
         userMenuContext[chatId] = { step: "inputUserId" };
         setMenuTimeout(chatId);
-        const msg = `${salam}! Nomor WhatsApp Anda belum terdaftar.\nSilakan ketik NRP/NIP Anda untuk melihat data, atau ketik *userrequest* untuk panduan.`;
+        const msg = `${salam}! Nomor WhatsApp Anda belum terdaftar.`;
         await waClient.sendMessage(chatId, msg.trim());
+        await waClient.sendMessage(chatId, "Silakan masukkan NRP Anda untuk melihat data.");
+        await waClient.sendMessage(chatId, "Ketik *userrequest* jika membutuhkan panduan.");
       }
       return;
     }
@@ -548,7 +552,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       updateUsernameSession[chatId].field = field;
       await waClient.sendMessage(
         chatId,
-        "Nomor WhatsApp Anda belum terhubung ke data user manapun.\nSilakan ketik NRP/NIP Anda untuk binding akun:"
+        "Nomor WhatsApp Anda belum terhubung ke data user mana pun.\nSilakan masukkan NRP Anda untuk melakukan binding akun atau balas *batal* untuk keluar:"
       );
       return;
     }
@@ -563,7 +567,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
     if (!nrp) {
       await waClient.sendMessage(
         chatId,
-        "NRP/NIP tidak valid. Coba lagi atau balas *batal* untuk membatalkan."
+        "NRP yang Anda masukkan tidak valid. Coba lagi atau balas *batal* untuk membatalkan."
       );
       return;
     }
@@ -571,7 +575,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
     if (!user) {
       await waClient.sendMessage(
         chatId,
-        `User dengan NRP/NIP *${nrp}* tidak ditemukan. Silakan hubungi Opr Humas Polres Anda.`
+        `User dengan NRP *${nrp}* tidak ditemukan. Silakan hubungi Opr Humas Polres Anda.`
       );
       return;
     }
@@ -1755,8 +1759,10 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       } else {
         userMenuContext[chatId] = { step: "inputUserId" };
         setMenuTimeout(chatId);
-        const msg = `${salam}! Nomor WhatsApp Anda belum terdaftar.\nSilakan ketik NRP/NIP Anda untuk melihat data, atau ketik *userrequest* untuk panduan.` + clientInfoText;
+        const msg = `${salam}! Nomor WhatsApp Anda belum terdaftar.` + clientInfoText;
         await safeSendMessage(waClient, chatId, msg.trim());
+        await safeSendMessage(waClient, chatId, "Silakan masukkan NRP Anda untuk melihat data.");
+        await safeSendMessage(waClient, chatId, "Ketik *userrequest* jika membutuhkan panduan.");
       }
     return;
   }
@@ -1771,19 +1777,19 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       if (session.step === "ask_nrp") {
         if (text.trim().toLowerCase() === "batal") {
           delete waBindSessions[chatId];
-          await waClient.sendMessage(chatId, "Proses dibatalkan. Silakan masukkan NRP/NIP Anda untuk memulai.");
+          await waClient.sendMessage(chatId, "Proses dibatalkan. Silakan masukkan NRP Anda untuk memulai.");
           waBindSessions[chatId] = { step: "ask_nrp" };
           setBindTimeout(chatId);
           return;
         }
         const nrp = text.replace(/[^0-9a-zA-Z]/g, "");
         if (!nrp) {
-          await waClient.sendMessage(chatId, "NRP/NIP tidak valid. Coba lagi atau ketik *batal*.");
+          await waClient.sendMessage(chatId, "NRP yang Anda masukkan tidak valid. Silakan coba lagi atau ketik *batal*.");
           return;
         }
         const user = await userModel.findUserById(nrp);
         if (!user) {
-          await waClient.sendMessage(chatId, `NRP/NIP *${nrp}* tidak ditemukan. Hubungi Opr Humas Polres Anda.`);
+          await waClient.sendMessage(chatId, `NRP *${nrp}* tidak ditemukan. Hubungi Opr Humas Polres Anda.`);
           return;
         }
         session.step = "confirm";
@@ -1791,7 +1797,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
         setBindTimeout(chatId);
         await waClient.sendMessage(
           chatId,
-          `Apakah Anda ingin menghubungkan nomor WhatsApp ini dengan NRP/NIP *${nrp}*?\n` +
+          `Apakah Anda ingin menghubungkan nomor WhatsApp ini dengan NRP *${nrp}*?\n` +
             "Satu username hanya bisa menggunakan satu akun WhatsApp.\n" +
             "Balas *ya* untuk menyetujui atau *tidak* untuk membatalkan."
         );
@@ -1804,7 +1810,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
           const user = await userModel.findUserById(nrp);
           await waClient.sendMessage(
             chatId,
-            `✅ Nomor WhatsApp berhasil dihubungkan ke NRP/NIP *${nrp}*.\n` +
+            `✅ Nomor WhatsApp berhasil dihubungkan ke NRP *${nrp}*.\n` +
               `${formatUserSummary(user)}`
           );
           delete waBindSessions[chatId];
@@ -1812,7 +1818,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
         }
         if (text.trim().toLowerCase() === "tidak") {
           delete waBindSessions[chatId];
-          await waClient.sendMessage(chatId, "Baik, proses dibatalkan. Silakan masukkan NRP/NIP Anda untuk melanjutkan.");
+          await waClient.sendMessage(chatId, "Baik, proses dibatalkan. Silakan masukkan NRP Anda untuk melanjutkan.");
           waBindSessions[chatId] = { step: "ask_nrp" };
           setBindTimeout(chatId);
           return;
@@ -1825,7 +1831,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       setBindTimeout(chatId);
       await waClient.sendMessage(
         chatId,
-        "🤖 Maaf, perintah yang Anda kirim belum dikenali. Masukkan NRP/NIP Anda untuk melanjutkan proses binding akun:"
+        "🤖 Maaf, perintah yang Anda kirim belum dikenali. Silakan masukkan NRP Anda untuk melanjutkan proses binding akun atau balas *batal* untuk keluar:"
       );
       return;
     }


### PR DESCRIPTION
## Summary
- clarify instructions when WhatsApp numbers are unregistered
- improve invalid NRP input messages
- tweak operator menu error reply

## Testing
- `npm run lint` *(fails: `npm: command not found`)*
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68706cab8ec08327a7c1fd1429fa8c7f