### PR TITLE
Fix monthly rekap timezone

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -80,9 +80,9 @@ export async function getLikesByShortcode(shortcode) {
  */
 
 export async function getRekapLikesByClient(client_id, periode = "harian") {
-  let tanggalFilter = "created_at::date = NOW()::date";
+  let tanggalFilter = "created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   if (periode === "bulanan") {
-    tanggalFilter = "date_trunc('month', created_at) = date_trunc('month', NOW())";
+    tanggalFilter = "date_trunc('month', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
   }
 
   // Ambil jumlah post IG untuk periode

--- a/src/model/linkReportKhususModel.js
+++ b/src/model/linkReportKhususModel.js
@@ -96,7 +96,7 @@ export async function getReportsTodayByClient(client_id) {
   const res = await query(
     `SELECT r.* FROM link_report_khusus r
      JOIN "user" u ON u.user_id = r.user_id
-     WHERE u.client_id = $1 AND r.created_at::date = NOW()::date
+     WHERE u.client_id = $1 AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ORDER BY r.created_at ASC`,
     [client_id]
   );
@@ -108,7 +108,7 @@ export async function getReportsTodayByShortcode(client_id, shortcode) {
     `SELECT r.* FROM link_report_khusus r
      JOIN "user" u ON u.user_id = r.user_id
      WHERE u.client_id = $1 AND r.shortcode = $2
-       AND r.created_at::date = NOW()::date
+       AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ORDER BY r.created_at ASC`,
     [client_id, shortcode]
   );
@@ -119,8 +119,8 @@ export async function getRekapLinkByClient(
   periode = 'harian',
   tanggal
 ) {
-  let dateFilterPost = 'p.created_at::date = NOW()::date';
-  let dateFilterReport = 'r.created_at::date = NOW()::date';
+  let dateFilterPost = "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
+  let dateFilterReport = "r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
   if (periode === 'semua') {
     dateFilterPost = '1=1';
@@ -138,11 +138,11 @@ export async function getRekapLinkByClient(
     if (tanggal) {
       const monthDate = tanggal.length === 7 ? `${tanggal}-01` : tanggal;
       params.push(monthDate);
-      dateFilterPost = "date_trunc('month', p.created_at) = date_trunc('month', $2::date)";
-      dateFilterReport = "date_trunc('month', r.created_at) = date_trunc('month', $2::date)";
+      dateFilterPost = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
+      dateFilterReport = "date_trunc('month', r.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
     } else {
-      dateFilterPost = "date_trunc('month', p.created_at) = date_trunc('month', NOW())";
-      dateFilterReport = "date_trunc('month', r.created_at) = date_trunc('month', NOW())";
+      dateFilterPost = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
+      dateFilterReport = "date_trunc('month', r.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
     }
   } else if (tanggal) {
     params.push(tanggal);

--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -96,7 +96,7 @@ export async function getReportsTodayByClient(client_id) {
   const res = await query(
     `SELECT r.* FROM link_report r
      JOIN "user" u ON u.user_id = r.user_id
-     WHERE u.client_id = $1 AND r.created_at::date = NOW()::date
+     WHERE u.client_id = $1 AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ORDER BY r.created_at ASC`,
     [client_id]
   );
@@ -108,7 +108,7 @@ export async function getReportsTodayByShortcode(client_id, shortcode) {
     `SELECT r.* FROM link_report r
      JOIN "user" u ON u.user_id = r.user_id
      WHERE u.client_id = $1 AND r.shortcode = $2
-       AND r.created_at::date = NOW()::date
+       AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ORDER BY r.created_at ASC`,
     [client_id, shortcode]
   );
@@ -119,8 +119,8 @@ export async function getRekapLinkByClient(
   periode = 'harian',
   tanggal
 ) {
-  let dateFilterPost = 'p.created_at::date = NOW()::date';
-  let dateFilterReport = 'r.created_at::date = NOW()::date';
+  let dateFilterPost = "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
+  let dateFilterReport = "r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
   if (periode === 'semua') {
     dateFilterPost = '1=1';
@@ -138,11 +138,11 @@ export async function getRekapLinkByClient(
     if (tanggal) {
       const monthDate = tanggal.length === 7 ? `${tanggal}-01` : tanggal;
       params.push(monthDate);
-      dateFilterPost = "date_trunc('month', p.created_at) = date_trunc('month', $2::date)";
-      dateFilterReport = "date_trunc('month', r.created_at) = date_trunc('month', $2::date)";
+      dateFilterPost = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
+      dateFilterReport = "date_trunc('month', r.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
     } else {
-      dateFilterPost = "date_trunc('month', p.created_at) = date_trunc('month', NOW())";
-      dateFilterReport = "date_trunc('month', r.created_at) = date_trunc('month', NOW())";
+      dateFilterPost = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
+      dateFilterReport = "date_trunc('month', r.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
     }
   } else if (tanggal) {
     params.push(tanggal);
@@ -220,7 +220,7 @@ export async function getReportsThisMonthByClient(client_id) {
      JOIN insta_post p ON p.shortcode = r.shortcode
      JOIN "user" u ON u.user_id = r.user_id
      WHERE p.client_id = $1
-       AND date_trunc('month', r.created_at) = date_trunc('month', NOW())
+       AND date_trunc('month', r.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')
      ORDER BY r.created_at ASC`,
     [client_id]
   );

--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -63,9 +63,9 @@ export const findByVideoId = getCommentsByVideoId;
 
 
 export async function getRekapKomentarByClient(client_id, periode = "harian") {
-  let tanggalFilter = "p.created_at::date = NOW()::date";
+  let tanggalFilter = "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   if (periode === "bulanan") {
-    tanggalFilter = "date_trunc('month', p.created_at) = date_trunc('month', NOW())";
+    tanggalFilter = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
   }
 
   const { rows: postRows } = await query(

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -98,7 +98,7 @@ test('getReportsThisMonthByClient selects monthly rows', async () => {
   const rows = await getReportsThisMonthByClient('POLRES');
   expect(rows).toEqual([{ date: '2024-01-01' }]);
   expect(mockQuery).toHaveBeenCalledWith(
-    expect.stringContaining("date_trunc('month', r.created_at)"),
+    expect.stringContaining("date_trunc('month', r.created_at AT TIME ZONE 'Asia/Jakarta')"),
     ['POLRES']
   );
 });


### PR DESCRIPTION
## Summary
- ensure queries use Asia/Jakarta timezone for monthly reports
- update tests for new query

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688846c4c5c08327a5b5df386b8d78b8