### PR TITLE
Add Google API request logs

### DIFF
--- a/src/service/amplifyExportService.js
+++ b/src/service/amplifyExportService.js
@@ -1,4 +1,5 @@
 import * as XLSX from 'xlsx';
+import { google } from 'googleapis';
 
 export async function exportRowsToGoogleSheet(rows, fileName = 'Data Rekap Bulan Tahun') {
   const email = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
@@ -8,6 +9,8 @@ export async function exportRowsToGoogleSheet(rows, fileName = 'Data Rekap Bulan
     err.statusCode = 500;
     throw err;
   }
+
+  console.log(`[GOOGLE] Using service account: ${email}`);
 
   const auth = new google.auth.JWT({
     email,
@@ -24,11 +27,12 @@ export async function exportRowsToGoogleSheet(rows, fileName = 'Data Rekap Bulan
 
   const sheets = google.sheets({ version: 'v4', auth });
 
+  console.log('[GOOGLE] Creating new spreadsheet');
   const createRes = await sheets.spreadsheets.create({
     requestBody: { properties: { title: fileName } }
   });
-
   const sheetId = createRes.data.spreadsheetId;
+  console.log(`[GOOGLE] Spreadsheet created with ID: ${sheetId}`);
 
   const header = [
     'Date',
@@ -52,6 +56,7 @@ export async function exportRowsToGoogleSheet(rows, fileName = 'Data Rekap Bulan
     r.youtube || ''
   ]);
 
+  console.log(`[GOOGLE] Appending ${values.length} data rows`);
   await sheets.spreadsheets.values.append({
     spreadsheetId: sheetId,
     range: 'Sheet1',

--- a/src/service/linkReportSheetService.js
+++ b/src/service/linkReportSheetService.js
@@ -18,16 +18,20 @@ export async function createLinkReportSheet(rows, title, clientId, monthName) {
   const sheets = google.sheets({ version: 'v4', auth: client });
   const drive = google.drive({ version: 'v3', auth: client });
 
+  console.log('[GOOGLE] Creating new spreadsheet');
   const createRes = await sheets.spreadsheets.create({
     requestBody: { properties: { title } }
   });
   const spreadsheetId = createRes.data.spreadsheetId;
+  console.log(`[GOOGLE] Spreadsheet created with ID: ${spreadsheetId}`);
 
   const newName = `${clientId}_${monthName} Rekap`;
+  console.log(`[GOOGLE] Renaming spreadsheet to: ${newName}`);
   await drive.files.update({
     fileId: spreadsheetId,
     requestBody: { name: newName }
   });
+  console.log('[GOOGLE] Setting spreadsheet permissions to public read');
   await drive.permissions.create({
     fileId: spreadsheetId,
     requestBody: {
@@ -60,6 +64,7 @@ export async function createLinkReportSheet(rows, title, clientId, monthName) {
     ])
   ];
 
+  console.log(`[GOOGLE] Writing ${values.length - 1} data rows to spreadsheet`);
   await sheets.spreadsheets.values.update({
     spreadsheetId,
     range: 'Sheet1!A1',


### PR DESCRIPTION
## Summary
- log service account usage in `amplifyExportService`
- log each Google Sheets and Drive call in `linkReportSheetService`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881c03857e88327a7467a5bb2dd64de