### PR TITLE
Implement periode filter for dashboard stats

### DIFF
--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -87,3 +87,35 @@ export async function getPostsByClientId(client_id) {
 export async function findByClientId(client_id) {
   return getPostsByClientId(client_id);
 }
+
+export async function countPostsByClient(client_id, periode = 'harian', tanggal) {
+  let dateFilter = "created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
+  const params = [client_id];
+  if (periode === 'semua') {
+    dateFilter = '1=1';
+  } else if (periode === 'mingguan') {
+    if (tanggal) {
+      params.push(tanggal);
+      dateFilter = "date_trunc('week', created_at) = date_trunc('week', $2::date)";
+    } else {
+      dateFilter = "date_trunc('week', created_at) = date_trunc('week', NOW())";
+    }
+  } else if (periode === 'bulanan') {
+    if (tanggal) {
+      const monthDate = tanggal.length === 7 ? `${tanggal}-01` : tanggal;
+      params.push(monthDate);
+      dateFilter = "date_trunc('month', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
+    } else {
+      dateFilter = "date_trunc('month', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
+    }
+  } else if (tanggal) {
+    params.push(tanggal);
+    dateFilter = 'created_at::date = $2::date';
+  }
+
+  const { rows } = await query(
+    `SELECT COUNT(*) AS jumlah_post FROM insta_post WHERE client_id = $1 AND ${dateFilter}`,
+    params
+  );
+  return parseInt(rows[0]?.jumlah_post || '0', 10);
+}


### PR DESCRIPTION
## Summary
- add countPostsByClient helper to Insta/TikTok models for period filtering
- support `periode` and `tanggal` params in dashboard stats endpoint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b4249418c8327a5a3ad9d887bfde2