### PR TITLE
Fix syntax error in oprRequestHandlers

### DIFF
--- a/src/handler/menu/oprRequestHandlers.js
+++ b/src/handler/menu/oprRequestHandlers.js
@@ -1212,7 +1212,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
   },
 
   rekapLink_chooseClient: async (session, chatId, text, waClient, pool) => {
-  rekapLink_chooseClient: async (session, chatId, text, waClient, pool) => {
     const rows = await pool.query(
       "SELECT client_id, nama FROM clients ORDER BY client_id"
     );


### PR DESCRIPTION
## Summary
- remove duplicated `rekapLink_chooseClient` function definition

## Testing
- `npm run lint`
- `npm test`
- `node --check src/handler/menu/oprRequestHandlers.js`

------
https://chatgpt.com/codex/tasks/task_e_687e63955ae4832790e00480e346cf60