### PR TITLE
Remove unused IG API exports

### DIFF
--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -316,7 +316,7 @@ export async function fetchAllInstagramLikesItems(shortcode, maxPage = 20) {
 }
 
 
-export async function searchInstagramUsers(query, limit = 10) {
+async function searchInstagramUsers(query, limit = 10) {
   if (!query) return [];
   try {
     sendConsoleDebug('searchInstagramUsers request', query);
@@ -342,7 +342,7 @@ export async function searchInstagramUsers(query, limit = 10) {
   }
 }
 
-export async function fetchInstagramCommentsPage(shortcode, token = null) {
+async function fetchInstagramCommentsPage(shortcode, token = null) {
   if (!shortcode) return { comments: [], next_token: null, has_more: false };
   const params = new URLSearchParams({ code_or_id_or_url: shortcode });
   if (token) params.append('pagination_token', token);

--- a/src/service/instagramApi.js
+++ b/src/service/instagramApi.js
@@ -6,7 +6,6 @@ export {
   fetchInstagramLikesPage,
   fetchAllInstagramLikes,
   fetchAllInstagramLikesItems,
-  fetchInstagramCommentsPage,
   fetchAllInstagramComments,
   fetchInstagramHashtag,
   fetchInstagramPostInfo


### PR DESCRIPTION
## Summary
- stop exporting `searchInstagramUsers` and `fetchInstagramCommentsPage`
- drop re-export for `fetchInstagramCommentsPage`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b6966e7ec83278eb06f9202f43c9b