### PR TITLE
Add last_update tracking to editorial_event

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -33,7 +33,8 @@ CREATE TABLE editorial_event (
   image_path TEXT,
   created_by INTEGER REFERENCES users(user_id),
   username TEXT,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -285,7 +285,8 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   image_path TEXT,
   created_by TEXT REFERENCES penmas_user(user_id),
   username TEXT,
-  created_at TIMESTAMP DEFAULT NOW()
+  created_at TIMESTAMP DEFAULT NOW(),
+  last_update TIMESTAMP DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS approval_request (

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -22,8 +22,8 @@ export async function createEvent(data) {
   const res = await query(
     `INSERT INTO editorial_event (
       event_date, topic, assignee, status, content, summary, image_path,
-      created_by, username, created_at
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, COALESCE($10, NOW()))
+      created_by, username, created_at, last_update
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, COALESCE($10, NOW()), COALESCE($11, NOW()))
      RETURNING *`,
     [
       eventDate,
@@ -35,7 +35,8 @@ export async function createEvent(data) {
       data.image_path || null,
       data.created_by,
       data.username || null,
-      data.created_at || null
+      data.created_at || null,
+      data.last_update || null
     ]
   );
   return res.rows[0];
@@ -55,7 +56,8 @@ export async function updateEvent(id, data) {
       content=$6,
       summary=$7,
       image_path=$8,
-      username=$9
+      username=$9,
+      last_update=COALESCE($10, NOW())
      WHERE event_id=$1 RETURNING *`,
     [
       id,
@@ -66,7 +68,8 @@ export async function updateEvent(id, data) {
       merged.content || null,
       merged.summary || null,
       merged.image_path || null,
-      merged.username || null
+      merged.username || null,
+      merged.last_update || null
     ]
   );
   return res.rows[0];


### PR DESCRIPTION
## Summary
- update SQL schema and API design docs for `editorial_event`
- store `last_update` timestamp when creating or updating events

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a11a69f7c832792bc1c412c6dc3fb