### PR TITLE
feat: sync single IG post to main table

### DIFF
--- a/src/handler/fetchpost/instaFetchPost.js
+++ b/src/handler/fetchpost/instaFetchPost.js
@@ -6,6 +6,7 @@ import { sendDebug } from "../../middleware/debugHandler.js";
 import { fetchInstagramPosts, fetchInstagramPostInfo } from "../../service/instagramApi.js";
 import { savePostWithMedia } from "../../model/instaPostExtendedModel.js";
 import { upsertInstaPost as upsertInstaPostKhusus } from "../../model/instaPostKhususModel.js";
+import { upsertInstaPost } from "../../model/instaPostModel.js";
 import { extractInstagramShortcode } from "../../utils/utilsHelper.js";
 
 const ADMIN_WHATSAPP = (process.env.ADMIN_WHATSAPP || "")
@@ -352,8 +353,9 @@ export async function fetchSinglePostKhusus(linkOrCode, clientId) {
       : null,
     is_carousel: Array.isArray(info.carousel_media) && info.carousel_media.length > 1,
     created_at: info.taken_at ? new Date(info.taken_at * 1000).toISOString() : null
-  };
+  }; 
   await upsertInstaPostKhusus(data);
+  await upsertInstaPost(data);
   try {
     await savePostWithMedia(info);
   } catch (e) {


### PR DESCRIPTION
## Summary
- import upsertInstaPost in instaFetchPost handler
- persist fetched post into main insta_post table before saving media

## Testing
- `npm run lint`
- `npm test`
- `node -e "import('./src/handler/fetchpost/instaFetchPost.js').then(async ({fetchSinglePostKhusus}) => {try{await fetchSinglePostKhusus('https://www.instagram.com/p/C8q123abc', 1);}catch(e){console.error('fetch error:', e.message);}})"` *(fails: Failed to launch the browser process! libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689207cc0d5883278bafe5ba8c16ea7c