### PR TITLE
Remove getLatestCache

### DIFF
--- a/src/model/instaPostCacheModel.js
+++ b/src/model/instaPostCacheModel.js
@@ -7,9 +7,3 @@ export async function insertCache(username, posts) {
   await redis.set(key, value);
 }
 
-export async function getLatestCache(username) {
-  const key = `insta:posts:${username}`;
-  const val = await redis.get(key);
-  if (!val) return null;
-  return JSON.parse(val);
-}

--- a/src/service/instaPostCacheService.js
+++ b/src/service/instaPostCacheService.js
@@ -1,4 +1,3 @@
 import * as cacheModel from '../model/instaPostCacheModel.js';
 
 export const insertCache = cacheModel.insertCache;
-export const getLatestCache = cacheModel.getLatestCache;


### PR DESCRIPTION
## Summary
- drop unused `getLatestCache` from instaPostCacheService
- remove `getLatestCache` implementation from the model

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b6437e9c88327b00bc2c081b38ff8