### PR TITLE
Add Penmas signup route

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -25,6 +25,15 @@ CREATE TABLE "user" (
   status BOOLEAN DEFAULT TRUE
 );
 
+CREATE TABLE penmas_user (
+  user_id TEXT PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
 CREATE TABLE insta_post (
   shortcode VARCHAR PRIMARY KEY,
   client_id VARCHAR REFERENCES clients(client_id),

--- a/src/model/penmasUserModel.js
+++ b/src/model/penmasUserModel.js
@@ -1,0 +1,19 @@
+import { query } from '../repository/db.js';
+
+export async function findByUsername(username) {
+  const res = await query(
+    'SELECT * FROM penmas_user WHERE username = $1',
+    [username]
+  );
+  return res.rows[0] || null;
+}
+
+export async function createUser(data) {
+  const res = await query(
+    `INSERT INTO penmas_user (user_id, username, password_hash, role)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [data.user_id, data.username, data.password_hash, data.role]
+  );
+  return res.rows[0];
+}


### PR DESCRIPTION
## Summary
- allow creating Penmas users via `/api/auth/penmas-register`
- store Penmas user accounts in new `penmas_user` table
- test registration endpoint logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687867753eb483279542a758ef15ca44