### PR TITLE
Fix date parsing for editorial events

### DIFF
--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -1,4 +1,5 @@
 import { query } from '../repository/db.js';
+import { formatIsoDate } from '../utils/utilsHelper.js';
 
 export async function getEvents(userId) {
   const res = await query(
@@ -14,13 +15,14 @@ export async function findEventById(id) {
 }
 
 export async function createEvent(data) {
+  const eventDate = formatIsoDate(data.event_date);
   const res = await query(
     `INSERT INTO editorial_event (
       event_date, topic, assignee, status, content, summary, image_path, created_by, created_at
      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8, COALESCE($9, NOW()))
      RETURNING *`,
     [
-      data.event_date,
+      eventDate,
       data.topic,
       data.assignee || null,
       data.status || 'draft',
@@ -38,6 +40,7 @@ export async function updateEvent(id, data) {
   const old = await findEventById(id);
   if (!old) return null;
   const merged = { ...old, ...data };
+  merged.event_date = formatIsoDate(merged.event_date);
   const res = await query(
     `UPDATE editorial_event SET
       event_date=$2,

--- a/src/utils/utilsHelper.js
+++ b/src/utils/utilsHelper.js
@@ -145,3 +145,16 @@ export function extractFirstUrl(text) {
   const match = String(text).match(/https?:\/\/\S+/);
   return match ? match[0] : null;
 }
+
+export function formatIsoDate(value) {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  const str = String(value).trim();
+  let match = str.match(/^(\d{2})[-/](\d{2})[-/](\d{4})$/);
+  if (match) return `${match[3]}-${match[2]}-${match[1]}`;
+  match = str.match(/^(\d{4})[-/](\d{2})[-/](\d{2})$/);
+  if (match) return `${match[1]}-${match[2]}-${match[3]}`;
+  const d = new Date(str);
+  if (!Number.isNaN(d)) return d.toISOString().slice(0, 10);
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `formatIsoDate` helper to convert various date string formats to `YYYY-MM-DD`
- use `formatIsoDate` in `editorialEventModel` when inserting or updating events

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878fad019748327928a2a99947bf427