### PR TITLE
Remove unused WhatsApp helpers

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -104,30 +104,6 @@ export async function getTiktokEmptyUsersByClient(clientId) {
   return result.rows;
 }
 
-// Ambil user yang SUDAH mengisi WhatsApp (status true)
-export async function getWaFilledUsersByClient(clientId) {
-  const result = await query(
-    `SELECT divisi, nama, user_id, title, whatsapp
-     FROM "user"
-     WHERE client_id = $1 AND whatsapp IS NOT NULL AND whatsapp <> '' AND status = true
-     ORDER BY divisi, nama`,
-    [clientId]
-  );
-  return result.rows;
-}
-
-// Ambil user yang BELUM mengisi WhatsApp (status true)
-export async function getWaEmptyUsersByClient(clientId) {
-  const result = await query(
-    `SELECT divisi, nama, user_id, title
-     FROM "user"
-     WHERE client_id = $1 AND (whatsapp IS NULL OR whatsapp = '') AND status = true
-     ORDER BY divisi, nama`,
-    [clientId]
-  );
-  return result.rows;
-}
-
 // Ambil semua user aktif (status=true) beserta whatsapp
 export async function getUsersWithWaByClient(clientId) {
   const result = await query(


### PR DESCRIPTION
## Summary
- delete `getWaFilledUsersByClient` and `getWaEmptyUsersByClient`
- keep `getUsersWithWaByClient` for WhatsApp attendance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b6439a5d08327bba09af4e2f9d755