### PR TITLE
Add username to editorial events

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -32,6 +32,7 @@ CREATE TABLE editorial_event (
   summary TEXT,
   image_path TEXT,
   created_by INTEGER REFERENCES users(user_id),
+  username TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -284,6 +284,7 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   summary TEXT,
   image_path TEXT,
   created_by TEXT REFERENCES penmas_user(user_id),
+  username TEXT,
   created_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/src/controller/editorialEventController.js
+++ b/src/controller/editorialEventController.js
@@ -1,4 +1,5 @@
 import * as eventModel from '../model/editorialEventModel.js';
+import * as penmasUserModel from '../model/penmasUserModel.js';
 import { sendSuccess } from '../utils/response.js';
 
 export async function getEvents(req, res, next) {
@@ -12,7 +13,12 @@ export async function getEvents(req, res, next) {
 
 export async function createEvent(req, res, next) {
   try {
-    const data = { ...req.body, created_by: req.penmasUser.user_id };
+    const user = await penmasUserModel.findById(req.penmasUser.user_id);
+    const data = {
+      ...req.body,
+      created_by: req.penmasUser.user_id,
+      username: user?.username || null,
+    };
     const ev = await eventModel.createEvent(data);
     sendSuccess(res, ev, 201);
   } catch (err) {
@@ -22,7 +28,9 @@ export async function createEvent(req, res, next) {
 
 export async function updateEvent(req, res, next) {
   try {
-    const ev = await eventModel.updateEvent(Number(req.params.id), req.body);
+    const user = await penmasUserModel.findById(req.penmasUser.user_id);
+    const body = { ...req.body, username: user?.username || null };
+    const ev = await eventModel.updateEvent(Number(req.params.id), body);
     sendSuccess(res, ev);
   } catch (err) {
     next(err);

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -21,8 +21,9 @@ export async function createEvent(data) {
   const eventDate = formatIsoTimestamp(data.event_date);
   const res = await query(
     `INSERT INTO editorial_event (
-      event_date, topic, assignee, status, content, summary, image_path, created_by, created_at
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8, COALESCE($9, NOW()))
+      event_date, topic, assignee, status, content, summary, image_path,
+      created_by, username, created_at
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, COALESCE($10, NOW()))
      RETURNING *`,
     [
       eventDate,
@@ -33,6 +34,7 @@ export async function createEvent(data) {
       data.summary || null,
       data.image_path || null,
       data.created_by,
+      data.username || null,
       data.created_at || null
     ]
   );
@@ -52,7 +54,8 @@ export async function updateEvent(id, data) {
       status=$5,
       content=$6,
       summary=$7,
-      image_path=$8
+      image_path=$8,
+      username=$9
      WHERE event_id=$1 RETURNING *`,
     [
       id,
@@ -62,7 +65,8 @@ export async function updateEvent(id, data) {
       merged.status,
       merged.content || null,
       merged.summary || null,
-      merged.image_path || null
+      merged.image_path || null,
+      merged.username || null
     ]
   );
   return res.rows[0];

--- a/src/model/penmasUserModel.js
+++ b/src/model/penmasUserModel.js
@@ -17,3 +17,11 @@ export async function createUser(data) {
   );
   return res.rows[0];
 }
+
+export async function findById(userId) {
+  const res = await query(
+    'SELECT * FROM penmas_user WHERE user_id = $1',
+    [userId]
+  );
+  return res.rows[0] || null;
+}


### PR DESCRIPTION
## Summary
- add a `username` column to `editorial_event`
- include username when creating or updating events
- expose a helper to fetch penmas users by ID
- document the new column

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a0ed109cc83278581945b4650fbf3