### PR TITLE
Add special amplify API routes

### DIFF
--- a/src/controller/amplifyKhususController.js
+++ b/src/controller/amplifyKhususController.js
@@ -1,0 +1,19 @@
+import { getRekapLinkByClient } from '../model/linkReportKhususModel.js';
+import { sendConsoleDebug } from '../middleware/debugHandler.js';
+
+export async function getAmplifyKhususRekap(req, res) {
+  const client_id = req.query.client_id;
+  const periode = req.query.periode || 'harian';
+  if (!client_id) {
+    return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
+  }
+  try {
+    sendConsoleDebug({ tag: 'AMPLIFY_KHUSUS', msg: `getAmplifyKhususRekap ${client_id} ${periode}` });
+    const data = await getRekapLinkByClient(client_id, periode);
+    res.json({ success: true, data });
+  } catch (err) {
+    sendConsoleDebug({ tag: 'AMPLIFY_KHUSUS', msg: `Error getAmplifyKhususRekap: ${err.message}` });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
+  }
+}

--- a/src/controller/linkReportKhususController.js
+++ b/src/controller/linkReportKhususController.js
@@ -1,0 +1,66 @@
+import * as linkReportModel from '../model/linkReportKhususModel.js';
+import { sendSuccess } from '../utils/response.js';
+import { extractFirstUrl } from '../utils/utilsHelper.js';
+
+export async function getAllLinkReports(req, res, next) {
+  try {
+    const data = await linkReportModel.getLinkReports();
+    sendSuccess(res, data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getLinkReportByShortcode(req, res, next) {
+  try {
+    const report = await linkReportModel.findLinkReportByShortcode(
+      req.params.shortcode,
+      req.query.user_id
+    );
+    sendSuccess(res, report);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createLinkReport(req, res, next) {
+  try {
+    const data = { ...req.body };
+    ['instagram_link','facebook_link','twitter_link','tiktok_link','youtube_link'].forEach(f => {
+      if (data[f]) data[f] = extractFirstUrl(data[f]);
+    });
+    const report = await linkReportModel.createLinkReport(data);
+    sendSuccess(res, report, 201);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateLinkReport(req, res, next) {
+  try {
+    const bodyData = { ...req.body };
+    ['instagram_link','facebook_link','twitter_link','tiktok_link','youtube_link'].forEach(f => {
+      if (bodyData[f]) bodyData[f] = extractFirstUrl(bodyData[f]);
+    });
+    const report = await linkReportModel.updateLinkReport(
+      req.params.shortcode,
+      bodyData.user_id,
+      bodyData
+    );
+    sendSuccess(res, report);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteLinkReport(req, res, next) {
+  try {
+    const report = await linkReportModel.deleteLinkReport(
+      req.params.shortcode,
+      req.query.user_id
+    );
+    sendSuccess(res, report);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/routes/amplifyKhususRoutes.js
+++ b/src/routes/amplifyKhususRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getAmplifyKhususRekap } from '../controller/amplifyKhususController.js';
+import { authRequired } from '../middleware/authMiddleware.js';
+
+const router = Router();
+
+router.get('/rekap', authRequired, getAmplifyKhususRekap);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,10 +10,12 @@ import tiktokRoutes from "./tiktokRoutes.js";
 import metaRoutes from './metaRoutes.js';
 import logRoutes from './logRoutes.js';
 import linkReportRoutes from './linkReportRoutes.js';
+import linkReportKhususRoutes from './linkReportKhususRoutes.js';
 import premiumSubscriptionRoutes from './premiumSubscriptionRoutes.js';
 import subscriptionRegistrationRoutes from './subscriptionRegistrationRoutes.js';
 import subscriptionConfirmationRoutes from './subscriptionConfirmationRoutes.js';
 import amplifyRoutes from './amplifyRoutes.js';
+import amplifyKhususRoutes from './amplifyKhususRoutes.js';
 import editorialEventRoutes from './editorialEventRoutes.js';
 import approvalRequestRoutes from './approvalRequestRoutes.js';
 import pressReleaseDetailRoutes from './pressReleaseDetailRoutes.js';
@@ -31,6 +33,7 @@ router.use('/oauth', oauthRoutes);
 router.use('/metadata', metaRoutes);
 router.use('/logs', logRoutes);
 router.use('/link-reports', linkReportRoutes);
+router.use('/link-reports-khusus', linkReportKhususRoutes);
 router.use('/events', editorialEventRoutes);
 router.use('/approvals', approvalRequestRoutes);
 router.use('/press-release-details', pressReleaseDetailRoutes);
@@ -38,6 +41,7 @@ router.use('/premium-subscriptions', premiumSubscriptionRoutes);
 router.use('/subscription-registrations', subscriptionRegistrationRoutes);
 router.use('/subscription-confirmations', subscriptionConfirmationRoutes);
 router.use('/amplify', amplifyRoutes);
+router.use('/amplify-khusus', amplifyKhususRoutes);
 
 export default router;
 

--- a/src/routes/linkReportKhususRoutes.js
+++ b/src/routes/linkReportKhususRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import * as controller from '../controller/linkReportKhususController.js';
+
+const router = express.Router();
+
+router.get('/', controller.getAllLinkReports);
+router.get('/:shortcode', controller.getLinkReportByShortcode);
+router.post('/', controller.createLinkReport);
+router.put('/:shortcode', controller.updateLinkReport);
+router.delete('/:shortcode', controller.deleteLinkReport);
+
+export default router;


### PR DESCRIPTION
## Summary
- implement `linkReportKhususController` and routes for special tasks
- add `amplifyKhususController` and routes
- register new routes in the API index

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e50b283388327871c7d36670a92b9