### PR TITLE
Drop username column from editorial events

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -35,7 +35,6 @@ CREATE TABLE editorial_event (
   kategori TEXT,
   created_by INTEGER REFERENCES users(user_id),
   updated_by INTEGER REFERENCES users(user_id),
-  username TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -280,7 +280,6 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   kategori TEXT,
   created_by TEXT REFERENCES penmas_user(user_id),
   updated_by TEXT REFERENCES penmas_user(user_id),
-  username TEXT,
   created_at TIMESTAMP DEFAULT NOW(),
   last_update TIMESTAMP DEFAULT NOW()
 );

--- a/src/controller/editorialEventController.js
+++ b/src/controller/editorialEventController.js
@@ -1,5 +1,4 @@
 import * as eventModel from '../model/editorialEventModel.js';
-import * as penmasUserModel from '../model/penmasUserModel.js';
 import { sendSuccess } from '../utils/response.js';
 
 export async function getEvents(req, res, next) {
@@ -13,12 +12,10 @@ export async function getEvents(req, res, next) {
 
 export async function createEvent(req, res, next) {
   try {
-    const user = await penmasUserModel.findById(req.penmasUser.user_id);
     const data = {
       ...req.body,
       created_by: req.penmasUser.user_id,
       updated_by: req.penmasUser.user_id,
-      username: user?.username || null,
     };
     const ev = await eventModel.createEvent(data);
     sendSuccess(res, ev, 201);
@@ -29,10 +26,8 @@ export async function createEvent(req, res, next) {
 
 export async function updateEvent(req, res, next) {
   try {
-    const user = await penmasUserModel.findById(req.penmasUser.user_id);
     const body = {
       ...req.body,
-      username: user?.username || null,
       updated_by: req.penmasUser.user_id,
     };
     const ev = await eventModel.updateEvent(Number(req.params.id), body);

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -28,8 +28,8 @@ export async function createEvent(data) {
     `INSERT INTO editorial_event (
       event_date, topic, assignee, status, content, summary, image_path,
       tag, kategori,
-      created_by, updated_by, username, created_at, last_update
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12, COALESCE($13, NOW()), COALESCE($14, NOW()))
+      created_by, updated_by, created_at, last_update
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, COALESCE($12, NOW()), COALESCE($13, NOW()))
      RETURNING *`,
     [
       eventDate,
@@ -43,7 +43,6 @@ export async function createEvent(data) {
       data.kategori || null,
       data.created_by,
       data.updated_by || data.created_by,
-      data.username || null,
       data.created_at || null,
       data.last_update || null
     ]
@@ -67,9 +66,8 @@ export async function updateEvent(id, data) {
       image_path=$8,
       tag=$9,
       kategori=$10,
-      username=$11,
-      updated_by=$12,
-      last_update=COALESCE($13, NOW())
+      updated_by=$11,
+      last_update=COALESCE($12, NOW())
      WHERE event_id=$1 RETURNING *`,
     [
       id,
@@ -82,7 +80,6 @@ export async function updateEvent(id, data) {
       merged.image_path || null,
       merged.tag || null,
       merged.kategori || null,
-      merged.username || null,
       data.updated_by || merged.updated_by || null,
       merged.last_update || null
     ]


### PR DESCRIPTION
## Summary
- remove `username` from `editorial_event` schema and docs
- update event model and controller to stop using the column

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cede909c883278f41d36553ebd9c4