### PR TITLE
Add posts khusus API

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -1,6 +1,7 @@
 // src/controller/instaController.js
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import * as instaPostService from "../service/instaPostService.js";
+import * as instaPostKhususService from "../service/instaPostKhususService.js";
 import {
   fetchInstagramPosts,
   fetchInstagramProfile,
@@ -319,6 +320,31 @@ export async function getInstagramUser(req, res) {
     sendSuccess(res, profile);
   } catch (err) {
     sendConsoleDebug({ tag: 'INSTA', msg: `Error getInstagramUser: ${err.message}` });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
+  }
+}
+
+export async function getInstaPostsKhusus(req, res) {
+  try {
+    const client_id =
+      req.query.client_id ||
+      req.user?.client_id ||
+      req.headers["x-client-id"];
+    if (!client_id) {
+      return res
+        .status(400)
+        .json({ success: false, message: "client_id wajib diisi" });
+    }
+
+    sendConsoleDebug({ tag: "INSTA", msg: `getInstaPostsKhusus ${client_id}` });
+    const posts = await instaPostKhususService.findByClientId(client_id);
+    sendSuccess(res, posts);
+  } catch (err) {
+    sendConsoleDebug({
+      tag: "INSTA",
+      msg: `Error getInstaPostsKhusus: ${err.message}`
+    });
     const code = err.statusCode || err.response?.status || 500;
     res.status(code).json({ success: false, message: err.message });
   }

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -3,6 +3,7 @@ import { Router } from "express";
 import {
   getInstaRekapLikes,
   getInstaPosts,
+  getInstaPostsKhusus,
   getRapidInstagramPosts,
   getRapidInstagramProfile,
   getRapidInstagramInfo,
@@ -17,6 +18,7 @@ const router = Router();
 
 router.get("/rekap-likes", authRequired, getInstaRekapLikes);
 router.get("/posts", authRequired, getInstaPosts);
+router.get("/posts-khusus", authRequired, getInstaPostsKhusus);
 router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
 router.get("/rapid-posts-month", authRequired, getRapidInstagramPostsByMonth);
 router.get("/rapid-posts-store", authRequired, getRapidInstagramPostsStore);

--- a/src/service/instaPostKhususService.js
+++ b/src/service/instaPostKhususService.js
@@ -1,0 +1,5 @@
+import * as instaPostKhususModel from '../model/instaPostKhususModel.js';
+
+export const findByClientId = async (client_id) => {
+  return await instaPostKhususModel.findByClientId(client_id);
+};


### PR DESCRIPTION
## Summary
- allow fetching of Instagram posts khusus
- wire `/api/insta/posts-khusus` route

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ecfe560c48327988210abf6c2edd9