### PR TITLE
Fix subscription registration username handling

### DIFF
--- a/src/controller/subscriptionRegistrationController.js
+++ b/src/controller/subscriptionRegistrationController.js
@@ -23,7 +23,7 @@ export async function getRegistrationById(req, res, next) {
 
 export async function createRegistration(req, res, next) {
   try {
-    const existing = await service.findPendingByUsername(req.body.user_id);
+    const existing = await service.findPendingByUsername(req.body.username);
     if (existing)
       return res
         .status(400)

--- a/src/model/subscriptionRegistrationModel.js
+++ b/src/model/subscriptionRegistrationModel.js
@@ -8,7 +8,7 @@ export async function createRegistration(data) {
      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8, NOW()))
      RETURNING *`,
     [
-      data.user_id || data.username,
+      data.username,
       data.nama_rekening || null,
       data.nomor_rekening || null,
       data.phone || null,
@@ -62,7 +62,7 @@ export async function updateRegistration(id, data) {
      WHERE registration_id=$1 RETURNING *`,
     [
       id,
-      merged.user_id || merged.username,
+      merged.username,
       merged.nama_rekening || null,
       merged.nomor_rekening || null,
       merged.phone || null,

--- a/tests/subscriptionRegistrationController.test.js
+++ b/tests/subscriptionRegistrationController.test.js
@@ -34,7 +34,7 @@ beforeEach(() => {
 test('sends WhatsApp notification when registration created', async () => {
   mockFindPending.mockResolvedValueOnce(null);
   mockCreateRegistration.mockResolvedValueOnce({ registration_id: 1, username: 'user', amount: 50 });
-  const req = { body: { user_id: 'user', amount: 50 } };
+  const req = { body: { username: 'user', amount: 50 } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const next = jest.fn();
 
@@ -49,7 +49,7 @@ test('sends WhatsApp notification when registration created', async () => {
 
 test('returns 400 when pending registration exists', async () => {
   mockFindPending.mockResolvedValueOnce({ registration_id: 2 });
-  const req = { body: { user_id: 'user' } };
+  const req = { body: { username: 'user' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const next = jest.fn();
 

--- a/tests/subscriptionRegistrationModel.test.js
+++ b/tests/subscriptionRegistrationModel.test.js
@@ -32,6 +32,17 @@ test('createRegistration inserts row', async () => {
   );
 });
 
+test('createRegistration ignores user_id field', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ registration_id: 2 }] });
+  const data = { username: 'u2', user_id: 'ignored', amount: 5 };
+  const res = await createRegistration(data);
+  expect(res).toEqual({ registration_id: 2 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO subscription_registration'),
+    ['u2', null, null, null, 5, 'pending', null, null]
+  );
+});
+
 test('getRegistrations selects all', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ registration_id: 1 }] });
   const rows = await getRegistrations();


### PR DESCRIPTION
## Summary
- fix username field handling in subscription registration model and controller
- update unit tests for new username requirement
- ensure `createRegistration` ignores any `user_id` field

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68789ba4effc83279436f9c0f42288f2