### PR TITLE
Implement role-based user creation

### DIFF
--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -1,0 +1,72 @@
+import { jest } from '@jest/globals';
+
+const mockCreateUser = jest.fn();
+const mockFindUserById = jest.fn();
+const mockUpdateUserField = jest.fn();
+
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  createUser: mockCreateUser,
+  findUserById: mockFindUserById,
+  updateUserField: mockUpdateUserField
+}));
+
+let createUser;
+
+beforeAll(async () => {
+  const mod = await import('../src/controller/userController.js');
+  createUser = mod.createUser;
+});
+
+beforeEach(() => {
+  mockCreateUser.mockReset();
+  mockFindUserById.mockReset();
+  mockUpdateUserField.mockReset();
+});
+
+test('operator adds user with defaults', async () => {
+  mockCreateUser.mockResolvedValue({ user_id: '1' });
+  const req = { body: { user_id: '1', nama: 'A' }, user: { role: 'operator', client_id: 'c1' } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { status, json };
+
+  await createUser(req, res, () => {});
+
+  expect(mockCreateUser).toHaveBeenCalledWith({ user_id: '1', nama: 'A', ditbinmas: false, ditlantas: false });
+  expect(status).toHaveBeenCalledWith(201);
+  expect(json).toHaveBeenCalledWith({ success: true, data: { user_id: '1' } });
+});
+
+test('ditbinmas updates existing user', async () => {
+  mockFindUserById.mockResolvedValue({ user_id: '1', status: false });
+  mockUpdateUserField.mockResolvedValue({ user_id: '1', ditbinmas: true });
+  const req = { body: { user_id: '1' }, user: { role: 'ditbinmas', client_id: 'c2' } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { status, json };
+
+  await createUser(req, res, () => {});
+
+  expect(mockUpdateUserField).toHaveBeenCalledWith('1', 'ditbinmas', true);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({ success: true, data: { user_id: '1', ditbinmas: true } });
+});
+
+test('ditlantas creates new user with flag', async () => {
+  mockFindUserById.mockResolvedValue(null);
+  mockCreateUser.mockResolvedValue({ user_id: '2', ditlantas: true, client_id: 'c2' });
+  const req = { body: { user_id: '2', nama: 'B' }, user: { role: 'ditlantas', client_id: 'c2' } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { status, json };
+
+  await createUser(req, res, () => {});
+
+  expect(mockCreateUser).toHaveBeenCalledWith({
+    user_id: '2',
+    nama: 'B',
+    client_id: 'c2',
+    ditlantas: true
+  });
+  expect(status).toHaveBeenCalledWith(201);
+});


### PR DESCRIPTION
## Summary
- modify `createUser` controller to handle directorate roles
- add `userController` tests for new logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68805b6cb2c4832793dced6fd2d84937