### PR TITLE
Enable client selection for admin oprrequest

### DIFF
--- a/docs/wa_operator_request.md
+++ b/docs/wa_operator_request.md
@@ -1,11 +1,12 @@
 # Panduan Operator WA Bot
 *Last updated: 2025-11-23*
 
-Dokumen ini menjelaskan cara menggunakan perintah `oprrequest` pada Bot WhatsApp **Cicero_V2**. Menu ini hanya untuk operator client dan berguna untuk mengelola data user serta update tugas harian. Hanya nomor operator yang terdaftar pada data client yang dapat mengakses menu ini.
+Dokumen ini menjelaskan cara menggunakan perintah `oprrequest` pada Bot WhatsApp **Cicero_V2**. Menu ini hanya untuk operator client dan berguna untuk mengelola data user serta update tugas harian. Hanya nomor operator yang terdaftar pada data client yang dapat mengakses menu ini. Jika perintah dikirim dari nomor admin, bot akan meminta memilih client terlebih dahulu.
 
 ## Cara Masuk Menu Operator
 1. Kirim perintah `oprrequest` ke Bot WhatsApp.
-2. Bot menampilkan pilihan berikut:
+2. Jika Anda admin, pilih salah satu client yang ditampilkan.
+3. Bot menampilkan pilihan berikut:
    - 1️⃣ Tambah user baru
    - 2️⃣ Update data user
    - 3️⃣ Ubah status user (aktif/nonaktif)

--- a/src/handler/menu/oprRequestHandlers.js
+++ b/src/handler/menu/oprRequestHandlers.js
@@ -25,7 +25,45 @@ Balas angka field di atas atau *batal* untuk keluar.`.trim();
 }
 
 export const oprRequestHandlers = {
- main: async (session, chatId, text, waClient, pool, userModel) => {
+  chooseClientStart: async (session, chatId, text, waClient, pool) => {
+    const rows = await pool.query(
+      "SELECT client_id, nama FROM clients ORDER BY client_id"
+    );
+    const clients = rows.rows;
+    if (!clients.length) {
+      await waClient.sendMessage(chatId, "Tidak ada client terdaftar.");
+      session.step = "main";
+      return oprRequestHandlers.main(session, chatId, text, waClient, pool, userModel);
+    }
+    session.clientList = clients;
+    let msg = `*Daftar Client*\nBalas angka untuk pilih client:\n`;
+    clients.forEach((c, i) => {
+      msg += `${i + 1}. *${c.client_id}* - ${c.nama}\n`;
+    });
+    await waClient.sendMessage(chatId, msg.trim());
+    session.step = "chooseClientStart_action";
+  },
+
+  chooseClientStart_action: async (
+    session,
+    chatId,
+    text,
+    waClient,
+    pool,
+    userModel
+  ) => {
+    const idx = parseInt(text.trim()) - 1;
+    const clients = session.clientList || [];
+    if (isNaN(idx) || !clients[idx]) {
+      await waClient.sendMessage(chatId, "Pilihan tidak valid. Balas angka sesuai daftar.");
+      return;
+    }
+    session.admin_client_id = clients[idx].client_id;
+    session.step = "main";
+    return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
+  },
+
+  main: async (session, chatId, text, waClient, pool, userModel) => {
     let msg =
       `┏━━━ *MENU OPERATOR CICERO* ━━━┓
 👮‍♂️  Hanya untuk operator client.
@@ -55,6 +93,7 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
       delete session.addUser;
       delete session.availableSatfung;
       delete session.updateStatusNRP;
