### PR TITLE
Update schedule dates to timestamp

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -24,7 +24,7 @@ Events from the editorial calendar.
 ```sql
 CREATE TABLE editorial_event (
   event_id SERIAL PRIMARY KEY,
-  event_date DATE NOT NULL,
+  event_date TIMESTAMP NOT NULL,
   topic TEXT NOT NULL,
   assignee VARCHAR(50),
   status VARCHAR(20) DEFAULT 'draft',
@@ -35,6 +35,9 @@ CREATE TABLE editorial_event (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```
+
+The `event_date` column uses a timestamp so the schedule can include time of day.
+In list views, the API returns `event_date` formatted as `dd/mm/yyyy`.
 
 ### `approval_request`
 Records waiting for editor approval.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -265,7 +265,7 @@ CREATE TABLE IF NOT EXISTS subscription_registration (
 
 CREATE TABLE IF NOT EXISTS editorial_event (
   event_id SERIAL PRIMARY KEY,
-  event_date DATE NOT NULL,
+  event_date TIMESTAMP NOT NULL,
   topic TEXT NOT NULL,
   assignee VARCHAR(50),
   status VARCHAR(20) DEFAULT 'draft',

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -1,12 +1,15 @@
 import { query } from '../repository/db.js';
-import { formatIsoDate } from '../utils/utilsHelper.js';
+import { formatIsoTimestamp, formatDdMmYyyy } from '../utils/utilsHelper.js';
 
 export async function getEvents(userId) {
   const res = await query(
     'SELECT * FROM editorial_event WHERE created_by = $1 ORDER BY event_date ASC',
     [userId]
   );
-  return res.rows;
+  return res.rows.map((row) => ({
+    ...row,
+    event_date: formatDdMmYyyy(row.event_date),
+  }));
 }
 
 export async function findEventById(id) {
@@ -15,7 +18,7 @@ export async function findEventById(id) {
 }
 
 export async function createEvent(data) {
-  const eventDate = formatIsoDate(data.event_date);
+  const eventDate = formatIsoTimestamp(data.event_date);
   const res = await query(
     `INSERT INTO editorial_event (
       event_date, topic, assignee, status, content, summary, image_path, created_by, created_at
@@ -40,7 +43,7 @@ export async function updateEvent(id, data) {
   const old = await findEventById(id);
   if (!old) return null;
   const merged = { ...old, ...data };
-  merged.event_date = formatIsoDate(merged.event_date);
+  merged.event_date = formatIsoTimestamp(merged.event_date);
   const res = await query(
     `UPDATE editorial_event SET
       event_date=$2,

--- a/src/utils/utilsHelper.js
+++ b/src/utils/utilsHelper.js
@@ -146,6 +146,37 @@ export function extractFirstUrl(text) {
   return match ? match[0] : null;
 }
 
+export function formatDdMmYyyy(value) {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d)) return null;
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year = d.getFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+export function formatIsoTimestamp(value) {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  const str = String(value).trim();
+  // dd/mm/yyyy or dd-mm-yyyy optionally with time HH:MM
+  let match = str.match(/^(\d{2})[-/](\d{2})[-/](\d{4})(?:[ T](\d{2}):(\d{2}))?$/);
+  if (match) {
+    const [, d, m, y, hh = '00', mm = '00'] = match;
+    return `${y}-${m}-${d}T${hh}:${mm}:00Z`;
+  }
+  // yyyy-mm-dd or yyyy/mm/dd optionally with time
+  match = str.match(/^(\d{4})[-/](\d{2})[-/](\d{2})(?:[ T](\d{2}):(\d{2}))?$/);
+  if (match) {
+    const [, y, m, d, hh = '00', mm = '00'] = match;
+    return `${y}-${m}-${d}T${hh}:${mm}:00Z`;
+  }
+  const d = new Date(str);
+  if (!Number.isNaN(d)) return d.toISOString();
+  return null;
+}
+
 export function formatIsoDate(value) {
   if (!value) return null;
   if (value instanceof Date) return value.toISOString().slice(0, 10);


### PR DESCRIPTION
## Summary
- store editorial event dates as `TIMESTAMP` instead of `DATE`
- add helpers to format timestamp and dd/mm/yyyy
- return formatted date for event list
- document timestamp usage

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879d59a541c83279414f388598c8ade