### PR TITLE
Remove unused debug helpers

### DIFF
--- a/src/middleware/debugHandler.js
+++ b/src/middleware/debugHandler.js
@@ -63,16 +63,6 @@ export function sendDebug({ tag = "DEBUG", msg, client_id = "" } = {}) {
   console.log(fullMsg);
 }
 
-// Shorthand untuk kebutuhan umum
-export const sendCronDebug = (client_id, msg) =>
-  sendDebug({ tag: "CRON", msg, client_id });
-
-export const sendAdminDebug = (msg) =>
-  sendDebug({ tag: "CICERO", msg });
-
-export const sendTiktokDebug = (msg) =>
-  sendDebug({ tag: "REGULAR", msg });
-
 // Debug khusus yang hanya dicetak di console tanpa mengirim pesan WhatsApp
 export function sendConsoleDebug({ tag = "DEBUG", msg, client_id = "" } = {}) {
   const safeMsg = typeof msg === "string" ? msg : safeStringify(msg);


### PR DESCRIPTION
## Summary
- remove unused `sendCronDebug`, `sendAdminDebug` and `sendTiktokDebug` helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b611a206083279459d4cce5f351c2