### PR TITLE
Add press_release_detail storage

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -284,6 +284,20 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   last_update TIMESTAMP DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS press_release_detail (
+  event_id INTEGER PRIMARY KEY REFERENCES editorial_event(event_id),
+  judul TEXT,
+  dasar TEXT,
+  tersangka TEXT,
+  tkp TEXT,
+  kronologi TEXT,
+  modus TEXT,
+  barang_bukti TEXT,
+  pasal TEXT,
+  ancaman TEXT,
+  catatan TEXT
+);
+
 CREATE TABLE IF NOT EXISTS approval_request (
   request_id SERIAL PRIMARY KEY,
   event_id INTEGER REFERENCES editorial_event(event_id),

--- a/src/controller/pressReleaseDetailController.js
+++ b/src/controller/pressReleaseDetailController.js
@@ -1,0 +1,30 @@
+import * as model from '../model/pressReleaseDetailModel.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function getDetail(req, res, next) {
+  try {
+    const data = await model.findDetailByEvent(Number(req.params.id));
+    sendSuccess(res, data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createDetail(req, res, next) {
+  try {
+    const body = { ...req.body, event_id: Number(req.body.event_id) };
+    const row = await model.createDetail(body);
+    sendSuccess(res, row, 201);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateDetail(req, res, next) {
+  try {
+    const row = await model.updateDetail(Number(req.params.id), req.body);
+    sendSuccess(res, row);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/model/pressReleaseDetailModel.js
+++ b/src/model/pressReleaseDetailModel.js
@@ -1,0 +1,67 @@
+import { query } from '../repository/db.js';
+
+export async function findDetailByEvent(eventId) {
+  const res = await query(
+    'SELECT * FROM press_release_detail WHERE event_id=$1',
+    [eventId]
+  );
+  return res.rows[0] || null;
+}
+
+export async function createDetail(data) {
+  const res = await query(
+    `INSERT INTO press_release_detail (
+      event_id, judul, dasar, tersangka, tkp, kronologi, modus,
+      barang_bukti, pasal, ancaman, catatan
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+     RETURNING *`,
+    [
+      data.event_id,
+      data.judul || null,
+      data.dasar || null,
+      data.tersangka || null,
+      data.tkp || null,
+      data.kronologi || null,
+      data.modus || null,
+      data.barang_bukti || null,
+      data.pasal || null,
+      data.ancaman || null,
+      data.catatan || null
+    ]
+  );
+  return res.rows[0];
+}
+
+export async function updateDetail(eventId, data) {
+  const old = await findDetailByEvent(eventId);
+  if (!old) return null;
+  const merged = { ...old, ...data };
+  const res = await query(
+    `UPDATE press_release_detail SET
+      judul=$2,
+      dasar=$3,
+      tersangka=$4,
+      tkp=$5,
+      kronologi=$6,
+      modus=$7,
+      barang_bukti=$8,
+      pasal=$9,
+      ancaman=$10,
+      catatan=$11
+     WHERE event_id=$1 RETURNING *`,
+    [
+      eventId,
+      merged.judul || null,
+      merged.dasar || null,
+      merged.tersangka || null,
+      merged.tkp || null,
+      merged.kronologi || null,
+      merged.modus || null,
+      merged.barang_bukti || null,
+      merged.pasal || null,
+      merged.ancaman || null,
+      merged.catatan || null
+    ]
+  );
+  return res.rows[0];
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -16,6 +16,7 @@ import subscriptionConfirmationRoutes from './subscriptionConfirmationRoutes.js'
 import amplifyRoutes from './amplifyRoutes.js';
 import editorialEventRoutes from './editorialEventRoutes.js';
 import approvalRequestRoutes from './approvalRequestRoutes.js';
+import pressReleaseDetailRoutes from './pressReleaseDetailRoutes.js';
 
 const router = express.Router();
 
@@ -32,6 +33,7 @@ router.use('/logs', logRoutes);
 router.use('/link-reports', linkReportRoutes);
 router.use('/events', editorialEventRoutes);
 router.use('/approvals', approvalRequestRoutes);
+router.use('/press-release-details', pressReleaseDetailRoutes);
 router.use('/premium-subscriptions', premiumSubscriptionRoutes);
 router.use('/subscription-registrations', subscriptionRegistrationRoutes);
 router.use('/subscription-confirmations', subscriptionConfirmationRoutes);

--- a/src/routes/pressReleaseDetailRoutes.js
+++ b/src/routes/pressReleaseDetailRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import * as controller from '../controller/pressReleaseDetailController.js';
+import { verifyPenmasToken } from '../middleware/penmasAuth.js';
+
+const router = express.Router();
+
+router.use(verifyPenmasToken);
+router.get('/:id', controller.getDetail);
+router.post('/', controller.createDetail);
+router.put('/:id', controller.updateDetail);
+
+export default router;

--- a/tests/pressReleaseDetailModel.test.js
+++ b/tests/pressReleaseDetailModel.test.js
@@ -1,0 +1,80 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery,
+}));
+
+let createDetail;
+let updateDetail;
+let findDetailByEvent;
+
+beforeAll(async () => {
+  const mod = await import('../src/model/pressReleaseDetailModel.js');
+  createDetail = mod.createDetail;
+  updateDetail = mod.updateDetail;
+  findDetailByEvent = mod.findDetailByEvent;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('createDetail inserts row', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ event_id: 1 }] });
+  const data = { event_id: 1, judul: 'x' };
+  const row = await createDetail(data);
+  expect(row).toEqual({ event_id: 1 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO press_release_detail'),
+    [
+      1,
+      'x',
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]
+  );
+});
+
+test('findDetailByEvent selects by id', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ event_id: 1 }] });
+  const row = await findDetailByEvent(1);
+  expect(row).toEqual({ event_id: 1 });
+  expect(mockQuery).toHaveBeenCalledWith(
+    'SELECT * FROM press_release_detail WHERE event_id=$1',
+    [1]
+  );
+});
+
+test('updateDetail updates row', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ event_id: 1 }] })
+    .mockResolvedValueOnce({ rows: [{ event_id: 1, judul: 'a' }] });
+  const row = await updateDetail(1, { judul: 'a' });
+  expect(row).toEqual({ event_id: 1, judul: 'a' });
+  expect(mockQuery).toHaveBeenLastCalledWith(
+    expect.stringContaining('UPDATE press_release_detail SET'),
+    [
+      1,
+      'a',
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]
+  );
+});
+


### PR DESCRIPTION
## Summary
- add `press_release_detail` table to schema
- implement model, controller and routes for press release details
- expose `/press-release-details` endpoints
- test pressReleaseDetailModel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d01f9397483278bb48ffb0391985b