### PR TITLE
Add tag & kategori columns for editorial events

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -31,6 +31,8 @@ CREATE TABLE editorial_event (
   content TEXT,
   summary TEXT,
   image_path TEXT,
+  tag TEXT,
+  kategori TEXT,
   created_by INTEGER REFERENCES users(user_id),
   updated_by INTEGER REFERENCES users(user_id),
   username TEXT,
@@ -38,6 +40,9 @@ CREATE TABLE editorial_event (
   last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```
+
+The `tag` and `kategori` columns store optional keywords and category labels
+submitted by the Android client.
 
 The `event_date` column uses a timestamp so the schedule can include time of day.
 In list views, the API returns `event_date` formatted as `dd/mm/yyyy`.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -276,6 +276,8 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   content TEXT,
   summary TEXT,
   image_path TEXT,
+  tag TEXT,
+  kategori TEXT,
   created_by TEXT REFERENCES penmas_user(user_id),
   updated_by TEXT REFERENCES penmas_user(user_id),
   username TEXT,

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -27,8 +27,9 @@ export async function createEvent(data) {
   const res = await query(
     `INSERT INTO editorial_event (
       event_date, topic, assignee, status, content, summary, image_path,
+      tag, kategori,
       created_by, updated_by, username, created_at, last_update
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, COALESCE($11, NOW()), COALESCE($12, NOW()))
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12, COALESCE($13, NOW()), COALESCE($14, NOW()))
      RETURNING *`,
     [
       eventDate,
@@ -38,6 +39,8 @@ export async function createEvent(data) {
       data.content || null,
       data.summary || null,
       data.image_path || null,
+      data.tag || null,
+      data.kategori || null,
       data.created_by,
       data.updated_by || data.created_by,
       data.username || null,
@@ -62,9 +65,11 @@ export async function updateEvent(id, data) {
       content=$6,
       summary=$7,
       image_path=$8,
-      username=$9,
-      updated_by=$10,
-      last_update=COALESCE($11, NOW())
+      tag=$9,
+      kategori=$10,
+      username=$11,
+      updated_by=$12,
+      last_update=COALESCE($13, NOW())
      WHERE event_id=$1 RETURNING *`,
     [
       id,
@@ -75,6 +80,8 @@ export async function updateEvent(id, data) {
       merged.content || null,
       merged.summary || null,
       merged.image_path || null,
+      merged.tag || null,
+      merged.kategori || null,
       merged.username || null,
       data.updated_by || merged.updated_by || null,
       merged.last_update || null


### PR DESCRIPTION
## Summary
- update `editorial_event` table with `tag` and `kategori` fields
- support new fields in `editorialEventModel`
- document updated schema in `penmas_api_design.md`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ce11b5cec8327a0baff6fdfcef898