### PR TITLE
Adjust dashboard auth defaults

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -93,7 +93,9 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  const { username, password, role = 'operator', client_id = null } = req.body;
+  const { username, password, client_id = null } = req.body;
+  const role = 'operator';
+  const status = true;
   if (!username || !password) {
     return res
       .status(400)
@@ -107,7 +109,6 @@ router.post('/dashboard-register', async (req, res) => {
   }
   const user_id = uuidv4();
   const password_hash = await bcrypt.hash(password, 10);
-  const status = role === 'admin' ? false : true;
   const user = await dashboardUserModel.createUser({
     user_id,
     username,
@@ -116,11 +117,6 @@ router.post('/dashboard-register', async (req, res) => {
     status,
     client_id,
   });
-  if (role === 'admin') {
-    notifyAdmin(
-      `\uD83D\uDCCB Permintaan admin dashboard baru\nUsername: ${username}\nID: ${user_id}\nBalas approvedash#${user_id} untuk menyetujui atau denydash#${user_id} untuk menolak.`
-    );
-  }
   return res
     .status(201)
     .json({ success: true, user_id: user.user_id, status: user.status });
@@ -150,7 +146,7 @@ router.post('/dashboard-login', async (req, res) => {
       .status(403)
       .json({ success: false, message: 'Akun belum disetujui' });
   }
-  const payload = { user_id: user.user_id, role: user.role };
+  const payload = { user_id: user.user_id, role: user.role, client_id: user.client_id };
   const token = jwt.sign(payload, process.env.JWT_SECRET || 'secretkey', {
     expiresIn: '2h',
   });

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -244,29 +244,6 @@ describe('POST /dashboard-register', () => {
     );
   });
 
-  test('admin registration inserted as pending', async () => {
-    mockQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ user_id: 'a1', status: false }] });
-
-    const res = await request(app)
-      .post('/api/auth/dashboard-register')
-      .send({ username: 'admin', password: 'pass', role: 'admin' });
-
-    expect(res.status).toBe(201);
-    expect(res.body.success).toBe(true);
-    expect(res.body.status).toBe(false);
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
-      'SELECT * FROM dashboard_user WHERE username = $1',
-      ['admin']
-    );
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('INSERT INTO dashboard_user'),
-      [expect.any(String), 'admin', expect.any(String), 'admin', false, null]
-    );
-  });
 
   test('returns 400 when username exists', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ user_id: 'x' }] });
@@ -290,7 +267,8 @@ describe('POST /dashboard-login', () => {
           username: 'dash',
           password_hash: await bcrypt.hash('pass', 10),
           role: 'admin',
-          status: true
+          status: true,
+          client_id: 'c1'
         }
       ]
     });
@@ -301,6 +279,7 @@ describe('POST /dashboard-login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
+    expect(res.body.user).toEqual({ user_id: 'd1', role: 'admin', client_id: 'c1' });
     expect(mockRedis.sAdd).toHaveBeenCalledWith('dashboard_login:d1', res.body.token);
     expect(mockRedis.set).toHaveBeenCalledWith(
       `login_token:${res.body.token}`,
@@ -317,7 +296,8 @@ describe('POST /dashboard-login', () => {
           username: 'dash',
           password_hash: await bcrypt.hash('pass', 10),
           role: 'admin',
-          status: true
+          status: true,
+          client_id: 'c1'
         }
       ]
     });
@@ -333,126 +313,3 @@ describe('POST /dashboard-login', () => {
   });
 });
 
-describe('POST /user-register', () => {
-  test('creates new user when nrp free', async () => {
-    mockQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ user_id: '1' }] });
-
-    const res = await request(app)
-      .post('/api/auth/user-register')
-      .send({ nrp: '1', nama: 'User', client_id: 'c1' });
-
-    expect(res.status).toBe(201);
-    expect(res.body.success).toBe(true);
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
-      'SELECT * FROM "user" WHERE user_id = $1',
-      ['1']
-    );
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('INSERT INTO "user"'),
-      expect.any(Array)
-    );
-  });
-
-  test('returns 400 when nrp exists', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '1' }] });
-
-    const res = await request(app)
-      .post('/api/auth/user-register')
-      .send({ nrp: '1', nama: 'User', client_id: 'c1' });
-
-    expect(res.status).toBe(400);
-    expect(res.body.success).toBe(false);
-    expect(mockQuery).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('POST /dashboard-register', () => {
-  test('creates new dashboard user when username free', async () => {
-    mockQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ user_id: 'd1' }] });
-
-    const res = await request(app)
-      .post('/api/auth/dashboard-register')
-      .send({ username: 'dash', password: 'pass' });
-
-    expect(res.status).toBe(201);
-    expect(res.body.success).toBe(true);
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
-      'SELECT * FROM dashboard_user WHERE username = $1',
-      ['dash']
-    );
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('INSERT INTO dashboard_user'),
-      [expect.any(String), 'dash', expect.any(String), 'operator', null]
-    );
-  });
-
-  test('returns 400 when username exists', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [{ user_id: 'x' }] });
-
-    const res = await request(app)
-      .post('/api/auth/dashboard-register')
-      .send({ username: 'dash', password: 'pass' });
-
-    expect(res.status).toBe(400);
-    expect(res.body.success).toBe(false);
-    expect(mockQuery).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('POST /dashboard-login', () => {
-  test('logs in dashboard user with correct password', async () => {
-    mockQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          user_id: 'd1',
-          username: 'dash',
-          password_hash: await bcrypt.hash('pass', 10),
-          role: 'admin'
-        }
-      ]
-    });
-
-    const res = await request(app)
-      .post('/api/auth/dashboard-login')
-      .send({ username: 'dash', password: 'pass' });
-
-    expect(res.status).toBe(200);
-    expect(res.body.success).toBe(true);
-    expect(mockRedis.sAdd).toHaveBeenCalledWith('dashboard_login:d1', res.body.token);
-    expect(mockRedis.set).toHaveBeenCalledWith(
-      `login_token:${res.body.token}`,
-      'dashboard:d1',
-      { EX: 2 * 60 * 60 }
-    );
-  });
-
-  test('returns 401 when password wrong', async () => {
-    mockQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          user_id: 'd1',
-          username: 'dash',
-          password_hash: await bcrypt.hash('pass', 10),
-          role: 'admin'
-        }
-      ]
-    });
-
-    const res = await request(app)
-      .post('/api/auth/dashboard-login')
-      .send({ username: 'dash', password: 'wrong' });
-
-    expect(res.status).toBe(401);
-    expect(res.body.success).toBe(false);
-    expect(mockRedis.sAdd).not.toHaveBeenCalled();
-    expect(mockRedis.set).not.toHaveBeenCalled();
-  });
-});


### PR DESCRIPTION
## Summary
- restrict dashboard registration to the operator role
- include `client_id` from `dashboard_user` in dashboard login response
- remove duplicate code and align unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879ec38976c832788d098e509ce5e5d