### PR TITLE
Handle link-only input for link reports

### DIFF
--- a/src/controller/linkReportController.js
+++ b/src/controller/linkReportController.js
@@ -1,5 +1,6 @@
 import * as linkReportModel from '../model/linkReportModel.js';
 import { sendSuccess } from '../utils/response.js';
+import { extractFirstUrl } from '../utils/utilsHelper.js';
 
 export async function getAllLinkReports(req, res, next) {
   try {
@@ -24,7 +25,17 @@ export async function getLinkReportByShortcode(req, res, next) {
 
 export async function createLinkReport(req, res, next) {
   try {
-    const report = await linkReportModel.createLinkReport(req.body);
+    const data = { ...req.body };
+    [
+      'instagram_link',
+      'facebook_link',
+      'twitter_link',
+      'tiktok_link',
+      'youtube_link'
+    ].forEach((f) => {
+      if (data[f]) data[f] = extractFirstUrl(data[f]);
+    });
+    const report = await linkReportModel.createLinkReport(data);
     sendSuccess(res, report, 201);
   } catch (err) {
     next(err);
@@ -33,10 +44,20 @@ export async function createLinkReport(req, res, next) {
 
 export async function updateLinkReport(req, res, next) {
   try {
+    const bodyData = { ...req.body };
+    [
+      'instagram_link',
+      'facebook_link',
+      'twitter_link',
+      'tiktok_link',
+      'youtube_link'
+    ].forEach((f) => {
+      if (bodyData[f]) bodyData[f] = extractFirstUrl(bodyData[f]);
+    });
     const report = await linkReportModel.updateLinkReport(
       req.params.shortcode,
-      req.body.user_id,
-      req.body
+      bodyData.user_id,
+      bodyData
     );
     sendSuccess(res, report);
   } catch (err) {

--- a/src/utils/utilsHelper.js
+++ b/src/utils/utilsHelper.js
@@ -138,3 +138,9 @@ export function formatUserData(user) {
   ].join("\n");
 }
 
+
+export function extractFirstUrl(text) {
+  if (!text) return null;
+  const match = String(text).match(/https?:\/\/\S+/);
+  return match ? match[0] : null;
+}


### PR DESCRIPTION
## Summary
- extract first URL from any text
- sanitize link inputs when creating or updating link reports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest' in node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_6870c90663f48327ba747725c13138bd