### PR TITLE
Revise cron logic based on client status

### DIFF
--- a/src/cron/cronInstaService.js
+++ b/src/cron/cronInstaService.js
@@ -11,7 +11,7 @@ import { rekapLikesIG } from "../handler/fetchabsensi/insta/absensiLikesInsta.js
 import { sendDebug } from "../middleware/debugHandler.js";
 
 cron.schedule(
-  "32 6-20 * * *",
+  "30 6-21 * * *",
   async () => {
     sendDebug({
       tag: "CRON IG",
@@ -46,6 +46,7 @@ cron.schedule(
       });
 
       for (const client of clients) {
+        if (!client.client_insta_status) continue;
         // --- FETCH LIKES IG ---
         try {
           sendDebug({

--- a/src/cron/cronRekapLink.js
+++ b/src/cron/cronRekapLink.js
@@ -12,7 +12,7 @@ async function getActiveClients() {
   const rows = await query(
     `SELECT client_id, nama, client_operator, client_super, client_group
      FROM clients
-     WHERE client_status=true AND client_insta_status=true AND client_amplify_status=true
+     WHERE client_status=true AND client_amplify_status=true
      ORDER BY client_id`
   );
   return rows.rows;
@@ -46,7 +46,7 @@ function getRecipients(client) {
 }
 
 cron.schedule(
-  "2 15,20 * * *",
+  "2 15,18,21 * * *",
   async () => {
     sendDebug({ tag: "CRON LINK", msg: "Mulai rekap link harian" });
     try {

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -224,7 +224,11 @@ export async function absensiLikesPerKonten(client_id, opts = {}) {
 
 export async function getActiveClientsIG() {
   const res = await query(
-    `SELECT client_id, client_insta FROM clients WHERE client_status = true AND client_insta_status = true AND client_amplify_status = true AND client_insta IS NOT NULL`
+    `SELECT client_id, client_insta, client_insta_status, client_amplify_status
+     FROM clients
+     WHERE client_status = true
+       AND (client_insta_status = true OR client_amplify_status = true)
+       AND client_insta IS NOT NULL`
   );
   return res.rows;
 }

--- a/src/handler/fetchpost/instaFetchPost.js
+++ b/src/handler/fetchpost/instaFetchPost.js
@@ -67,7 +67,9 @@ async function deleteShortcodes(shortcodesToDelete, clientId = null) {
 async function getEligibleClients() {
   const res = await query(
     `SELECT client_ID as id, client_insta FROM clients
-      WHERE client_status=true AND client_insta_status=true AND client_insta IS NOT NULL`
+      WHERE client_status=true
+        AND (client_insta_status=true OR client_amplify_status=true)
+        AND client_insta IS NOT NULL`
   );
   return res.rows;
 }


### PR DESCRIPTION
## Summary
- expand eligible Instagram clients for post fetching
- query active IG clients based on insta or amplify status
- run hourly IG cron from 06:30–21:30
- skip likes processing for clients without Instagram enabled
- include amplification recap in Instagram report cron
- adjust link recap cron to run at 15:00, 18:00, 21:00

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e2d54fc4883279152b773e41f869a