### PR TITLE
Add client amplification status flag

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE clients (
   client_insta_status BOOLEAN DEFAULT TRUE,
   client_tiktok VARCHAR,
   client_tiktok_status BOOLEAN DEFAULT TRUE,
+  client_amplify_status BOOLEAN DEFAULT TRUE,
   client_operator VARCHAR,
   client_group VARCHAR,
   tiktok_secuid VARCHAR,

--- a/src/cron/cronInstaLaphar.js
+++ b/src/cron/cronInstaLaphar.js
@@ -13,7 +13,7 @@ async function getActiveClientsIG() {
   const rows = await query(
     `SELECT client_id, nama, client_operator, client_super, client_group
      FROM clients
-     WHERE client_status = true AND client_insta_status = true
+     WHERE client_status = true AND client_insta_status = true AND client_amplify_status = true
      ORDER BY client_id`
   );
   return rows.rows;

--- a/src/cron/cronRekapLink.js
+++ b/src/cron/cronRekapLink.js
@@ -12,7 +12,7 @@ async function getActiveClients() {
   const rows = await query(
     `SELECT client_id, nama, client_operator, client_super, client_group
      FROM clients
-     WHERE client_status=true AND client_insta_status=true
+     WHERE client_status=true AND client_insta_status=true AND client_amplify_status=true
      ORDER BY client_id`
   );
   return rows.rows;

--- a/src/cron/cronTiktokLaphar.js
+++ b/src/cron/cronTiktokLaphar.js
@@ -14,7 +14,7 @@ async function getActiveClientsTiktok() {
   const rows = await query(
     `SELECT client_id, nama, client_operator, client_super, client_group
      FROM clients
-     WHERE client_status = true AND client_tiktok_status = true
+     WHERE client_status = true AND client_tiktok_status = true AND client_amplify_status = true
      ORDER BY client_id`
   );
   return rows.rows;

--- a/src/cron/cronTiktokService.js
+++ b/src/cron/cronTiktokService.js
@@ -12,7 +12,7 @@ import { absensiKomentar } from "../handler/fetchabsensi/tiktok/absensiKomentarT
 async function getActiveClientsTiktok() {
   const { query } = await import("../db/index.js");
   const rows = await query(
-    "SELECT client_id, nama FROM clients WHERE client_status = true AND client_tiktok_status = true ORDER BY client_id"
+    "SELECT client_id, nama FROM clients WHERE client_status = true AND client_tiktok_status = true AND client_amplify_status = true ORDER BY client_id"
   );
   return rows.rows;
 }

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -224,7 +224,7 @@ export async function absensiLikesPerKonten(client_id, opts = {}) {
 
 export async function getActiveClientsIG() {
   const res = await query(
-    `SELECT client_id, client_insta FROM clients WHERE client_status = true AND client_insta_status = true AND client_insta IS NOT NULL`
+    `SELECT client_id, client_insta FROM clients WHERE client_status = true AND client_insta_status = true AND client_amplify_status = true AND client_insta IS NOT NULL`
   );
   return res.rows;
 }

--- a/src/handler/menu/clientRequestHandlers.js
+++ b/src/handler/menu/clientRequestHandlers.js
@@ -329,6 +329,10 @@ export const clientRequestHandlers = {
           key: "client_tiktok_status",
           label: "Status TikTok Aktif (true/false)",
         },
+        {
+          key: "client_amplify_status",
+          label: "Status Amplifikasi (true/false)",
+        },
         { key: "client_type", label: "Tipe Client" },
       ];
       session.updateFieldList = fields;

--- a/src/model/clientModel.js
+++ b/src/model/clientModel.js
@@ -45,10 +45,10 @@ export const findBySuperAdmin = async (waNumber) => {
 // Buat client baru
 export const create = async (client) => {
   const q = `
-    INSERT INTO clients 
-      (client_id, nama, client_type, client_status, client_insta, client_insta_status, client_tiktok, client_tiktok_status, client_operator, client_group, tiktok_secuid, client_super)
+    INSERT INTO clients
+      (client_id, nama, client_type, client_status, client_insta, client_insta_status, client_tiktok, client_tiktok_status, client_amplify_status, client_operator, client_group, tiktok_secuid, client_super)
     VALUES
-      ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
     RETURNING *
   `;
   const values = [
@@ -60,6 +60,7 @@ export const create = async (client) => {
     client.client_insta_status ?? true,
     client.client_tiktok || '',
     client.client_tiktok_status ?? true,
+    client.client_amplify_status ?? true,
     client.client_operator || '',
     client.client_group || '',
     client.tiktok_secuid || '',
@@ -84,10 +85,11 @@ export const update = async (client_id, clientData) => {
       client_insta_status = $6,
       client_tiktok = $7,
       client_tiktok_status = $8,
-      client_operator = $9,
-      client_group = $10,
-      tiktok_secuid = $11,
-      client_super = $12
+      client_amplify_status = $9,
+      client_operator = $10,
+      client_group = $11,
+      tiktok_secuid = $12,
+      client_super = $13
     WHERE client_id = $1
     RETURNING *
   `;
@@ -100,6 +102,7 @@ export const update = async (client_id, clientData) => {
     merged.client_insta_status,
     merged.client_tiktok || '',
     merged.client_tiktok_status,
+    merged.client_amplify_status,
     merged.client_operator,
     merged.client_group,
     merged.tiktok_secuid || '',
@@ -118,7 +121,7 @@ export const remove = async (client_id) => {
 // Ambil semua client aktif IG
 export async function findAllActiveWithInstagram() {
   const res = await query(
-    `SELECT * FROM clients WHERE client_status = true AND client_insta_status = true`
+    `SELECT * FROM clients WHERE client_status = true AND client_insta_status = true AND client_amplify_status = true`
   );
   return res.rows;
 }
@@ -126,7 +129,7 @@ export async function findAllActiveWithInstagram() {
 // Ambil semua client aktif TikTok
 export async function findAllActiveWithTiktok() {
   const res = await query(
-    `SELECT * FROM clients WHERE client_status = true AND client_tiktok_status = true`
+    `SELECT * FROM clients WHERE client_status = true AND client_tiktok_status = true AND client_amplify_status = true`
   );
   return res.rows;
 }

--- a/src/utils/utilsHelper.js
+++ b/src/utils/utilsHelper.js
@@ -69,6 +69,7 @@ export function formatClientInfo(client) {
     `IG Aktif        : ${client.client_insta_status ? "✅ Aktif" : "❌ Tidak aktif"}`,
     `TikTok          : ${client.client_tiktok ? "@" + client.client_tiktok : "-"}`,
     `TikTok Aktif    : ${client.client_tiktok_status ? "✅ Aktif" : "❌ Tidak aktif"}`,
+    `Amplifikasi     : ${client.client_amplify_status ? "✅ Aktif" : "❌ Tidak aktif"}`,
     `Operator WA     : ${client.client_operator || "-"}`,
     `Group WA        : ${client.client_group || "-"}`,
     `Super Admin     : ${client.client_super || "-"}`,

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -55,6 +55,7 @@ export function formatClientData(obj, title = "") {
     "client_insta_status",
     "client_tiktok",
     "client_tiktok_status",
+    "client_amplify_status",
     "client_operator",
     "client_super",
     "client_group",


### PR DESCRIPTION
## Summary
- support new `client_amplify_status` field in `clients` table
- include amplification status when creating or updating clients
- filter cron jobs by amplification status
- show amplification status in client info utilities
- allow updating amplification status via clientrequest menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877da1817bc83278f9a0a0e28c2bcad