### PR TITLE
Show usernames in Penmas logs and events

### DIFF
--- a/src/model/changeLogModel.js
+++ b/src/model/changeLogModel.js
@@ -2,7 +2,11 @@ import { query } from '../repository/db.js';
 
 export async function getLogsByEvent(eventId) {
   const res = await query(
-    'SELECT * FROM change_log WHERE event_id=$1 ORDER BY logged_at ASC',
+    `SELECT l.*, u.username
+     FROM change_log l
+     LEFT JOIN penmas_user u ON u.user_id = l.user_id
+     WHERE l.event_id=$1
+     ORDER BY l.logged_at ASC`,
     [eventId]
   );
   return res.rows;

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -3,7 +3,11 @@ import { formatIsoTimestamp, formatDdMmYyyy } from '../utils/utilsHelper.js';
 
 export async function getEvents(userId) {
   const res = await query(
-    'SELECT * FROM editorial_event WHERE created_by = $1 ORDER BY event_date ASC',
+    `SELECT e.*, u.username AS updated_by_username
+     FROM editorial_event e
+     LEFT JOIN penmas_user u ON u.user_id = e.updated_by
+     WHERE e.created_by = $1
+     ORDER BY e.event_date ASC`,
     [userId]
   );
   return res.rows.map((row) => ({

--- a/tests/changeLogModel.test.js
+++ b/tests/changeLogModel.test.js
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery,
+}));
+
+let getLogsByEvent;
+
+beforeAll(async () => {
+  const mod = await import('../src/model/changeLogModel.js');
+  getLogsByEvent = mod.getLogsByEvent;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('getLogsByEvent joins with penmas_user', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getLogsByEvent(1);
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('JOIN penmas_user'),
+    [1]
+  );
+});

--- a/tests/editorialEventModel.test.js
+++ b/tests/editorialEventModel.test.js
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery,
+}));
+
+let getEvents;
+
+beforeAll(async () => {
+  const mod = await import('../src/model/editorialEventModel.js');
+  getEvents = mod.getEvents;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('getEvents joins with penmas_user for username', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getEvents('u1');
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('JOIN penmas_user'),
+    ['u1']
+  );
+});


### PR DESCRIPTION
## Summary
- join with `penmas_user` to show usernames for `updated_by` in events
- join with `penmas_user` when fetching change logs
- add unit tests for new joins

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a46afd2248327aecd679e661dfe52