### PR TITLE
Implement role-based user directory

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -191,6 +191,21 @@ export async function getDirektoratUsers(clientId = null) {
   return rows;
 }
 
+// Ambil user berdasarkan flag direktorat tertentu (ditbinmas/ditlantas)
+export async function getUsersByDirektorat(flag, clientId = null) {
+  if (!['ditbinmas', 'ditlantas'].includes(flag)) {
+    throw new Error('Direktorat flag tidak valid');
+  }
+  let sql = `SELECT * FROM "user" WHERE ${flag} = true`;
+  const params = [];
+  if (clientId) {
+    sql += ' AND client_id = $1';
+    params.push(clientId);
+  }
+  const { rows } = await query(sql, params);
+  return rows;
+}
+
 export async function findUserByWhatsApp(wa) {
   if (!wa) return null;
   const result = await query('SELECT * FROM "user" WHERE whatsapp = $1', [

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -11,6 +11,7 @@ let findUserByIdAndClient;
 let createUser;
 let updateUserField;
 let updatePremiumStatus;
+let getUsersByDirektorat;
 
 beforeAll(async () => {
   const mod = await import('../src/model/userModel.js');
@@ -19,6 +20,7 @@ beforeAll(async () => {
   createUser = mod.createUser;
   updateUserField = mod.updateUserField;
   updatePremiumStatus = mod.updatePremiumStatus;
+  getUsersByDirektorat = mod.getUsersByDirektorat;
 });
 
 test('findUserByIdAndWhatsApp returns user', async () => {
@@ -83,5 +85,15 @@ test('updatePremiumStatus updates fields', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     'UPDATE "user" SET premium_status=$2, premium_end_date=$3 WHERE user_id=$1 RETURNING *',
     ['1', true, '2025-08-01']
+  );
+});
+
+test('getUsersByDirektorat queries by flag', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '2' }] });
+  const users = await getUsersByDirektorat('ditbinmas');
+  expect(users).toEqual([{ user_id: '2' }]);
+  expect(mockQuery).toHaveBeenCalledWith(
+    'SELECT * FROM "user" WHERE ditbinmas = true',
+    []
   );
 });


### PR DESCRIPTION
## Summary
- filter user list by admin role
- query users by directorate flag
- test directorate query helper

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688054f09e888327b6bc23dc1ac936c9