### PR TITLE
Fix TikTok rekap filter logic

### DIFF
--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -63,11 +63,12 @@ import { getRekapKomentarByClient } from '../model/tiktokCommentModel.js';
 export async function getTiktokRekapKomentar(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || 'harian';
+  const tanggal = req.query.tanggal;
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }
   try {
-    const data = await getRekapKomentarByClient(client_id, periode);
+    const data = await getRekapKomentarByClient(client_id, periode, tanggal);
     res.json({ success: true, data });
   } catch (err) {
     const code = err.statusCode || err.response?.status || 500;


### PR DESCRIPTION
## Summary
- add periode & tanggal support for TikTok comment recap
- pass tanggal to TikTok recap controller

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b4488431c83279471b20e7022aa9a