### PR TITLE
Change amplifikasi export to Excel file

### DIFF
--- a/src/service/linkReportExcelService.js
+++ b/src/service/linkReportExcelService.js
@@ -1,0 +1,14 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { generateLinkReportExcelBuffer } from './amplifyExportService.js';
+
+export async function saveLinkReportExcel(rows, clientId, monthName) {
+  const buffer = generateLinkReportExcelBuffer(rows);
+  const exportDir = path.resolve('export_data');
+  await fs.mkdir(exportDir, { recursive: true });
+  const safeMonth = monthName.replace(/\s+/g, '_');
+  const fileName = `${clientId}_${safeMonth}.xlsx`;
+  const filePath = path.join(exportDir, fileName);
+  await fs.writeFile(filePath, buffer);
+  return filePath;
+}

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -1,5 +1,7 @@
 // src/utils/waHelper.js
 import dotenv from 'dotenv';
+import pkg from 'whatsapp-web.js';
+const { MessageMedia } = pkg;
 dotenv.config();
 
 export function getAdminWhatsAppList() {
@@ -23,6 +25,35 @@ export async function sendWAReport(waClient, message, chatIds = null) {
       console.log(`[WA CRON] Sent WA to ${target}: ${message.substring(0, 64)}...`);
     } catch (err) {
       console.error(`[WA CRON] ERROR send WA to ${target}:`, err.message);
+    }
+  }
+}
+
+export async function sendWAFile(
+  waClient,
+  buffer,
+  filename,
+  chatIds = null
+) {
+  const targets = chatIds
+    ? Array.isArray(chatIds)
+      ? chatIds
+      : [chatIds]
+    : getAdminWhatsAppList();
+  const mimeType =
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+  const base64 = buffer.toString('base64');
+  const media = new MessageMedia(mimeType, base64, filename);
+  for (const target of targets) {
+    if (!target || !target.endsWith('@c.us')) {
+      console.warn(`[SKIP WA] Invalid wid: ${target}`);
+      continue;
+    }
+    try {
+      await waClient.sendMessage(target, media, { sendMediaAsDocument: true });
+      console.log(`[WA CRON] Sent file to ${target}: ${filename}`);
+    } catch (err) {
+      console.error(`[WA CRON] ERROR send file to ${target}:`, err.message);
     }
   }
 }


### PR DESCRIPTION
## Summary
- implement `saveLinkReportExcel` utility to save link report rows to an Excel file
- add `sendWAFile` helper for sending documents via WhatsApp
- adjust `downloadSheet_action` to create Excel and send to admin

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881da2f4e508327a03e1fc8a370562e