### PR TITLE
Fix comment handler imports

### DIFF
--- a/src/handler/datamining/fetchDmComments.js
+++ b/src/handler/datamining/fetchDmComments.js
@@ -1,6 +1,5 @@
 import pLimit from 'p-limit';
 import { fetchAllInstagramComments } from '../../service/instagramApi.js';
-import { upsertInstaComments } from '../../model/instaCommentModel.js';
 import { getShortcodesTodayByUsername } from '../../model/instaPostModel.js';
 import { insertIgPostComments } from '../../model/igPostCommentModel.js';
 import { upsertIgUser } from '../../model/instaPostExtendedModel.js';
@@ -20,7 +19,6 @@ export async function handleFetchKomentarInstagramDM(username) {
       await limit(async () => {
         try {
           const comments = await fetchAllInstagramComments(sc);
-          await upsertInstaComments(sc, comments);
           for (const c of comments) {
             if (c.user) await upsertIgUser(c.user);
           }

--- a/src/handler/fetchengagement/fetchCommentInstagram.js
+++ b/src/handler/fetchengagement/fetchCommentInstagram.js
@@ -2,7 +2,8 @@ import pLimit from 'p-limit';
 import { query } from '../../db/index.js';
 import { sendDebug } from '../../middleware/debugHandler.js';
 import { fetchAllInstagramComments } from '../../service/instagramApi.js';
-import { upsertInstaComments } from '../../model/instaCommentModel.js';
+import { insertIgPostComments } from '../../model/igPostCommentModel.js';
+import { upsertIgUser } from '../../model/instaPostExtendedModel.js';
 
 const limit = pLimit(3);
 
@@ -27,7 +28,10 @@ export async function handleFetchKomentarInstagram(waClient = null, chatId = nul
       await limit(async () => {
         try {
           const comments = await fetchAllInstagramComments(sc);
-          await upsertInstaComments(sc, comments);
+          for (const c of comments) {
+            if (c.user) await upsertIgUser(c.user);
+          }
+          await insertIgPostComments(sc, comments);
           sukses++;
           sendDebug({ tag: 'IG COMMENT', msg: `Shortcode ${sc} berhasil simpan komentar (${comments.length})`, client_id });
         } catch (err) {


### PR DESCRIPTION
## Summary
- remove unused `upsertInstaComments` calls
- write Instagram comments directly via `insertIgPostComments`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b6bf24d248327b5d87363a74c5084