### PR TITLE
Fix subscription username handling

### DIFF
--- a/src/model/premiumSubscriptionModel.js
+++ b/src/model/premiumSubscriptionModel.js
@@ -8,7 +8,7 @@ export async function createSubscription(data) {
      ) VALUES ($1,$2,$3,$4,$5,$6,COALESCE($7, NOW()),COALESCE($8, NOW()))
      RETURNING *`,
     [
-      data.userId || data.username,
+      data.username,
       data.status || 'active',
       data.start_date || new Date(),
       data.end_date || null,
@@ -36,22 +36,22 @@ export async function findSubscriptionById(id) {
   return res.rows[0] || null;
 }
 
-export async function findActiveSubscriptionByUser(userId) {
+export async function findActiveSubscriptionByUser(username) {
   const res = await query(
     `SELECT * FROM premium_subscription
      WHERE username=$1 AND status='active'
      ORDER BY start_date DESC LIMIT 1`,
-    [userId]
+    [username]
   );
   return res.rows[0] || null;
 }
 
-export async function findLatestSubscriptionByUser(userId) {
+export async function findLatestSubscriptionByUser(username) {
   const res = await query(
     `SELECT * FROM premium_subscription
      WHERE username=$1
      ORDER BY start_date DESC LIMIT 1`,
-    [userId]
+    [username]
   );
   return res.rows[0] || null;
 }
@@ -72,7 +72,7 @@ export async function updateSubscription(id, data) {
      WHERE subscription_id=$1 RETURNING *`,
     [
       id,
-      merged.userId || merged.username,
+      merged.username,
       merged.status,
       merged.start_date,
       merged.end_date || null,

--- a/src/service/premiumSubscriptionService.js
+++ b/src/service/premiumSubscriptionService.js
@@ -6,11 +6,11 @@ export const getSubscriptions = async () => model.getSubscriptions();
 
 export const findSubscriptionById = async id => model.findSubscriptionById(id);
 
-export const findActiveSubscriptionByUser = async userId =>
-  model.findActiveSubscriptionByUser(userId);
+export const findActiveSubscriptionByUser = async username =>
+  model.findActiveSubscriptionByUser(username);
 
-export const findLatestSubscriptionByUser = async userId =>
-  model.findLatestSubscriptionByUser(userId);
+export const findLatestSubscriptionByUser = async username =>
+  model.findLatestSubscriptionByUser(username);
 
 export const updateSubscription = async (id, data) =>
   model.updateSubscription(id, data);

--- a/tests/premiumSubscriptionModel.test.js
+++ b/tests/premiumSubscriptionModel.test.js
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 test('createSubscription inserts row', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ subscription_id: 1 }] });
-  const data = { userId: 'abc', start_date: '2024-01-01' };
+  const data = { username: 'abc', start_date: '2024-01-01' };
   const res = await createSubscription(data);
   expect(res).toEqual({ subscription_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- ensure `username` is used for `premium_subscription` records
- adjust service and model tests accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b6e5bcf4c8327a62a6c7ff2e8af48