### PR TITLE
Save spreadsheets in designated Drive folder

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -22,5 +22,6 @@ export const env = cleanEnv(process.env, {
   DEBUG_FETCH_INSTAGRAM: bool({ default: false }),
   AMQP_URL: str({ default: 'amqp://localhost' }),
   GOOGLE_SERVICE_ACCOUNT_EMAIL: str({ default: '' }),
-  GOOGLE_PRIVATE_KEY: str({ default: '' })
+  GOOGLE_PRIVATE_KEY: str({ default: '' }),
+  GOOGLE_SHEET_FOLDER_ID: str({ default: '' })
 });

--- a/src/service/amplifyExportService.js
+++ b/src/service/amplifyExportService.js
@@ -26,12 +26,18 @@ export async function exportRowsToGoogleSheet(rows, fileName = 'Data Rekap Bulan
   });
 
   const sheets = google.sheets({ version: 'v4', auth });
+  const drive = google.drive({ version: 'v3', auth });
 
   console.log('[GOOGLE] Creating new spreadsheet');
-  const createRes = await sheets.spreadsheets.create({
-    requestBody: { properties: { title: fileName } }
+  const createRes = await drive.files.create({
+    requestBody: {
+      name: fileName,
+      mimeType: 'application/vnd.google-apps.spreadsheet',
+      parents: [process.env.GOOGLE_SHEET_FOLDER_ID || 'Sheet_Cicero']
+    },
+    fields: 'id'
   });
-  const sheetId = createRes.data.spreadsheetId;
+  const sheetId = createRes.data.id;
   console.log(`[GOOGLE] Spreadsheet created with ID: ${sheetId}`);
 
   const header = [

--- a/src/service/linkReportSheetService.js
+++ b/src/service/linkReportSheetService.js
@@ -19,10 +19,15 @@ export async function createLinkReportSheet(rows, title, clientId, monthName) {
   const drive = google.drive({ version: 'v3', auth: client });
 
   console.log('[GOOGLE] Creating new spreadsheet');
-  const createRes = await sheets.spreadsheets.create({
-    requestBody: { properties: { title } }
+  const createRes = await drive.files.create({
+    requestBody: {
+      name: title,
+      mimeType: 'application/vnd.google-apps.spreadsheet',
+      parents: [process.env.GOOGLE_SHEET_FOLDER_ID || 'Sheet_Cicero']
+    },
+    fields: 'id'
   });
-  const spreadsheetId = createRes.data.spreadsheetId;
+  const spreadsheetId = createRes.data.id;
   console.log(`[GOOGLE] Spreadsheet created with ID: ${spreadsheetId}`);
 
   const newName = `${clientId}_${monthName} Rekap`;


### PR DESCRIPTION
## Summary
- add `GOOGLE_SHEET_FOLDER_ID` env variable
- create Google Sheets via Drive API and specify parent folder

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881c3f24138832795b544f65a7b3acd