### PR TITLE
Add RabbitMQ service and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,14 @@ The API exposes endpoints for managing clients and users, fetching Instagram and
     sudo systemctl enable redis-server
     sudo systemctl start redis-server
     ```
-4. **Initialize the database** using scripts in `sql/schema.sql`.
-5. **Start the application**
+4. **Set up RabbitMQ**
+   ```bash
+   sudo apt-get install rabbitmq-server
+   sudo systemctl enable rabbitmq-server
+   sudo systemctl start rabbitmq-server
+   ```
+5. **Initialize the database** using scripts in `sql/schema.sql`.
+6. **Start the application**
     ```bash
     npm start
     ```
@@ -84,7 +90,7 @@ The API exposes endpoints for managing clients and users, fetching Instagram and
     ```bash
     pm2 start app.js --name cicero_v2
     ```
-6. **Lint & Test**
+7. **Lint & Test**
     ```bash
     npm run lint
     npm test

--- a/docs/rabbitmq.md
+++ b/docs/rabbitmq.md
@@ -1,5 +1,5 @@
 # RabbitMQ Guide
-*Last updated: 2025-06-25*
+*Last updated: 2025-07-10*
 
 This document explains how to enable and use RabbitMQ in **Cicero_V2**. RabbitMQ processes heavy jobs asynchronously so the dashboard remains responsive.
 
@@ -20,6 +20,30 @@ The project may include helper functions such as:
 
 - Run the worker in a separate process using PM2 or another supervisor.
 - Monitor the queue and RabbitMQ connection regularly to avoid bottlenecks.
+
+## 4. Step-by-Step Setup
+
+1. **Install RabbitMQ** (Ubuntu example)
+   ```bash
+   sudo apt-get install rabbitmq-server
+   sudo systemctl enable rabbitmq-server
+   sudo systemctl start rabbitmq-server
+   ```
+2. **Configure the environment**
+   - Ensure `.env` contains `AMQP_URL=amqp://localhost` (or another host).
+3. **Add the helper file** `src/service/rabbitMQService.js` containing
+   `initRabbitMQ`, `publishToQueue`, and `consumeQueue`.
+4. **Run a worker process** to handle heavy jobs
+   ```javascript
+   import { consumeQueue } from '../src/service/rabbitMQService.js';
+
+   consumeQueue('heavy_task', async (data) => {
+     // do processing here
+   });
+   ```
+   Start it with `node worker.js` or `pm2 start worker.js`.
+5. **Publish tasks** from your cron or controllers using
+   `publishToQueue('heavy_task', payload)`.
 
 ---
 See the README section *High Volume Queue (RabbitMQ)* for a short overview.

--- a/src/service/rabbitMQService.js
+++ b/src/service/rabbitMQService.js
@@ -1,0 +1,43 @@
+import amqp from 'amqplib';
+import { env } from '../config/env.js';
+
+let connection;
+let channel;
+
+export async function initRabbitMQ() {
+  if (channel) return channel;
+  connection = await amqp.connect(env.AMQP_URL);
+  channel = await connection.createChannel();
+  return channel;
+}
+
+export async function publishToQueue(queue, msg) {
+  const ch = await initRabbitMQ();
+  await ch.assertQueue(queue, { durable: true });
+  ch.sendToQueue(queue, Buffer.from(JSON.stringify(msg)), {
+    persistent: true
+  });
+}
+
+export async function consumeQueue(queue, onMessage) {
+  const ch = await initRabbitMQ();
+  await ch.assertQueue(queue, { durable: true });
+  await ch.consume(queue, async (msg) => {
+    if (!msg) return;
+    try {
+      const data = JSON.parse(msg.content.toString());
+      await onMessage(data);
+      ch.ack(msg);
+    } catch (err) {
+      console.error('RabbitMQ message error', err);
+      ch.nack(msg, false, false);
+    }
+  });
+}
+
+export async function closeRabbitMQ() {
+  await channel?.close();
+  await connection?.close();
+  channel = undefined;
+  connection = undefined;
+}


### PR DESCRIPTION
## Summary
- implement `rabbitMQService.js` with helper functions
- update RabbitMQ documentation with step-by-step setup
- mention RabbitMQ setup in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e30e7d10c8327ac2dabba76cab108