### PR TITLE
Update query logging

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -10,14 +10,28 @@ if (env.DB_DRIVER && env.DB_DRIVER.toLowerCase() === 'sqlite') {
 }
 
 export const query = async (text, params) => {
-  console.log('[DB QUERY]', text, params);
+  const shouldLog = process.env.NODE_ENV !== 'production';
+  const paramSummary = Array.isArray(params)
+    ? `[${params.length} params]`
+    : params && typeof params === 'object'
+    ? `object with ${Object.keys(params).length} keys`
+    : params !== undefined
+    ? 'scalar param'
+    : 'none';
+  if (shouldLog) {
+    console.log('[DB QUERY]', text, paramSummary);
+  }
   try {
     const res = await adapter.query(text, params);
     const count = res?.rowCount ?? res?.rows?.length ?? 0;
     console.log('[DB RESULT]', count);
     return res;
   } catch (err) {
-    console.error('[DB ERROR]', err.message, { text, params });
+    if (shouldLog) {
+      console.error('[DB ERROR]', err.message, { text, paramSummary });
+    } else {
+      console.error('[DB ERROR]', err.message);
+    }
     throw err;
   }
 };


### PR DESCRIPTION
## Summary
- control SQL logging based on `NODE_ENV`
- avoid leaking full parameter values

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876ec183f883279be2bda09e928484