### PR TITLE
Fix dashboard operator approval flow

### DIFF
--- a/docs/frontend_login_scaling.md
+++ b/docs/frontend_login_scaling.md
@@ -33,9 +33,9 @@ Expose `/api/auth/dashboard-register`:
 
 1. Validate `username`, `password` and optional `role` and `client_id`.
 2. Ensure the username is unique in `dashboard_user`.
-3. Hash the password with `bcrypt.hash` and insert the new row.
-4. If the role is `admin`, insert with `status=false` and send a WhatsApp notification to administrators. They can approve using `approvedash#<id>`.
-5. Return `201 Created` with the new `user_id`.
+3. Hash the password with `bcrypt.hash` and insert the new row with `status=false`.
+4. Send a WhatsApp notification to administrators. They can approve using `approvedash#<id>` or reject with `denydash#<id>`.
+5. Return `201 Created` with the new `user_id` and current status.
 
 
 ## 3. Login Endpoint

--- a/docs/login_api.md
+++ b/docs/login_api.md
@@ -49,7 +49,7 @@ All return a JSON Web Token (JWT) that must be included in subsequent requests.
 ```
 
 To register a dashboard user send a similar payload to `/api/auth/dashboard-register` with optional `role` and `client_id`.
-When registering an account with role `admin`, the status is set to `false` and an approval request is sent to the WhatsApp administrators. They can approve using `approvedash#<id>`.
+Every new dashboard account is created with `status` set to `false` and an approval request is sent to the WhatsApp administrators. They can approve using `approvedash#<id>`.
 
 
 ## 2. Example `curl`

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -99,9 +99,8 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  const { username, password, client_id = null } = req.body;
-  const role = 'operator';
-  const status = true;
+  const { username, password, role = 'operator', client_id = null } = req.body;
+  const status = false;
   if (!username || !password) {
     return res
       .status(400)
@@ -123,6 +122,9 @@ router.post('/dashboard-register', async (req, res) => {
     status,
     client_id,
   });
+  notifyAdmin(
+    `\uD83D\uDCCB Permintaan user dashboard baru\nUsername: ${username}\nRole: ${role}\nID: ${user_id}\nBalas approvedash#${user_id} untuk menyetujui atau denydash#${user_id} untuk menolak.`
+  );
   return res
     .status(201)
     .json({ success: true, user_id: user.user_id, status: user.status });
@@ -182,30 +184,6 @@ router.post('/dashboard-login', async (req, res) => {
   return res.json({ success: true, token, user: payload });
 });
 
-router.post('/dashboard-register', async (req, res) => {
-  const { username, password, role = 'operator', client_id = null } = req.body;
-  if (!username || !password) {
-    return res
-      .status(400)
-      .json({ success: false, message: 'username dan password wajib diisi' });
-  }
-  const existing = await dashboardUserModel.findByUsername(username);
-  if (existing) {
-    return res
-      .status(400)
-      .json({ success: false, message: 'username sudah terpakai' });
-  }
-  const user_id = uuidv4();
-  const password_hash = await bcrypt.hash(password, 10);
-  const user = await dashboardUserModel.createUser({
-    user_id,
-    username,
-    password_hash,
-    role,
-    client_id,
-  });
-  return res.status(201).json({ success: true, user_id: user.user_id });
-});
 
 router.post('/dashboard-login', async (req, res) => {
   const { username, password } = req.body;

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1709,7 +1709,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       return;
     }
     await dashboardUserModel.updateStatus(id, true);
-    await waClient.sendMessage(chatId, `✅ Admin ${usr.username} disetujui.`);
+    await waClient.sendMessage(chatId, `✅ User ${usr.username} disetujui.`);
     return;
   }
 
@@ -1725,7 +1725,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       return;
     }
     await dashboardUserModel.updateStatus(id, false);
-    await waClient.sendMessage(chatId, `❌ Admin ${usr.username} ditolak.`);
+    await waClient.sendMessage(chatId, `❌ User ${usr.username} ditolak.`);
     return;
   }
 

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -241,7 +241,7 @@ describe('POST /dashboard-register', () => {
   test('creates new dashboard user when username free', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ user_id: 'd1' }] });
+      .mockResolvedValueOnce({ rows: [{ user_id: 'd1', status: false }] });
 
     const res = await request(app)
       .post('/api/auth/dashboard-register')
@@ -249,6 +249,7 @@ describe('POST /dashboard-register', () => {
 
     expect(res.status).toBe(201);
     expect(res.body.success).toBe(true);
+    expect(res.body.status).toBe(false);
     expect(mockQuery).toHaveBeenNthCalledWith(
       1,
       'SELECT * FROM dashboard_user WHERE username = $1',
@@ -257,7 +258,7 @@ describe('POST /dashboard-register', () => {
     expect(mockQuery).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('INSERT INTO dashboard_user'),
-      [expect.any(String), 'dash', expect.any(String), 'operator', true, null]
+      [expect.any(String), 'dash', expect.any(String), 'operator', false, null]
     );
   });
 


### PR DESCRIPTION
## Summary
- require dashboard user registrations to start as `status=false`
- send WhatsApp notification for approvals
- allow WA admins to approve/deny users
- update docs about the approval flow
- adjust tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879f813c14c83279aa021621f6221b8