### PR TITLE
Remove unused ig_post_likes table

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -36,7 +36,6 @@ for PostgreSQL but can work with MySQL or SQLite via the DB adapter.
 | ig_ext_hashtags | hashtags detected in posts |
 | ig_hashtag_info | metadata for individual hashtags |
 | ig_post_metrics | advanced engagement metrics |
-| ig_post_likes | JSON list of like usernames |
 | ig_post_like_users | relational table of likes |
 | ig_post_comments | stored comments per post |
 | visitor_logs | record of API access |

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -207,13 +207,6 @@ CREATE TABLE IF NOT EXISTS ig_post_metrics (
     fb_play_count INT
 );
 
--- Store full list of usernames who liked a post (Data Mining)
-CREATE TABLE IF NOT EXISTS ig_post_likes (
-    post_id VARCHAR(50) PRIMARY KEY REFERENCES ig_ext_posts(post_id),
-    likes JSONB,
-    updated_at TIMESTAMP
-);
-
 -- Relational table for individual likes
 CREATE TABLE IF NOT EXISTS ig_post_like_users (
     post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id),


### PR DESCRIPTION
## Summary
- delete unused `ig_post_likes` table from schema
- remove table from database documentation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b697640448327bbd367a013b5db60