### PR TITLE
Add monthly link report export

### DIFF
--- a/src/controller/linkReportController.js
+++ b/src/controller/linkReportController.js
@@ -1,6 +1,7 @@
 import * as linkReportModel from '../model/linkReportModel.js';
 import { sendSuccess } from '../utils/response.js';
 import { extractFirstUrl } from '../utils/utilsHelper.js';
+import { generateExcelBuffer } from '../service/amplifyExportService.js';
 
 export async function getAllLinkReports(req, res, next) {
   try {
@@ -72,6 +73,30 @@ export async function deleteLinkReport(req, res, next) {
       req.query.user_id
     );
     sendSuccess(res, report);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function downloadMonthlyLinkReportExcel(req, res, next) {
+  try {
+    const clientId = req.query.client_id;
+    if (!clientId) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'client_id wajib diisi' });
+    }
+    const rows = await linkReportModel.getReportsThisMonthByClient(clientId);
+    const buffer = generateExcelBuffer(rows);
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="link_report.xlsx"'
+    );
+    res.send(buffer);
   } catch (err) {
     next(err);
   }

--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -178,3 +178,26 @@ export async function getRekapLinkByClient(client_id, periode = 'harian') {
 
   return rows;
 }
+
+export async function getReportsThisMonthByClient(client_id) {
+  const { rows } = await query(
+    `SELECT
+       r.created_at::date AS date,
+       TRIM(CONCAT(u.title, ' ', u.nama)) AS pangkat_nama,
+       u.user_id AS nrp,
+       u.divisi AS satfung,
+       r.instagram_link AS instagram,
+       r.facebook_link AS facebook,
+       r.twitter_link AS twitter,
+       r.tiktok_link AS tiktok,
+       r.youtube_link AS youtube
+     FROM link_report r
+     JOIN insta_post p ON p.shortcode = r.shortcode
+     JOIN "user" u ON u.user_id = r.user_id
+     WHERE p.client_id = $1
+       AND date_trunc('month', r.created_at) = date_trunc('month', NOW())
+     ORDER BY r.created_at ASC`,
+    [client_id]
+  );
+  return rows;
+}

--- a/src/routes/linkReportRoutes.js
+++ b/src/routes/linkReportRoutes.js
@@ -4,6 +4,7 @@ import * as controller from '../controller/linkReportController.js';
 const router = express.Router();
 
 router.get('/', controller.getAllLinkReports);
+router.get('/excel', controller.downloadMonthlyLinkReportExcel);
 router.get('/:shortcode', controller.getLinkReportByShortcode);
 router.post('/', controller.createLinkReport);
 router.put('/:shortcode', controller.updateLinkReport);

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -15,6 +15,7 @@ let getLinkReports;
 let findLinkReportByShortcode;
 let getReportsTodayByClient;
 let getReportsTodayByShortcode;
+let getReportsThisMonthByClient;
 
 beforeAll(async () => {
   const mod = await import('../src/model/linkReportModel.js');
@@ -23,6 +24,7 @@ beforeAll(async () => {
   findLinkReportByShortcode = mod.findLinkReportByShortcode;
   getReportsTodayByClient = mod.getReportsTodayByClient;
   getReportsTodayByShortcode = mod.getReportsTodayByShortcode;
+  getReportsThisMonthByClient = mod.getReportsThisMonthByClient;
 });
 
 beforeEach(() => {
@@ -86,5 +88,15 @@ test('getReportsTodayByShortcode filters by client and shortcode', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('r.shortcode = $2'),
     ['POLRES', 'abc']
+  );
+});
+
+test('getReportsThisMonthByClient selects monthly rows', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ date: '2024-01-01' }] });
+  const rows = await getReportsThisMonthByClient('POLRES');
+  expect(rows).toEqual([{ date: '2024-01-01' }]);
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining("date_trunc('month', r.created_at)"),
+    ['POLRES']
   );
 });


### PR DESCRIPTION
## Summary
- support exporting monthly link reports to Excel
- expose `GET /link-reports/excel` endpoint
- test monthly link report model query

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688060d3b5b483279515d7f587dae468