### PR TITLE
Add dashboard login docs

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -11,6 +11,7 @@ for PostgreSQL but can work with MySQL or SQLite via the DB adapter.
 |------------|---------|
 | clients | master table for registered organisations |
 | user | members belonging to a client |
+| dashboard_user | login credentials for dashboard access |
 | insta_post | Instagram posts fetched for each client |
 | insta_like | cached likes for an Instagram post |
 | insta_comment | cached comments for an Instagram post |
@@ -60,6 +61,15 @@ Holds users belonging to a client.
 - `insta`, `tiktok` – social media handles
 - `client_id` – foreign key referencing `clients(client_id)`
 - `status` – boolean flag
+
+### `dashboard_user`
+Credentials for the web dashboard login.
+- `user_id` – primary key generated with `uuid.v4()`
+- `username` – unique login name
+- `password_hash` – bcrypt hashed password
+- `role` – permission level such as `admin` or `operator`
+- `client_id` – optional link to `clients`
+- `created_at`, `updated_at` – timestamps
 
 ### `insta_post`
 Stores Instagram posts fetched for a client.

--- a/docs/frontend_login_scaling.md
+++ b/docs/frontend_login_scaling.md
@@ -1,0 +1,58 @@
+# Frontend Login Scaling Scenario
+*Last updated: 2025-07-16*
+
+This guide describes a secure approach for handling login and registration on the web dashboard. It introduces a dedicated table `dashboard_user` so credentials are separated from the existing `user` table. The workflow aligns with the current JWT authentication model used across Cicero_V2.
+
+## 1. Database Table
+
+```sql
+CREATE TABLE dashboard_user (
+  user_id TEXT PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL,
+  client_id VARCHAR REFERENCES clients(client_id),
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+- `user_id` is generated with `uuid.v4()`.
+- `password_hash` stores a bcrypt hash of the plaintext password.
+- `role` can be `admin`, `operator` or other roles required by the dashboard.
+- `client_id` links an account to a specific organisation if needed.
+
+## 2. Registration Endpoint
+
+Expose `/api/auth/dashboard-register`:
+
+1. Validate `username`, `password` and optional `role` and `client_id`.
+2. Ensure the username is unique in `dashboard_user`.
+3. Hash the password with `bcrypt.hash` and insert the new row.
+4. Return `201 Created` with the new `user_id`.
+
+## 3. Login Endpoint
+
+Expose `/api/auth/dashboard-login`:
+
+1. Validate `username` and `password`.
+2. Fetch the record from `dashboard_user` and verify the password with `bcrypt.compare`.
+3. On success generate a JWT containing `user_id` and `role`.
+4. Store the token in Redis with a two-hour expiry and return it in the response and as a `token` cookie.
+
+## 4. Middleware
+
+Create `verifyDashboardToken` to protect private routes:
+
+1. Check the `Authorization` header or `token` cookie.
+2. Verify the JWT using `process.env.JWT_SECRET` and confirm the token exists in Redis.
+3. Attach `req.dashboardUser` to the request object on success.
+
+## 5. Scaling Notes
+
+- Use HTTPS in production and enforce rate limiting on the login routes.
+- Store active tokens in Redis so the backend can invalidate sessions at any time.
+- Index `username` and `user_id` in the database to keep lookups fast when the number of users grows.
+- Log login attempts to monitor suspicious behaviour and audit access.
+
+This setup mirrors the `penmas_user` flow and fits the current architecture, allowing the web frontend to scale independently from the mobile app login system.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -34,6 +34,16 @@ CREATE TABLE penmas_user (
   updated_at TIMESTAMP DEFAULT NOW()
 );
 
+CREATE TABLE dashboard_user (
+  user_id TEXT PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL,
+  client_id VARCHAR REFERENCES clients(client_id),
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
 CREATE TABLE insta_post (
   shortcode VARCHAR PRIMARY KEY,
   client_id VARCHAR REFERENCES clients(client_id),

--- a/src/model/dashboardUserModel.js
+++ b/src/model/dashboardUserModel.js
@@ -1,0 +1,20 @@
+import { query } from '../repository/db.js';
+
+export async function findByUsername(username) {
+  const res = await query(
+    'SELECT * FROM dashboard_user WHERE username = $1',
+    [username]
+  );
+  return res.rows[0] || null;
+}
+
+export async function createUser(data) {
+  const res = await query(
+    `INSERT INTO dashboard_user (user_id, username, password_hash, role, client_id)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [data.user_id, data.username, data.password_hash, data.role, data.client_id]
+  );
+  return res.rows[0];
+}
+


### PR DESCRIPTION
## Summary
- document frontend login scenario with separate table
- expand database structure with `dashboard_user`
- update SQL schema for new table
- add `dashboardUserModel` for querying credentials

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879d35e11348327a74f9474d36782f9