### PR TITLE
Add shared helper for Instagram carousel data

### DIFF
--- a/src/handler/datamining/fetchDmPostInfo.js
+++ b/src/handler/datamining/fetchDmPostInfo.js
@@ -1,33 +1,15 @@
 import { fetchInstagramPostInfo } from '../../service/instagramApi.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
-import {
-  upsertIgUser,
-  upsertIgPost,
-  upsertIgMedia,
-  insertHashtags,
-  upsertTaggedUsers,
-  getPostIdsTodayByUsername
-} from '../../model/instaPostExtendedModel.js';
+import { savePostWithMedia, getPostIdsTodayByUsername } from '../../model/instaPostExtendedModel.js';
 import { upsertPostMetrics } from '../../model/instaPostMetricsModel.js';
 
 export async function fetchAndStoreDmPostInfo(postId) {
   try {
     const info = await fetchInstagramPostInfo(postId);
     if (!info) return;
-    await upsertIgUser(info.user);
-    await upsertIgPost(info, info.user?.id);
+    await savePostWithMedia(info);
     if (info.metrics) {
       await upsertPostMetrics(info.id, info.metrics);
-    }
-    if (Array.isArray(info.hashtags)) {
-      await insertHashtags(info.id, info.hashtags);
-    }
-    const medias = info.carousel_media || [info];
-    for (const m of medias) {
-      await upsertIgMedia(m, info.id);
-      if (Array.isArray(m.tagged_users)) {
-        await upsertTaggedUsers(m.id, m.tagged_users);
-      }
     }
     sendDebug({ tag: 'IG DM POST INFO', msg: `Fetched info for ${postId}` });
   } catch (err) {

--- a/src/handler/datamining/fetchDmPosts.js
+++ b/src/handler/datamining/fetchDmPosts.js
@@ -1,30 +1,13 @@
 import { fetchInstagramPosts } from '../../service/instagramApi.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
-import {
-  upsertIgUser,
-  upsertIgPost,
-  upsertIgMedia,
-  insertHashtags,
-  upsertTaggedUsers
-} from '../../model/instaPostExtendedModel.js';
+import { savePostWithMedia } from '../../model/instaPostExtendedModel.js';
 
 export async function fetchDmPosts(username, limit = 50) {
   if (!username) return [];
   try {
     const posts = await fetchInstagramPosts(username, limit);
     for (const post of posts) {
-      await upsertIgUser(post.user);
-      await upsertIgPost(post, post.user?.id);
-      if (Array.isArray(post.hashtags)) {
-        await insertHashtags(post.id, post.hashtags);
-      }
-      const medias = post.carousel_media || [post];
-      for (const m of medias) {
-        await upsertIgMedia(m, post.id);
-        if (Array.isArray(m.tagged_users)) {
-          await upsertTaggedUsers(m.id, m.tagged_users);
-        }
-      }
+      await savePostWithMedia(post);
     }
     sendDebug({ tag: 'IG DM POST', msg: `Fetched ${posts.length} posts for @${username}` });
     return posts.map(p => p.id);

--- a/src/handler/fetchpost/instaFetchPost.js
+++ b/src/handler/fetchpost/instaFetchPost.js
@@ -4,13 +4,7 @@ import pLimit from "p-limit";
 import { query } from "../../db/index.js";
 import { sendDebug } from "../../middleware/debugHandler.js";
 import { fetchInstagramPosts } from "../../service/instagramApi.js";
-import {
-  upsertIgUser,
-  upsertIgPost,
-  upsertIgMedia,
-  insertHashtags,
-  upsertTaggedUsers,
-} from "../../model/instaPostExtendedModel.js";
+import { savePostWithMedia } from "../../model/instaPostExtendedModel.js";
 
 const ADMIN_WHATSAPP = (process.env.ADMIN_WHATSAPP || "")
   .split(",")
@@ -223,18 +217,7 @@ export async function fetchAndStoreInstaContent(
 
       // store extended post data
       try {
-        await upsertIgUser(post.user);
-        await upsertIgPost(post, post.user?.id);
-        if (Array.isArray(post.hashtags)) {
-          await insertHashtags(post.id, post.hashtags);
-        }
-        const medias = post.carousel_media || [post];
-        for (const m of medias) {
-          await upsertIgMedia(m, post.id);
-          if (Array.isArray(m.tagged_users)) {
-            await upsertTaggedUsers(m.id, m.tagged_users);
-          }
-        }
+        await savePostWithMedia(post);
       } catch (err) {
         sendDebug({ tag: "IG EXT", msg: err.message });
       }

--- a/src/model/instaPostExtendedModel.js
+++ b/src/model/instaPostExtendedModel.js
@@ -111,3 +111,19 @@ export async function getPostIdsTodayByUsername(username) {
   return res.rows.map(r => r.post_id);
 }
 
+export async function savePostWithMedia(post) {
+  if (!post) return;
+  await upsertIgUser(post.user);
+  await upsertIgPost(post, post.user?.id);
+  if (Array.isArray(post.hashtags)) {
+    await insertHashtags(post.id, post.hashtags);
+  }
+  const medias = post.carousel_media || [post];
+  for (const m of medias) {
+    await upsertIgMedia(m, post.id);
+    if (Array.isArray(m.tagged_users)) {
+      await upsertTaggedUsers(m.id, m.tagged_users);
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `savePostWithMedia` helper to centralize saving Instagram post & carousel metadata
- reuse the helper across datamining and official fetch handlers

## Testing
- `npm run lint` *(fails: Parsing error and many no-unused-vars violations)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877a6745048832797d4b514aac81d9d