### PR TITLE
Remove unused TikTok comment rekap service

### DIFF
--- a/src/service/tiktokCommentService.js
+++ b/src/service/tiktokCommentService.js
@@ -4,9 +4,3 @@ export const findByVideoId = async (video_id) => {
   return await tiktokCommentModel.findByVideoId(video_id);
 };
 
-
-
-export const getRekapByClient = async (client_id, periode = 'harian') => {
-  return await tiktokCommentModel.getRekapKomentarByClient(client_id, periode);
-};
-


### PR DESCRIPTION
## Summary
- delete unused `getRekapByClient` from `tiktokCommentService`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b63219a0083278667b62d14b8701b