### PR TITLE
Add env example instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ dist
 
 node_modules/
 .env
+.env.example
 .wwebjs_auth/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The API exposes endpoints for managing clients and users, fetching Instagram and
     cd Cicero_V2
     npm install
     ```
-2. **Create `.env`** with your configuration:
+2. **Copy `.env.example` to `.env`** and update the values:
     ```ini
     PORT=3000
     DB_USER=cicero


### PR DESCRIPTION
## Summary
- note that `.env.example` is ignored
- instruct devs to copy `.env.example`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877cf79114483279b1d732f036cbc19