### PR TITLE
Enable admin client selection persistence

### DIFF
--- a/docs/wa_operator_request.md
+++ b/docs/wa_operator_request.md
@@ -6,7 +6,8 @@ Dokumen ini menjelaskan cara menggunakan perintah `oprrequest` pada Bot WhatsApp
 ## Cara Masuk Menu Operator
 1. Kirim perintah `oprrequest` ke Bot WhatsApp.
 2. Jika perintah dikirim dari nomor WhatsApp admin, bot terlebih dahulu
-   menampilkan daftar client untuk dipilih.
+   menampilkan daftar client untuk dipilih. Setelah memilih, nomor admin
+   dianggap terdaftar pada client tersebut selama sesi menu berlangsung.
 3. Bot menampilkan pilihan berikut:
    - 1️⃣ Tambah user baru
    - 2️⃣ Update data user

--- a/src/handler/menu/oprRequestHandlers.js
+++ b/src/handler/menu/oprRequestHandlers.js
@@ -568,7 +568,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nTikTok (${list.tiktok.length}):\n${list.tiktok.join("\n") || "-"}`;
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
-    delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
@@ -637,7 +636,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nTikTok (${list.tiktok.length}):\n${list.tiktok.join("\n") || "-"}`;
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
-    delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
@@ -706,7 +704,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
       await waClient.sendMessage(chatId, `Belum ada laporan link untuk post tersebut.`);
       session.step = "main";
       delete session.rekapShortcodes;
-      delete session.selected_client_id;
       return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
     }
     const list = {
@@ -761,7 +758,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
     delete session.rekapShortcodes;
-    delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
@@ -830,7 +826,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
       await waClient.sendMessage(chatId, `Belum ada laporan link untuk post tersebut.`);
       session.step = "main";
       delete session.rekapShortcodes;
-      delete session.selected_client_id;
       return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
     }
     const list = { facebook: [], instagram: [], twitter: [], tiktok: [], youtube: [] };
@@ -879,7 +874,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
     msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
     await waClient.sendMessage(chatId, msg.trim());
     delete session.rekapShortcodes;
-    delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },
@@ -1694,15 +1688,19 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
       await waClient.sendMessage(chatId, "❎ Batal tugas khusus.");
       return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
     }
-    let clientId = null;
-    const waNum = chatId.replace(/[^0-9]/g, "");
-    try {
-      const res = await pool.query(
-        "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1",
-        [waNum]
-      );
-      clientId = res.rows[0]?.client_id || null;
-    } catch (e) { console.error(e); }
+    let clientId = session.selected_client_id || null;
+    if (!clientId) {
+      const waNum = chatId.replace(/[^0-9]/g, "");
+      try {
+        const res = await pool.query(
+          "SELECT client_id FROM clients WHERE client_operator=$1 LIMIT 1",
+          [waNum]
+        );
+        clientId = res.rows[0]?.client_id || null;
+      } catch (e) {
+        console.error(e);
+      }
+    }
     if (!clientId) {
       await waClient.sendMessage(chatId, "❌ Client tidak ditemukan untuk nomor ini.");
       session.step = "main";
@@ -1806,7 +1804,6 @@ Balas *angka* (1/2) sesuai status baru, atau *batal* untuk keluar.
 `.trim();
       await waClient.sendMessage(chatId, msg);
     }
-    delete session.selected_client_id;
     session.step = "main";
     return oprRequestHandlers.main(session, chatId, "", waClient, pool, userModel);
   },


### PR DESCRIPTION
## Summary
- persist selected client ID for admin sessions
- respect selected client when saving special task posts
- clarify operator guide on admin behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e6bbf894c8327bac4bc490d6dc589