### PR TITLE
Add updated_by and last_updated fields

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -32,6 +32,7 @@ CREATE TABLE editorial_event (
   summary TEXT,
   image_path TEXT,
   created_by INTEGER REFERENCES users(user_id),
+  updated_by INTEGER REFERENCES users(user_id),
   username TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -284,6 +284,7 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   summary TEXT,
   image_path TEXT,
   created_by TEXT REFERENCES penmas_user(user_id),
+  updated_by TEXT REFERENCES penmas_user(user_id),
   username TEXT,
   created_at TIMESTAMP DEFAULT NOW(),
   last_update TIMESTAMP DEFAULT NOW()

--- a/src/controller/editorialEventController.js
+++ b/src/controller/editorialEventController.js
@@ -17,6 +17,7 @@ export async function createEvent(req, res, next) {
     const data = {
       ...req.body,
       created_by: req.penmasUser.user_id,
+      updated_by: req.penmasUser.user_id,
       username: user?.username || null,
     };
     const ev = await eventModel.createEvent(data);
@@ -29,7 +30,11 @@ export async function createEvent(req, res, next) {
 export async function updateEvent(req, res, next) {
   try {
     const user = await penmasUserModel.findById(req.penmasUser.user_id);
-    const body = { ...req.body, username: user?.username || null };
+    const body = {
+      ...req.body,
+      username: user?.username || null,
+      updated_by: req.penmasUser.user_id,
+    };
     const ev = await eventModel.updateEvent(Number(req.params.id), body);
     sendSuccess(res, ev);
   } catch (err) {

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -8,6 +8,7 @@ export async function getEvents(userId) {
   );
   return res.rows.map((row) => ({
     ...row,
+    last_updated: row.last_update,
     event_date: formatDdMmYyyy(row.event_date),
   }));
 }
@@ -22,8 +23,8 @@ export async function createEvent(data) {
   const res = await query(
     `INSERT INTO editorial_event (
       event_date, topic, assignee, status, content, summary, image_path,
-      created_by, username, created_at, last_update
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, COALESCE($10, NOW()), COALESCE($11, NOW()))
+      created_by, updated_by, username, created_at, last_update
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, COALESCE($11, NOW()), COALESCE($12, NOW()))
      RETURNING *`,
     [
       eventDate,
@@ -34,6 +35,7 @@ export async function createEvent(data) {
       data.summary || null,
       data.image_path || null,
       data.created_by,
+      data.updated_by || data.created_by,
       data.username || null,
       data.created_at || null,
       data.last_update || null
@@ -57,7 +59,8 @@ export async function updateEvent(id, data) {
       summary=$7,
       image_path=$8,
       username=$9,
-      last_update=COALESCE($10, NOW())
+      updated_by=$10,
+      last_update=COALESCE($11, NOW())
      WHERE event_id=$1 RETURNING *`,
     [
       id,
@@ -69,6 +72,7 @@ export async function updateEvent(id, data) {
       merged.summary || null,
       merged.image_path || null,
       merged.username || null,
+      data.updated_by || merged.updated_by || null,
       merged.last_update || null
     ]
   );


### PR DESCRIPTION
## Summary
- extend `editorial_event` schema with `updated_by`
- document new column in API design
- capture updater info when creating or updating events
- expose `last_updated` in event list view

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: jest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1480e024832784588f6b598f8b89