### PR TITLE
Align premium subscription API with front end

### DIFF
--- a/src/controller/premiumSubscriptionController.js
+++ b/src/controller/premiumSubscriptionController.js
@@ -48,7 +48,7 @@ export async function deleteSubscription(req, res, next) {
 
 export async function getActiveSubscription(req, res, next) {
   try {
-    const row = await service.findActiveSubscriptionByUser(req.params.username);
+    const row = await service.findActiveSubscriptionByUser(req.params.userId);
     sendSuccess(res, row);
   } catch (err) {
     next(err);

--- a/src/controller/subscriptionConfirmationController.js
+++ b/src/controller/subscriptionConfirmationController.js
@@ -1,0 +1,19 @@
+import waClient from '../service/waService.js';
+import { getAdminWAIds } from '../utils/waHelper.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function sendConfirmation(req, res, next) {
+  try {
+    const { user_id: userId } = req.body;
+    if (!userId) {
+      return res.status(400).json({ error: 'user_id required' });
+    }
+    const msg = `*Konfirmasi Pembayaran Premium*\nUser ID: *${userId}*`;
+    for (const admin of getAdminWAIds()) {
+      waClient.sendMessage(admin, msg).catch(() => {});
+    }
+    sendSuccess(res, { ok: true }, 201);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/controller/subscriptionRegistrationController.js
+++ b/src/controller/subscriptionRegistrationController.js
@@ -23,7 +23,7 @@ export async function getRegistrationById(req, res, next) {
 
 export async function createRegistration(req, res, next) {
   try {
-    const existing = await service.findPendingByUsername(req.body.username);
+    const existing = await service.findPendingByUsername(req.body.user_id);
     if (existing)
       return res
         .status(400)
@@ -36,7 +36,7 @@ export async function createRegistration(req, res, next) {
       const adminIds = getAdminWAIds();
       let msg = '*Permintaan Subscription Premium*\n';
       msg += `ID Permintaan: *${row.registration_id}*\n`;
-      msg += `Username Instagram : *${row.username}*\n`;
+      msg += `User ID : *${row.username}*\n`;
       if (row.amount) msg += `Nominal : *${row.amount}*\n`;
       msg +=
         `Balas *GRANTSUB#${row.registration_id}* untuk memberi akses atau *DENYSUB#${row.registration_id}* untuk menolak.`;

--- a/src/model/premiumSubscriptionModel.js
+++ b/src/model/premiumSubscriptionModel.js
@@ -7,10 +7,10 @@ export async function createSubscription(data) {
      ) VALUES ($1,$2,$3,$4,COALESCE($5, NOW()))
      RETURNING *`,
     [
-      data.username,
-      data.start_date,
+      data.userId || data.username,
+      data.start_date || new Date(),
       data.end_date || null,
-      data.is_active ?? true,
+      data.is_active ?? false,
       data.created_at || null,
     ],
   );
@@ -32,22 +32,22 @@ export async function findSubscriptionById(id) {
   return res.rows[0] || null;
 }
 
-export async function findActiveSubscriptionByUser(username) {
+export async function findActiveSubscriptionByUser(userId) {
   const res = await query(
     `SELECT * FROM premium_subscription
      WHERE username=$1 AND is_active = true
      ORDER BY start_date DESC LIMIT 1`,
-    [username],
+    [userId],
   );
   return res.rows[0] || null;
 }
 
-export async function findLatestSubscriptionByUser(username) {
+export async function findLatestSubscriptionByUser(userId) {
   const res = await query(
     `SELECT * FROM premium_subscription
      WHERE username=$1
      ORDER BY start_date DESC LIMIT 1`,
-    [username],
+    [userId],
   );
   return res.rows[0] || null;
 }
@@ -65,7 +65,7 @@ export async function updateSubscription(id, data) {
      WHERE subscription_id=$1 RETURNING *`,
     [
       id,
-      merged.username,
+      merged.userId || merged.username,
       merged.start_date,
       merged.end_date || null,
       merged.is_active,

--- a/src/model/subscriptionRegistrationModel.js
+++ b/src/model/subscriptionRegistrationModel.js
@@ -8,7 +8,7 @@ export async function createRegistration(data) {
      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8, NOW()))
      RETURNING *`,
     [
-      data.username,
+      data.user_id || data.username,
       data.nama_rekening || null,
       data.nomor_rekening || null,
       data.phone || null,
@@ -36,12 +36,12 @@ export async function findRegistrationById(id) {
   return res.rows[0] || null;
 }
 
-export async function findPendingByUsername(username) {
+export async function findPendingByUsername(userId) {
   const res = await query(
     `SELECT * FROM subscription_registration
      WHERE username=$1 AND status='pending'
      ORDER BY created_at DESC LIMIT 1`,
-    [username],
+    [userId],
   );
   return res.rows[0] || null;
 }
@@ -62,7 +62,7 @@ export async function updateRegistration(id, data) {
      WHERE registration_id=$1 RETURNING *`,
     [
       id,
-      merged.username,
+      merged.user_id || merged.username,
       merged.nama_rekening || null,
       merged.nomor_rekening || null,
       merged.phone || null,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -12,6 +12,7 @@ import logRoutes from './logRoutes.js';
 import linkReportRoutes from './linkReportRoutes.js';
 import premiumSubscriptionRoutes from './premiumSubscriptionRoutes.js';
 import subscriptionRegistrationRoutes from './subscriptionRegistrationRoutes.js';
+import subscriptionConfirmationRoutes from './subscriptionConfirmationRoutes.js';
 import amplifyRoutes from './amplifyRoutes.js';
 
 const router = express.Router();
@@ -29,6 +30,7 @@ router.use('/logs', logRoutes);
 router.use('/link-reports', linkReportRoutes);
 router.use('/premium-subscriptions', premiumSubscriptionRoutes);
 router.use('/subscription-registrations', subscriptionRegistrationRoutes);
+router.use('/subscription-confirmations', subscriptionConfirmationRoutes);
 router.use('/amplify', amplifyRoutes);
 
 export default router;

--- a/src/routes/premiumSubscriptionRoutes.js
+++ b/src/routes/premiumSubscriptionRoutes.js
@@ -4,7 +4,7 @@ import * as controller from '../controller/premiumSubscriptionController.js';
 const router = express.Router();
 
 router.get('/', controller.getAllSubscriptions);
-router.get('/user/:username/active', controller.getActiveSubscription);
+router.get('/user/:userId/active', controller.getActiveSubscription);
 router.get('/:id', controller.getSubscriptionById);
 router.post('/', controller.createSubscription);
 router.put('/:id', controller.updateSubscription);

--- a/src/routes/subscriptionConfirmationRoutes.js
+++ b/src/routes/subscriptionConfirmationRoutes.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as controller from '../controller/subscriptionConfirmationController.js';
+
+const router = express.Router();
+
+router.post('/', controller.sendConfirmation);
+
+export default router;

--- a/src/service/premiumSubscriptionService.js
+++ b/src/service/premiumSubscriptionService.js
@@ -6,11 +6,11 @@ export const getSubscriptions = async () => model.getSubscriptions();
 
 export const findSubscriptionById = async id => model.findSubscriptionById(id);
 
-export const findActiveSubscriptionByUser = async username =>
-  model.findActiveSubscriptionByUser(username);
+export const findActiveSubscriptionByUser = async userId =>
+  model.findActiveSubscriptionByUser(userId);
 
-export const findLatestSubscriptionByUser = async username =>
-  model.findLatestSubscriptionByUser(username);
+export const findLatestSubscriptionByUser = async userId =>
+  model.findLatestSubscriptionByUser(userId);
 
 export const updateSubscription = async (id, data) =>
   model.updateSubscription(id, data);

--- a/src/service/subscriptionRegistrationService.js
+++ b/src/service/subscriptionRegistrationService.js
@@ -6,8 +6,8 @@ export const getRegistrations = async () => model.getRegistrations();
 
 export const findRegistrationById = async id => model.findRegistrationById(id);
 
-export const findPendingByUsername = async username =>
-  model.findPendingByUsername(username);
+export const findPendingByUsername = async userId =>
+  model.findPendingByUsername(userId);
 
 export const updateRegistration = async (id, data) =>
   model.updateRegistration(id, data);

--- a/tests/premiumSubscriptionModel.test.js
+++ b/tests/premiumSubscriptionModel.test.js
@@ -25,12 +25,12 @@ beforeEach(() => {
 
 test('createSubscription inserts row', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
-  const data = { username: 'abc', start_date: '2024-01-01' };
+  const data = { userId: 'abc', start_date: '2024-01-01' };
   const res = await createSubscription(data);
   expect(res).toEqual({ subscription_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('INSERT INTO premium_subscription'),
-    ['abc', '2024-01-01', null, true, null]
+    ['abc', '2024-01-01', null, false, null]
   );
 });
 

--- a/tests/subscriptionRegistrationController.test.js
+++ b/tests/subscriptionRegistrationController.test.js
@@ -34,7 +34,7 @@ beforeEach(() => {
 test('sends WhatsApp notification when registration created', async () => {
   mockFindPending.mockResolvedValueOnce(null);
   mockCreateRegistration.mockResolvedValueOnce({ registration_id: 1, username: 'user', amount: 50 });
-  const req = { body: { username: 'user', amount: 50 } };
+  const req = { body: { user_id: 'user', amount: 50 } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const next = jest.fn();
 
@@ -49,7 +49,7 @@ test('sends WhatsApp notification when registration created', async () => {
 
 test('returns 400 when pending registration exists', async () => {
   mockFindPending.mockResolvedValueOnce({ registration_id: 2 });
-  const req = { body: { username: 'user' } };
+  const req = { body: { user_id: 'user' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const next = jest.fn();
 


### PR DESCRIPTION
## Summary
- use `userId` param for premium subscription endpoints
- add subscription confirmation route that notifies admins via WhatsApp
- accept `user_id` in subscription registration service
- update related tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68787734b00083278a2742f921ab010d