### PR TITLE
Handle Instagram carousels

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -75,6 +75,8 @@ Stores Instagram posts fetched for a client.
 - `is_video` – boolean whether post is a video
 - `video_url` – link to video file if any
 - `image_url` – link to image file
+- `images_url` – JSON array of all image URLs when the post is a carousel
+- `is_carousel` – boolean indicating whether the post contains multiple images
 - `created_at` – timestamp of the post
 
 ### `insta_like`

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -54,6 +54,8 @@ CREATE TABLE insta_post (
   is_video BOOLEAN DEFAULT FALSE,
   video_url TEXT,
   image_url TEXT,
+  images_url JSONB,
+  is_carousel BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP
 );
 

--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -12,22 +12,26 @@ export async function upsertInstaPost(data) {
     is_video = false,
     video_url = null,
     image_url = null,
+    images_url = null,
+    is_carousel = false,
   } = data;
 
   // created_at bisa dihandle via taken_at di service (lihat service)
   await query(
-    `INSERT INTO insta_post (client_id, shortcode, caption, comment_count, thumbnail_url, is_video, video_url, image_url, created_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,COALESCE($9, NOW()))
+    `INSERT INTO insta_post (client_id, shortcode, caption, comment_count, thumbnail_url, is_video, video_url, image_url, images_url, is_carousel, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,COALESCE($11, NOW()))
      ON CONFLICT (shortcode) DO UPDATE
-     SET client_id = EXCLUDED.client_id,
-         caption = EXCLUDED.caption,
-         comment_count = EXCLUDED.comment_count,
-         thumbnail_url = EXCLUDED.thumbnail_url,
-         is_video = EXCLUDED.is_video,
-         video_url = EXCLUDED.video_url,
-         image_url = EXCLUDED.image_url,
-         created_at = EXCLUDED.created_at`,
-    [client_id, shortcode, caption, comment_count, thumbnail_url, is_video, video_url, image_url, data.created_at || null]
+      SET client_id = EXCLUDED.client_id,
+          caption = EXCLUDED.caption,
+          comment_count = EXCLUDED.comment_count,
+          thumbnail_url = EXCLUDED.thumbnail_url,
+          is_video = EXCLUDED.is_video,
+          video_url = EXCLUDED.video_url,
+          image_url = EXCLUDED.image_url,
+          images_url = EXCLUDED.images_url,
+          is_carousel = EXCLUDED.is_carousel,
+          created_at = EXCLUDED.created_at`,
+    [client_id, shortcode, caption, comment_count, thumbnail_url, is_video, video_url, image_url, JSON.stringify(images_url), is_carousel, data.created_at || null]
   );
 }
 


### PR DESCRIPTION
## Summary
- support carousel posts
- save all carousel image URLs in `images_url` field
- flag carousel posts with `is_carousel`
- document new columns

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687dd189c84083278fcd157407efb57b