### PR TITLE
Update ESLint ECMAScript version

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ export default [
   {
     files: ['**/*.js'],
     languageOptions: {
-      ecmaVersion: 2021,
+      ecmaVersion: 2022,
       sourceType: 'module',
       globals: {
         process: 'readonly',


### PR DESCRIPTION
## Summary
- bump `ecmaVersion` in ESLint config to 2022

## Testing
- `npm run lint` *(fails: 151 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877cb17586083279578262d668e6e61