### PR TITLE
Add direktorat flags for user records

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -54,6 +54,7 @@ Holds users belonging to a client.
 - `insta`, `tiktok` – social media handles
 - `client_id` – foreign key referencing `clients(client_id)`
 - `status` – boolean flag
+- `ditbinmas`, `ditlantas` – boolean flags for directorate assignment
 
 ### `dashboard_user`
 Credentials for the web dashboard login.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -22,7 +22,9 @@ CREATE TABLE "user" (
   insta VARCHAR,
   tiktok VARCHAR,
   client_id VARCHAR REFERENCES clients(client_id),
-  status BOOLEAN DEFAULT TRUE
+  status BOOLEAN DEFAULT TRUE,
+  ditbinmas BOOLEAN DEFAULT FALSE,
+  ditlantas BOOLEAN DEFAULT FALSE
 );
 
 CREATE TABLE penmas_user (

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -145,6 +145,8 @@ export async function updateUserField(user_id, field, value) {
     "title",
     "divisi",
     "jabatan",
+    "ditbinmas",
+    "ditlantas",
   ];
   if (!allowed.includes(field)) throw new Error("Field tidak diizinkan!");
   if (["nama", "title", "divisi", "jabatan"].includes(field) && typeof value === 'string') {
@@ -163,6 +165,19 @@ export async function getExceptionUsersByClient(client_id) {
     'SELECT * FROM "user" WHERE exception = true AND client_id = $1',
     [client_id]
   );
+  return rows;
+}
+
+// Ambil user dengan flag direktorat binmas atau lantas
+export async function getDirektoratUsers(clientId = null) {
+  let sql =
+    'SELECT * FROM "user" WHERE ditbinmas = true OR ditlantas = true';
+  const params = [];
+  if (clientId) {
+    sql += ' AND client_id = $1';
+    params.push(clientId);
+  }
+  const { rows } = await query(sql, params);
   return rows;
 }
 
@@ -217,8 +232,8 @@ export async function createUser(userData) {
   // Sesuaikan dengan struktur dan database-mu!
   normalizeUserFields(userData);
   const q = `
-    INSERT INTO "user" (user_id, nama, title, divisi, jabatan, status, whatsapp, insta, tiktok, client_id, exception)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+    INSERT INTO "user" (user_id, nama, title, divisi, jabatan, status, whatsapp, insta, tiktok, client_id, exception, ditbinmas, ditlantas)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
     RETURNING *;
   `;
   const params = [
@@ -232,7 +247,9 @@ export async function createUser(userData) {
     userData.insta || "",
     userData.tiktok || "",
     userData.client_id || null,
-    userData.exception ?? false
+    userData.exception ?? false,
+    userData.ditbinmas ?? false,
+    userData.ditlantas ?? false
   ];
   const res = await query(q, params);
   return res.rows[0];

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -8,11 +8,15 @@ jest.unstable_mockModule('../src/repository/db.js', () => ({
 
 let findUserByIdAndWhatsApp;
 let findUserByIdAndClient;
+let createUser;
+let updateUserField;
 
 beforeAll(async () => {
   const mod = await import('../src/model/userModel.js');
   findUserByIdAndWhatsApp = mod.findUserByIdAndWhatsApp;
   findUserByIdAndClient = mod.findUserByIdAndClient;
+  createUser = mod.createUser;
+  updateUserField = mod.updateUserField;
 });
 
 test('findUserByIdAndWhatsApp returns user', async () => {
@@ -32,5 +36,40 @@ test('findUserByIdAndClient returns user', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     'SELECT * FROM "user" WHERE user_id=$1 AND client_id=$2',
     ['1', 'C1']
+  );
+});
+
+test('createUser inserts with directorate flags', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '9' }] });
+  const data = { user_id: '9', nama: 'X', ditbinmas: true, ditlantas: false };
+  const row = await createUser(data);
+  expect(row).toEqual({ user_id: '9' });
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO "user"'),
+    [
+      '9',
+      'X',
+      undefined,
+      undefined,
+      undefined,
+      true,
+      '',
+      '',
+      '',
+      null,
+      false,
+      true,
+      false,
+    ]
+  );
+});
+
+test('updateUserField updates ditbinmas field', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: true }] });
+  const row = await updateUserField('1', 'ditbinmas', true);
+  expect(row).toEqual({ user_id: '1', ditbinmas: true });
+  expect(mockQuery).toHaveBeenCalledWith(
+    'UPDATE "user" SET ditbinmas=$1 WHERE user_id=$2 RETURNING *',
+    [true, '1']
   );
 });


### PR DESCRIPTION
## Summary
- add `ditbinmas` and `ditlantas` columns to user schema
- handle the new flags in `createUser` and `updateUserField`
- expose `getDirektoratUsers` helper
- document new columns in database docs
- extend user model tests for the new behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e076565a08327a3599600d89d0510