### PR TITLE
Fix operator WA update issue

### DIFF
--- a/src/handler/menu/oprRequestHandlers.js
+++ b/src/handler/menu/oprRequestHandlers.js
@@ -844,7 +844,17 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
       }
       value = "@" + ttMatch[2];
     }
-    if (field === "whatsapp") value = value.replace(/[^0-9]/g, "");
+    if (field === "whatsapp") {
+      value = value.replace(/[^0-9]/g, "");
+      const operatorWa = chatId.replace(/[^0-9]/g, "");
+      if (value === operatorWa) {
+        await waClient.sendMessage(
+          chatId,
+          "❌ Nomor WhatsApp operator tidak boleh disimpan pada data user. Masukkan nomor lain."
+        );
+        return;
+      }
+    }
     if (["nama", "title", "divisi", "jabatan"].includes(field)) value = value.toUpperCase();
 
     try {


### PR DESCRIPTION
## Summary
- prevent operator WhatsApp number from being saved when updating user data in oprrequest menu

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6870808bf98c8327955f8e45d3ecc9bd