### PR TITLE
Add monthly amplify link cron job

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ import './src/cron/cronNotifikasiLikesDanKomentar.js';
 import './src/cron/cronInstaDataMining.js';
 import './src/cron/cronPremiumSubscription.js';
 import './src/cron/cronRekapLink.js';
+import './src/cron/cronAmplifyLinkMonthly.js';
 import './src/cron/cronPremiumRequest.js';
 
 const app = express();

--- a/docs/activity_schedule.md
+++ b/docs/activity_schedule.md
@@ -1,5 +1,5 @@
 # System Activity Schedule
-*Last updated: 2025-06-25*
+*Last updated: 2025-07-25*
 
 This document summarizes the automated jobs ("activity") that run inside Cicero_V2. All jobs use `node-cron` and are started automatically when `app.js` boots. Times are in **Asia/Jakarta** timezone.
 
@@ -13,6 +13,7 @@ This document summarizes the automated jobs ("activity") that run inside Cicero_
 | `cronTiktokLaphar.js` | `03 15,18,21 * * *` | Daily at 15:03, 18:03 and 21:03. Fetches TikTok posts and comments then sends attendance reports to recipients. |
 | `cronInstaDataMining.js` | `40 23 * * *` | Daily at 23:40. Crawls Instagram accounts for new posts and stores extended metadata. |
 | `cronNotifikasiLikesDanKomentar.js` | `10 12,16,19 * * *` | Daily at 12:10, 16:10 and 19:10. Sends WhatsApp reminders to users who have not liked/commented on today's posts. |
+| `cronAmplifyLinkMonthly.js` | `0 23 28-31 * *` | At 23:00 on the last day of each month. Generates monthly amplification link reports and sends an Excel file to each operator. |
 
 Each job collects data from the database, interacts with RapidAPI or WhatsApp, and updates the system accordingly. The cron files are imported in `app.js` so no additional setup is required.
 

--- a/src/cron/cronAmplifyLinkMonthly.js
+++ b/src/cron/cronAmplifyLinkMonthly.js
@@ -1,0 +1,85 @@
+import cron from 'node-cron';
+import dotenv from 'dotenv';
+import fs from 'fs/promises';
+import path from 'path';
+import waClient from '../service/waService.js';
+import { sendDebug } from '../middleware/debugHandler.js';
+import { saveLinkReportExcel } from '../service/linkReportExcelService.js';
+import { formatToWhatsAppId, sendWAFile } from '../utils/waHelper.js';
+import { getReportsThisMonthByClient } from '../model/linkReportModel.js';
+
+dotenv.config();
+
+async function getActiveClients() {
+  const { query } = await import('../db/index.js');
+  const res = await query(
+    `SELECT client_id, nama, client_operator
+       FROM clients
+       WHERE client_status=true AND client_amplify_status=true
+       ORDER BY client_id`
+  );
+  return res.rows;
+}
+
+function getJakartaDate() {
+  return new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Jakarta' }));
+}
+
+function isLastDayOfMonth() {
+  const now = getJakartaDate();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(now.getDate() + 1);
+  return tomorrow.getDate() === 1;
+}
+
+cron.schedule(
+  '0 23 28-31 * *',
+  async () => {
+    if (!isLastDayOfMonth()) return;
+    sendDebug({ tag: 'CRON AMPLIFY', msg: 'Mulai rekap link bulanan' });
+    try {
+      const clients = await getActiveClients();
+      for (const client of clients) {
+        try {
+          const rows = await getReportsThisMonthByClient(client.client_id);
+          const monthName = getJakartaDate().toLocaleString('id-ID', {
+            month: 'long',
+            timeZone: 'Asia/Jakarta'
+          });
+          const filePath = await saveLinkReportExcel(
+            rows,
+            client.client_id,
+            monthName
+          );
+          const buffer = await fs.readFile(filePath);
+          const target = client.client_operator
+            ? formatToWhatsAppId(client.client_operator)
+            : null;
+          if (target) {
+            await sendWAFile(waClient, buffer, path.basename(filePath), target);
+            sendDebug({
+              tag: 'CRON AMPLIFY',
+              msg: `[${client.client_id}] File dikirim ke operator`
+            });
+          } else {
+            sendDebug({
+              tag: 'CRON AMPLIFY',
+              msg: `[${client.client_id}] Nomor operator tidak valid`
+            });
+          }
+          await fs.unlink(filePath).catch(() => {});
+        } catch (err) {
+          sendDebug({
+            tag: 'CRON AMPLIFY',
+            msg: `[${client.client_id}] ERROR: ${err.message}`
+          });
+        }
+      }
+    } catch (err) {
+      sendDebug({ tag: 'CRON AMPLIFY', msg: `[ERROR GLOBAL] ${err.message || err}` });
+    }
+  },
+  { timezone: 'Asia/Jakarta' }
+);
+
+export default null;


### PR DESCRIPTION
## Summary
- schedule a monthly amplify link report cron
- load the cron in the main app
- document the new cron schedule

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881e32109d48327810e7204cd39cec8