### PR TITLE
Limit special tasks endpoint to today's posts

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -338,7 +338,7 @@ export async function getInstaPostsKhusus(req, res) {
     }
 
     sendConsoleDebug({ tag: "INSTA", msg: `getInstaPostsKhusus ${client_id}` });
-    const posts = await instaPostKhususService.findByClientId(client_id);
+    const posts = await instaPostKhususService.findTodayByClientId(client_id);
     sendSuccess(res, posts);
   } catch (err) {
     sendConsoleDebug({

--- a/src/service/instaPostKhususService.js
+++ b/src/service/instaPostKhususService.js
@@ -3,3 +3,7 @@ import * as instaPostKhususModel from '../model/instaPostKhususModel.js';
 export const findByClientId = async (client_id) => {
   return await instaPostKhususModel.findByClientId(client_id);
 };
+
+export const findTodayByClientId = async (client_id) => {
+  return await instaPostKhususModel.getPostsTodayByClient(client_id);
+};


### PR DESCRIPTION
## Summary
- filter `getInstaPostsKhusus` to only return today's posts
- add service helper to get today's special posts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68804e70e1e0832780b127d7ebfc3a4f