### PR TITLE
Update premium subscription workflow

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -141,6 +141,9 @@ Stores login events for auditing.
 Records premium subscription requests sent from the mobile app.
 - `request_id` – primary key
 - `user_id` – foreign key to `user`
+- `sender_name` – name of the account owner used for payment
+- `account_number` – bank account number used to transfer
+- `bank_name` – originating bank for the transfer
 - `screenshot_url` – optional path to proof of payment
 - `status` – `pending`, `approved`, `rejected` or `expired`
 - `created_at`, `updated_at` – timestamps

--- a/docs/premium_subscription.md
+++ b/docs/premium_subscription.md
@@ -12,11 +12,12 @@ routes check the values from `user` to determine access.
 ## Premium Request Workflow
 
 Mobile users from the `pegiat_medsos_apps` can request a premium
-subscription through the `/premium-requests` API. Each request records the
-screenshot of the payment and is stored in the `premium_request` table. The
-request will automatically expire after three hours if no admin action is
-taken.
+subscription through the `/premium-requests` API. A request is created with the
+name of the account holder, the account number and the originating bank. After
+the user transfers the fee they upload the proof of payment and confirm the
+request. Only at this confirmation stage does the system notify the
+administrators via WhatsApp.
 
-When a request is created the system sends a WhatsApp notification to the
-administrators. They can approve it by replying `grantsub#<id>` or reject it
-with `denysub#<id>`. Approval sets `premium_status` to `true` for the user.
+Each request will automatically expire after three hours if no confirmation is
+received. Administrators approve by replying `grantsub#<id>` or reject with
+`denysub#<id>`. Approval sets `premium_status` to `true` for the user.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -320,6 +320,9 @@ CREATE TABLE IF NOT EXISTS approval_request (
 CREATE TABLE IF NOT EXISTS premium_request (
   request_id SERIAL PRIMARY KEY,
   user_id TEXT REFERENCES "user"(user_id),
+  sender_name TEXT,
+  account_number TEXT,
+  bank_name TEXT,
   screenshot_url TEXT,
   status VARCHAR(20) DEFAULT 'pending',
   created_at TIMESTAMP DEFAULT NOW(),

--- a/src/controller/premiumRequestController.js
+++ b/src/controller/premiumRequestController.js
@@ -9,10 +9,6 @@ export async function createPremiumRequest(req, res, next) {
       return res.status(400).json({ success: false, message: 'user_id wajib diisi' });
     }
     const row = await premiumReqModel.createRequest(body);
-    if (waReady) {
-      const msg = `\uD83D\uDD14 Permintaan subscription\nUser: ${body.user_id}\nID: ${row.request_id}\nBalas grantsub#${row.request_id} untuk menyetujui atau denysub#${row.request_id} untuk menolak.`;
-      await sendWAReport(waClient, msg);
-    }
     res.status(201).json({ success: true, request: row });
   } catch (err) {
     next(err);
@@ -23,6 +19,10 @@ export async function updatePremiumRequest(req, res, next) {
   try {
     const row = await premiumReqModel.updateRequest(Number(req.params.id), req.body);
     if (!row) return res.status(404).json({ success: false, message: 'not found' });
+    if (req.body.screenshot_url && waReady) {
+      const msg = `\uD83D\uDD14 Permintaan subscription\nUser: ${row.user_id}\nNama: ${row.sender_name}\nRek: ${row.account_number}\nBank: ${row.bank_name}\nID: ${row.request_id}\nBalas grantsub#${row.request_id} untuk menyetujui atau denysub#${row.request_id} untuk menolak.`;
+      await sendWAReport(waClient, msg);
+    }
     res.json({ success: true, request: row });
   } catch (err) {
     next(err);

--- a/src/model/premiumRequestModel.js
+++ b/src/model/premiumRequestModel.js
@@ -2,10 +2,19 @@ import { query } from '../repository/db.js';
 
 export async function createRequest(data) {
   const res = await query(
-    `INSERT INTO premium_request (user_id, screenshot_url, status, created_at, updated_at)
-     VALUES ($1, $2, $3, COALESCE($4, NOW()), COALESCE($5, NOW()))
+    `INSERT INTO premium_request (user_id, sender_name, account_number, bank_name, screenshot_url, status, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7, NOW()), COALESCE($8, NOW()))
      RETURNING *`,
-    [data.user_id, data.screenshot_url || null, data.status || 'pending', data.created_at || null, data.updated_at || null]
+    [
+      data.user_id,
+      data.sender_name || null,
+      data.account_number || null,
+      data.bank_name || null,
+      data.screenshot_url || null,
+      data.status || 'pending',
+      data.created_at || null,
+      data.updated_at || null,
+    ]
   );
   return res.rows[0];
 }
@@ -22,11 +31,23 @@ export async function updateRequest(id, data) {
   const res = await query(
     `UPDATE premium_request SET
       user_id=$2,
-      screenshot_url=$3,
-      status=$4,
-      updated_at=COALESCE($5, NOW())
+      sender_name=$3,
+      account_number=$4,
+      bank_name=$5,
+      screenshot_url=$6,
+      status=$7,
+      updated_at=COALESCE($8, NOW())
      WHERE request_id=$1 RETURNING *`,
-    [id, merged.user_id, merged.screenshot_url, merged.status, data.updated_at || null]
+    [
+      id,
+      merged.user_id,
+      merged.sender_name,
+      merged.account_number,
+      merged.bank_name,
+      merged.screenshot_url,
+      merged.status,
+      data.updated_at || null,
+    ]
   );
   return res.rows[0];
 }

--- a/tests/premiumRequestModel.test.js
+++ b/tests/premiumRequestModel.test.js
@@ -23,23 +23,39 @@ beforeEach(() => {
 
 test('createRequest inserts row', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ request_id: 1 }] });
-  const row = await createRequest({ user_id: '1', screenshot_url: 'x.png' });
+  const row = await createRequest({
+    user_id: '1',
+    sender_name: 'A',
+    account_number: '123',
+    bank_name: 'BCA',
+    screenshot_url: 'x.png',
+  });
   expect(row).toEqual({ request_id: 1 });
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('INSERT INTO premium_request'),
-    ['1', 'x.png', 'pending', null, null]
+    ['1', 'A', '123', 'BCA', 'x.png', 'pending', null, null]
   );
 });
 
 test('updateRequest updates row', async () => {
   mockQuery
-    .mockResolvedValueOnce({ rows: [{ request_id: 1, status: 'pending', user_id: '1', screenshot_url: 'x' }] })
+    .mockResolvedValueOnce({
+      rows: [{
+        request_id: 1,
+        status: 'pending',
+        user_id: '1',
+        sender_name: 'A',
+        account_number: '123',
+        bank_name: 'BCA',
+        screenshot_url: 'x',
+      }],
+    })
     .mockResolvedValueOnce({ rows: [{ request_id: 1, status: 'approved' }] });
   const row = await updateRequest(1, { status: 'approved' });
   expect(row).toEqual({ request_id: 1, status: 'approved' });
   expect(mockQuery).toHaveBeenLastCalledWith(
     expect.stringContaining('UPDATE premium_request'),
-    [1, '1', 'x', 'approved', null]
+    [1, '1', 'A', '123', 'BCA', 'x', 'approved', null]
   );
 });
 


### PR DESCRIPTION
## Summary
- add sender_name, account_number and bank_name columns to `premium_request`
- send WhatsApp notification only after proof of transfer is uploaded
- document new table structure and workflow
- adjust tests for the extended model

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f599172708327826dcf112e0167f4