### PR TITLE
Implement sheet rename and share

### DIFF
--- a/src/handler/menu/clientRequestHandlers.js
+++ b/src/handler/menu/clientRequestHandlers.js
@@ -1327,7 +1327,7 @@ export const clientRequestHandlers = {
         timeZone: "Asia/Jakarta"
       });
       const title = `Data amplifikasi Bulan ${monthName}`;
-      const url = await createLinkReportSheet(rows, title);
+      const url = await createLinkReportSheet(rows, title, client_id, monthName);
       await waClient.sendMessage(chatId, `✅ Sheet berhasil dibuat:\n${url}`);
       const msg = `Sheet amplifikasi ${client_id} bulan ${monthName}:\n${url}`;
       await sendWAReport(waClient, msg, getAdminWAIds());

--- a/src/service/linkReportSheetService.js
+++ b/src/service/linkReportSheetService.js
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 
-export async function createLinkReportSheet(rows, title) {
+export async function createLinkReportSheet(rows, title, clientId, monthName) {
   const auth = new google.auth.GoogleAuth({
     credentials: {
       client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
@@ -13,11 +13,25 @@ export async function createLinkReportSheet(rows, title) {
   });
   const client = await auth.getClient();
   const sheets = google.sheets({ version: 'v4', auth: client });
+  const drive = google.drive({ version: 'v3', auth: client });
 
   const createRes = await sheets.spreadsheets.create({
     requestBody: { properties: { title } }
   });
   const spreadsheetId = createRes.data.spreadsheetId;
+
+  const newName = `${clientId}_${monthName} Rekap`;
+  await drive.files.update({
+    fileId: spreadsheetId,
+    requestBody: { name: newName }
+  });
+  await drive.permissions.create({
+    fileId: spreadsheetId,
+    requestBody: {
+      type: 'anyone',
+      role: 'reader'
+    }
+  });
 
   const header = [
     'Date',


### PR DESCRIPTION
## Summary
- rename spreadsheets after creation and allow public read access
- adjust command handler to pass new parameters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881af4570148327b486b6404f17a6f8