### PR TITLE
Add Penmas News backend routes

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -1,0 +1,95 @@
+# Penmas News Backend Design
+*Last updated: 2025-08-30*
+
+This document proposes a basic backend structure to support the **Penmas News** Android app. The application currently stores data in `SharedPreferences`. The following design migrates those records to a PostgreSQL database and exposes RESTful endpoints.
+
+## Database Schema
+
+### `users`
+Stores login credentials and profile data.
+
+```sql
+CREATE TABLE users (
+  user_id SERIAL PRIMARY KEY,
+  username VARCHAR(50) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  role VARCHAR(20) NOT NULL, -- penulis/editor
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `editorial_event`
+Events from the editorial calendar.
+
+```sql
+CREATE TABLE editorial_event (
+  event_id SERIAL PRIMARY KEY,
+  event_date DATE NOT NULL,
+  topic TEXT NOT NULL,
+  assignee VARCHAR(50),
+  status VARCHAR(20) DEFAULT 'draft',
+  content TEXT,
+  summary TEXT,
+  image_path TEXT,
+  created_by INTEGER REFERENCES users(user_id),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `approval_request`
+Records waiting for editor approval.
+
+```sql
+CREATE TABLE approval_request (
+  request_id SERIAL PRIMARY KEY,
+  event_id INTEGER REFERENCES editorial_event(event_id),
+  requested_by INTEGER REFERENCES users(user_id),
+  status VARCHAR(20) DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `change_log`
+Tracks changes to articles.
+
+```sql
+CREATE TABLE change_log (
+  log_id SERIAL PRIMARY KEY,
+  event_id INTEGER REFERENCES editorial_event(event_id),
+  user_id INTEGER REFERENCES users(user_id),
+  status VARCHAR(20),
+  changes TEXT,
+  logged_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## Data Migration Steps
+
+1. Extract the JSON arrays from `SharedPreferences` (`editorial_events`, `approval_requests`, and `change_logs`).
+2. For each item, insert a row into the corresponding table above. Use a one-off script or an Android `WorkManager` task that runs once.
+3. After verifying the migration, remove the local storage calls and rely solely on the API.
+
+## REST Endpoints
+
+### Authentication
+- `POST /api/auth/penmas-login` – body: `{ username, password }` → returns `{ success, token, user }`.
+- `POST /api/auth/penmas-register` – body: `{ username, password, role }` → returns `{ success, user_id }`.
+
+### Editorial Calendar
+- `GET /api/events` – list all events for the authenticated user.
+- `POST /api/events` – create a new event.
+- `PUT /api/events/:id` – update an event.
+- `DELETE /api/events/:id` – remove an event.
+
+### Approval Workflow
+- `GET /api/approvals` – list pending approval requests.
+- `POST /api/approvals` – create a new approval request for an event.
+- `PUT /api/approvals/:id` – update the status (`approved`/`rejected`).
+
+### Change Logs
+- `GET /api/events/:id/logs` – view change history for an event.
+- `POST /api/events/:id/logs` – append a new log entry.
+
+All routes require JWT authentication except registration and login. Roles (`penulis`, `editor`) determine access permissions.
+

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -262,3 +262,34 @@ CREATE TABLE IF NOT EXISTS subscription_registration (
     reviewed_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS editorial_event (
+  event_id SERIAL PRIMARY KEY,
+  event_date DATE NOT NULL,
+  topic TEXT NOT NULL,
+  assignee VARCHAR(50),
+  status VARCHAR(20) DEFAULT 'draft',
+  content TEXT,
+  summary TEXT,
+  image_path TEXT,
+  created_by TEXT REFERENCES penmas_user(user_id),
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS approval_request (
+  request_id SERIAL PRIMARY KEY,
+  event_id INTEGER REFERENCES editorial_event(event_id),
+  requested_by TEXT REFERENCES penmas_user(user_id),
+  status VARCHAR(20) DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS change_log (
+  log_id SERIAL PRIMARY KEY,
+  event_id INTEGER REFERENCES editorial_event(event_id),
+  user_id TEXT REFERENCES penmas_user(user_id),
+  status VARCHAR(20),
+  changes TEXT,
+  logged_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/controller/approvalRequestController.js
+++ b/src/controller/approvalRequestController.js
@@ -1,0 +1,30 @@
+import * as approvalModel from '../model/approvalRequestModel.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function getApprovals(req, res, next) {
+  try {
+    const data = await approvalModel.getApprovalRequests();
+    sendSuccess(res, data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createApproval(req, res, next) {
+  try {
+    const body = { ...req.body, requested_by: req.penmasUser.user_id };
+    const ap = await approvalModel.createRequest(body);
+    sendSuccess(res, ap, 201);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateApproval(req, res, next) {
+  try {
+    const ap = await approvalModel.updateRequest(Number(req.params.id), req.body);
+    sendSuccess(res, ap);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/controller/changeLogController.js
+++ b/src/controller/changeLogController.js
@@ -1,0 +1,25 @@
+import * as logModel from '../model/changeLogModel.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function getLogs(req, res, next) {
+  try {
+    const data = await logModel.getLogsByEvent(Number(req.params.id));
+    sendSuccess(res, data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function addLog(req, res, next) {
+  try {
+    const body = {
+      ...req.body,
+      event_id: Number(req.params.id),
+      user_id: req.penmasUser.user_id
+    };
+    const log = await logModel.createLog(body);
+    sendSuccess(res, log, 201);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/controller/editorialEventController.js
+++ b/src/controller/editorialEventController.js
@@ -1,0 +1,39 @@
+import * as eventModel from '../model/editorialEventModel.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function getEvents(req, res, next) {
+  try {
+    const data = await eventModel.getEvents(req.penmasUser.user_id);
+    sendSuccess(res, data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createEvent(req, res, next) {
+  try {
+    const data = { ...req.body, created_by: req.penmasUser.user_id };
+    const ev = await eventModel.createEvent(data);
+    sendSuccess(res, ev, 201);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateEvent(req, res, next) {
+  try {
+    const ev = await eventModel.updateEvent(Number(req.params.id), req.body);
+    sendSuccess(res, ev);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteEvent(req, res, next) {
+  try {
+    const ev = await eventModel.deleteEvent(Number(req.params.id));
+    sendSuccess(res, ev);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/middleware/penmasAuth.js
+++ b/src/middleware/penmasAuth.js
@@ -1,0 +1,18 @@
+import jwt from 'jsonwebtoken';
+import redis from '../config/redis.js';
+
+export async function verifyPenmasToken(req, res, next) {
+  const token = req.cookies?.token || req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ success: false, message: 'Token required' });
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const exists = await redis.get(`login_token:${token}`);
+    if (!exists || !String(exists).startsWith('penmas:')) {
+      return res.status(401).json({ success: false, message: 'Invalid token' });
+    }
+    req.penmasUser = payload;
+    next();
+  } catch {
+    return res.status(401).json({ success: false, message: 'Invalid token' });
+  }
+}

--- a/src/model/approvalRequestModel.js
+++ b/src/model/approvalRequestModel.js
@@ -1,0 +1,50 @@
+import { query } from '../repository/db.js';
+
+export async function getApprovalRequests() {
+  const res = await query('SELECT * FROM approval_request ORDER BY created_at DESC');
+  return res.rows;
+}
+
+export async function findRequestById(id) {
+  const res = await query('SELECT * FROM approval_request WHERE request_id=$1', [id]);
+  return res.rows[0] || null;
+}
+
+export async function createRequest(data) {
+  const res = await query(
+    `INSERT INTO approval_request (
+      event_id, requested_by, status, created_at, updated_at
+     ) VALUES ($1,$2,$3, COALESCE($4, NOW()), COALESCE($5, NOW()))
+     RETURNING *`,
+    [
+      data.event_id,
+      data.requested_by,
+      data.status || 'pending',
+      data.created_at || null,
+      data.updated_at || null
+    ]
+  );
+  return res.rows[0];
+}
+
+export async function updateRequest(id, data) {
+  const old = await findRequestById(id);
+  if (!old) return null;
+  const merged = { ...old, ...data };
+  const res = await query(
+    `UPDATE approval_request SET
+      event_id=$2,
+      requested_by=$3,
+      status=$4,
+      updated_at=COALESCE($5, NOW())
+     WHERE request_id=$1 RETURNING *`,
+    [
+      id,
+      merged.event_id,
+      merged.requested_by,
+      merged.status,
+      data.updated_at || null
+    ]
+  );
+  return res.rows[0];
+}

--- a/src/model/changeLogModel.js
+++ b/src/model/changeLogModel.js
@@ -1,0 +1,26 @@
+import { query } from '../repository/db.js';
+
+export async function getLogsByEvent(eventId) {
+  const res = await query(
+    'SELECT * FROM change_log WHERE event_id=$1 ORDER BY logged_at ASC',
+    [eventId]
+  );
+  return res.rows;
+}
+
+export async function createLog(data) {
+  const res = await query(
+    `INSERT INTO change_log (
+      event_id, user_id, status, changes, logged_at
+     ) VALUES ($1,$2,$3,$4, COALESCE($5, NOW()))
+     RETURNING *`,
+    [
+      data.event_id,
+      data.user_id,
+      data.status,
+      data.changes || null,
+      data.logged_at || null
+    ]
+  );
+  return res.rows[0];
+}

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -1,0 +1,68 @@
+import { query } from '../repository/db.js';
+
+export async function getEvents(userId) {
+  const res = await query(
+    'SELECT * FROM editorial_event WHERE created_by = $1 ORDER BY event_date ASC',
+    [userId]
+  );
+  return res.rows;
+}
+
+export async function findEventById(id) {
+  const res = await query('SELECT * FROM editorial_event WHERE event_id = $1', [id]);
+  return res.rows[0] || null;
+}
+
+export async function createEvent(data) {
+  const res = await query(
+    `INSERT INTO editorial_event (
+      event_date, topic, assignee, status, content, summary, image_path, created_by, created_at
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8, COALESCE($9, NOW()))
+     RETURNING *`,
+    [
+      data.event_date,
+      data.topic,
+      data.assignee || null,
+      data.status || 'draft',
+      data.content || null,
+      data.summary || null,
+      data.image_path || null,
+      data.created_by,
+      data.created_at || null
+    ]
+  );
+  return res.rows[0];
+}
+
+export async function updateEvent(id, data) {
+  const old = await findEventById(id);
+  if (!old) return null;
+  const merged = { ...old, ...data };
+  const res = await query(
+    `UPDATE editorial_event SET
+      event_date=$2,
+      topic=$3,
+      assignee=$4,
+      status=$5,
+      content=$6,
+      summary=$7,
+      image_path=$8
+     WHERE event_id=$1 RETURNING *`,
+    [
+      id,
+      merged.event_date,
+      merged.topic,
+      merged.assignee || null,
+      merged.status,
+      merged.content || null,
+      merged.summary || null,
+      merged.image_path || null
+    ]
+  );
+  return res.rows[0];
+}
+
+export async function deleteEvent(id) {
+  const res = await query('DELETE FROM editorial_event WHERE event_id=$1 RETURNING *', [id]);
+  return res.rows[0] || null;
+}

--- a/src/routes/approvalRequestRoutes.js
+++ b/src/routes/approvalRequestRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import * as controller from '../controller/approvalRequestController.js';
+import { verifyPenmasToken } from '../middleware/penmasAuth.js';
+
+const router = express.Router();
+
+router.use(verifyPenmasToken);
+router.get('/', controller.getApprovals);
+router.post('/', controller.createApproval);
+router.put('/:id', controller.updateApproval);
+
+export default router;

--- a/src/routes/editorialEventRoutes.js
+++ b/src/routes/editorialEventRoutes.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import * as controller from '../controller/editorialEventController.js';
+import { verifyPenmasToken } from '../middleware/penmasAuth.js';
+import * as logController from '../controller/changeLogController.js';
+
+const router = express.Router();
+
+router.use(verifyPenmasToken);
+router.get('/', controller.getEvents);
+router.post('/', controller.createEvent);
+router.put('/:id', controller.updateEvent);
+router.delete('/:id', controller.deleteEvent);
+router.get('/:id/logs', logController.getLogs);
+router.post('/:id/logs', logController.addLog);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,6 +14,8 @@ import premiumSubscriptionRoutes from './premiumSubscriptionRoutes.js';
 import subscriptionRegistrationRoutes from './subscriptionRegistrationRoutes.js';
 import subscriptionConfirmationRoutes from './subscriptionConfirmationRoutes.js';
 import amplifyRoutes from './amplifyRoutes.js';
+import editorialEventRoutes from './editorialEventRoutes.js';
+import approvalRequestRoutes from './approvalRequestRoutes.js';
 
 const router = express.Router();
 
@@ -28,6 +30,8 @@ router.use('/oauth', oauthRoutes);
 router.use('/metadata', metaRoutes);
 router.use('/logs', logRoutes);
 router.use('/link-reports', linkReportRoutes);
+router.use('/events', editorialEventRoutes);
+router.use('/approvals', approvalRequestRoutes);
 router.use('/premium-subscriptions', premiumSubscriptionRoutes);
 router.use('/subscription-registrations', subscriptionRegistrationRoutes);
 router.use('/subscription-confirmations', subscriptionConfirmationRoutes);


### PR DESCRIPTION
## Summary
- extend SQL schema for editorial events, approvals and change logs
- implement models, controllers and routes for Penmas News API
- add JWT middleware `verifyPenmasToken`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68789f6e12188327b249e90e41c5853b