+      delete session.admin_client_id;
       session.step = "main";
     };
     if (/^1$/i.test(text.trim())) {
@@ -451,7 +490,7 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
   },
 
   rekapLink: async (session, chatId, text, waClient, pool, userModel) => {
-    let clientId = session.selected_client_id || null;
+    let clientId = session.selected_client_id || session.admin_client_id || null;
     if (!clientId) {
       const waNum = chatId.replace(/[^0-9]/g, "");
       const q = "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1";
@@ -540,13 +579,13 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nTikTok (${list.tiktok.length}):\n${list.tiktok.join("\n") || "-"}`;
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
-    delete session.selected_client_id;
+    if (!session.admin_client_id) delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
 
   rekapLinkKhusus: async (session, chatId, text, waClient, pool, userModel) => {
-    let clientId = session.selected_client_id || null;
+    let clientId = session.selected_client_id || session.admin_client_id || null;
     if (!clientId) {
       const waNum = chatId.replace(/[^0-9]/g, "");
       const q = "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1";
@@ -609,13 +648,13 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nTikTok (${list.tiktok.length}):\n${list.tiktok.join("\n") || "-"}`;
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
-    delete session.selected_client_id;
+    if (!session.admin_client_id) delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
 
   rekapLinkPerPost: async (session, chatId, text, waClient, pool, userModel) => {
-    let clientId = session.selected_client_id || null;
+    let clientId = session.selected_client_id || session.admin_client_id || null;
     if (!clientId) {
       const waNum = chatId.replace(/[^0-9]/g, "");
       const q = "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1";
@@ -678,7 +717,7 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
       await waClient.sendMessage(chatId, `Belum ada laporan link untuk post tersebut.`);
       session.step = "main";
       delete session.rekapShortcodes;
-      delete session.selected_client_id;
+      if (!session.admin_client_id) delete session.selected_client_id;
       return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
     }
     const list = {
@@ -733,13 +772,13 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
     delete session.rekapShortcodes;
-    delete session.selected_client_id;
+    if (!session.admin_client_id) delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
 
   rekapLinkKhususPerPost: async (session, chatId, text, waClient, pool, userModel) => {
-    let clientId = session.selected_client_id || null;
+    let clientId = session.selected_client_id || session.admin_client_id || null;
     if (!clientId) {
       const waNum = chatId.replace(/[^0-9]/g, "");
       const q = "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1";
@@ -802,7 +841,7 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
       await waClient.sendMessage(chatId, `Belum ada laporan link untuk post tersebut.`);
       session.step = "main";
       delete session.rekapShortcodes;
-      delete session.selected_client_id;
+      if (!session.admin_client_id) delete session.selected_client_id;
       return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
     }
     const list = { facebook: [], instagram: [], twitter: [], tiktok: [], youtube: [] };
@@ -851,13 +890,13 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
     delete session.rekapShortcodes;
-    delete session.selected_client_id;
+    if (!session.admin_client_id) delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
 
   updateTugas: async (session, chatId, text, waClient, pool, userModel) => {
-    let clientId = session.selected_client_id || null;
+    let clientId = session.selected_client_id || session.admin_client_id || null;
     if (!clientId) {
       const waNum = chatId.replace(/[^0-9]/g, "");
       const q = "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1";
@@ -1696,7 +1735,7 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
       return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
     }
     const nrp = text.trim().replace(/[^0-9a-zA-Z]/g, "");
-    let clientId = session.selected_client_id || null;
+    let clientId = session.selected_client_id || session.admin_client_id || null;
     if (!clientId) {
       const waNum = chatId.replace(/[^0-9]/g, "");
       const q = "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1";
@@ -1734,7 +1773,7 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
 `.trim();
       await waClient.sendMessage(chatId, msg);
     }
-    delete session.selected_client_id;
+    if (!session.admin_client_id) delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -182,15 +182,21 @@ waClient.on("message", async (msg) => {
   if (operatorOptionSessions[chatId]) {
     if (/^1$/.test(text.trim())) {
       delete operatorOptionSessions[chatId];
-      setSession(chatId, { menu: "oprrequest", step: "main" });
-      await oprRequestHandlers.main(
-        getSession(chatId),
-        chatId,
-        `┏━━━ *MENU OPERATOR CICERO* ━━━┓\n👮‍♂️  Hanya untuk operator client.\n\n1️⃣ Tambah user baru\n2️⃣ Ubah status user (aktif/nonaktif)\n3️⃣ Cek data user (NRP/NIP)\n4️⃣ Update Tugas\n5️⃣ Rekap link harian\n6️⃣ Rekap link per post\n7️⃣ Absensi Amplifikasi User\n8️⃣ Absensi Registrasi User\n🔟 Tugas Khusus\n1️⃣1️⃣ Rekap link tugas khusus\n1️⃣2️⃣ Rekap per post khusus\n1️⃣3️⃣ Absensi Amplifikasi Khusus\n\nKetik *angka menu* di atas, atau *batal* untuk keluar.\n┗━━━━━━━━━━━━━━━━━━━━━━━━┛`,
-        waClient,
-        pool,
-        userModel
-      );
+      const step = isAdmin ? "chooseClientStart" : "main";
+      setSession(chatId, { menu: "oprrequest", step });
+      const sess = getSession(chatId);
+      if (isAdmin) {
+        await oprRequestHandlers.chooseClientStart(sess, chatId, "", waClient, pool, userModel);
+      } else {
+        await oprRequestHandlers.main(
+          sess,
+          chatId,
+          `┏━━━ *MENU OPERATOR CICERO* ━━━┓\n👮‍♂️  Hanya untuk operator client.\n\n1️⃣ Tambah user baru\n2️⃣ Ubah status user (aktif/nonaktif)\n3️⃣ Cek data user (NRP/NIP)\n4️⃣ Update Tugas\n5️⃣ Rekap link harian\n6️⃣ Rekap link per post\n7️⃣ Absensi Amplifikasi User\n8️⃣ Absensi Registrasi User\n🔟 Tugas Khusus\n1️⃣1️⃣ Rekap link tugas khusus\n1️⃣2️⃣ Rekap per post khusus\n1️⃣3️⃣ Absensi Amplifikasi Khusus\n\nKetik *angka menu* di atas, atau *batal* untuk keluar.\n┗━━━━━━━━━━━━━━━━━━━━━━━━┛`,
+          waClient,
+          pool,
+          userModel
+        );
+      }
       return;
     }
     if (/^2$/.test(text.trim())) {
@@ -306,11 +312,16 @@ waClient.on("message", async (msg) => {
       );
       return;
     }
-    setSession(chatId, { menu: "oprrequest", step: "main" });
-    await oprRequestHandlers.main(
-      getSession(chatId),
-      chatId,
-      `┏━━━ *MENU OPERATOR CICERO* ━━━┓
+    const step = isAdmin ? "chooseClientStart" : "main";
+    setSession(chatId, { menu: "oprrequest", step });
+    const sess = getSession(chatId);
+    if (isAdmin) {
+      await oprRequestHandlers.chooseClientStart(sess, chatId, "", waClient, pool, userModel);
+    } else {
+      await oprRequestHandlers.main(
+        sess,
+        chatId,
+        `┏━━━ *MENU OPERATOR CICERO* ━━━┓
 👮‍♂️  Hanya untuk operator client.
 
 1️⃣ Tambah user baru
@@ -328,10 +339,11 @@ waClient.on("message", async (msg) => {
 
 Ketik *angka menu* di atas, atau *batal* untuk keluar.
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━┛`,
-      waClient,
-      pool,
-      userModel
-    );
+        waClient,
+        pool,
+        userModel
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow admin to choose a client when starting `oprrequest`
- persist selected client while browsing operator menu
- update docs to mention admin client selection

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e5e152e7c832798b0224ee0326960