### PR TITLE
Move premium fields to user

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -53,6 +53,8 @@ Holds users belonging to a client.
 - `client_id` – foreign key referencing `clients(client_id)`
 - `status` – boolean flag
 - `ditbinmas`, `ditlantas` – boolean flags for directorate assignment
+- `premium_status` – boolean flag indicating active subscription
+- `premium_end_date` – date the premium access expires
 
 ### `dashboard_user`
 Credentials for the web dashboard login.
@@ -110,9 +112,6 @@ Core profile details returned from Instagram scraping.
 - `is_business`, `is_private`, `is_verified`
 - `public_email`, `public_phone_country_code`, `public_phone_number`
 - `profile_pic_url`, `profile_pic_url_hd`
-- `premium_status` – boolean flag indicating active subscription
-- `premium_end_date` – date the premium access expires
-
 ### `instagram_user_metrics`
 Follower and media statistics.
 - `user_id` – primary key referencing `instagram_user`

--- a/docs/premium_subscription.md
+++ b/docs/premium_subscription.md
@@ -1,10 +1,10 @@
 # Premium Subscription
 
-This simplified design stores subscription details directly in `instagram_user`.
-Each user profile has:
+Premium subscription data is stored in the `user` table.
+Each user record includes:
 
 - `premium_status` – boolean flag, `true` when the user has access.
 - `premium_end_date` – optional expiry date.
 
 Administrators update these fields via internal tools or scripts. Protected
-routes check the values from `instagram_user` to determine access.
+routes check the values from `user` to determine access.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -24,7 +24,9 @@ CREATE TABLE "user" (
   client_id VARCHAR REFERENCES clients(client_id),
   status BOOLEAN DEFAULT TRUE,
   ditbinmas BOOLEAN DEFAULT FALSE,
-  ditlantas BOOLEAN DEFAULT FALSE
+  ditlantas BOOLEAN DEFAULT FALSE,
+  premium_status BOOLEAN DEFAULT FALSE,
+  premium_end_date DATE
 );
 
 CREATE TABLE penmas_user (
@@ -135,9 +137,7 @@ CREATE TABLE instagram_user (
     public_phone_country_code VARCHAR(10),
     public_phone_number     VARCHAR(30),
     profile_pic_url         TEXT,
-    profile_pic_url_hd      TEXT,
-    premium_status          BOOLEAN DEFAULT FALSE,
-    premium_end_date        DATE
+    profile_pic_url_hd      TEXT
 );
 
 -- Statistik/metric akun

--- a/src/cron/cronPremiumSubscription.js
+++ b/src/cron/cronPremiumSubscription.js
@@ -8,7 +8,7 @@ cron.schedule(
   '0 0 * * *',
   async () => {
     await query(
-      `UPDATE instagram_user
+      `UPDATE "user"
        SET premium_status=false
        WHERE premium_status=true AND premium_end_date <= NOW()`
     );

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -131,6 +131,14 @@ export async function findUserByIdAndClient(user_id, client_id) {
   return rows[0];
 }
 
+export async function updatePremiumStatus(userId, status, endDate) {
+  const { rows } = await query(
+    'UPDATE "user" SET premium_status=$2, premium_end_date=$3 WHERE user_id=$1 RETURNING *',
+    [userId, status, endDate]
+  );
+  return rows[0] || null;
+}
+
 /**
  * Update field user (termasuk insta/tiktok/whatsapp/exception/status/nama/title/divisi/jabatan)
  */
@@ -147,6 +155,8 @@ export async function updateUserField(user_id, field, value) {
     "jabatan",
     "ditbinmas",
     "ditlantas",
+    "premium_status",
+    "premium_end_date",
   ];
   if (!allowed.includes(field)) throw new Error("Field tidak diizinkan!");
   if (["nama", "title", "divisi", "jabatan"].includes(field) && typeof value === 'string') {

--- a/src/service/premiumService.js
+++ b/src/service/premiumService.js
@@ -1,4 +1,4 @@
-import { findByUserId, updatePremiumStatus } from '../model/instagramUserModel.js';
+import { findUserById as findByUserId, updatePremiumStatus } from '../model/userModel.js';
 
 export async function getPremiumInfo(userId) {
   return findByUserId(userId);

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -10,6 +10,7 @@ let findUserByIdAndWhatsApp;
 let findUserByIdAndClient;
 let createUser;
 let updateUserField;
+let updatePremiumStatus;
 
 beforeAll(async () => {
   const mod = await import('../src/model/userModel.js');
@@ -17,6 +18,7 @@ beforeAll(async () => {
   findUserByIdAndClient = mod.findUserByIdAndClient;
   createUser = mod.createUser;
   updateUserField = mod.updateUserField;
+  updatePremiumStatus = mod.updatePremiumStatus;
 });
 
 test('findUserByIdAndWhatsApp returns user', async () => {
@@ -71,5 +73,15 @@ test('updateUserField updates ditbinmas field', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     'UPDATE "user" SET ditbinmas=$1 WHERE user_id=$2 RETURNING *',
     [true, '1']
+  );
+});
+
+test('updatePremiumStatus updates fields', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '1', premium_status: true }] });
+  const row = await updatePremiumStatus('1', true, '2025-08-01');
+  expect(row).toEqual({ user_id: '1', premium_status: true });
+  expect(mockQuery).toHaveBeenCalledWith(
+    'UPDATE "user" SET premium_status=$2, premium_end_date=$3 WHERE user_id=$1 RETURNING *',
+    ['1', true, '2025-08-01']
   );
 });


### PR DESCRIPTION
## Summary
- add `premium_status` and `premium_end_date` columns to the `user` table
- remove premium fields from `instagram_user`
- switch cron and premium service to use the user table
- expose premium update API in `userModel`
- document the new design and adjust tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f5102ea7883278ba7657731d7ad7e