### PR TITLE
Add cascading deletes for IG extended posts

### DIFF
--- a/sql/migrations/20241009_addOnDeleteCascade.sql
+++ b/sql/migrations/20241009_addOnDeleteCascade.sql
@@ -1,0 +1,30 @@
+-- Add cascading deletes for ig_ext_posts relations
+ALTER TABLE ig_ext_posts
+  DROP CONSTRAINT IF EXISTS ig_ext_posts_shortcode_fkey,
+  ADD CONSTRAINT ig_ext_posts_shortcode_fkey FOREIGN KEY (shortcode)
+    REFERENCES insta_post(shortcode) ON DELETE CASCADE;
+
+ALTER TABLE ig_ext_media_items
+  DROP CONSTRAINT IF EXISTS ig_ext_media_items_post_id_fkey,
+  ADD CONSTRAINT ig_ext_media_items_post_id_fkey FOREIGN KEY (post_id)
+    REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE;
+
+ALTER TABLE ig_ext_hashtags
+  DROP CONSTRAINT IF EXISTS ig_ext_hashtags_post_id_fkey,
+  ADD CONSTRAINT ig_ext_hashtags_post_id_fkey FOREIGN KEY (post_id)
+    REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE;
+
+ALTER TABLE ig_post_metrics
+  DROP CONSTRAINT IF EXISTS ig_post_metrics_post_id_fkey,
+  ADD CONSTRAINT ig_post_metrics_post_id_fkey FOREIGN KEY (post_id)
+    REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE;
+
+ALTER TABLE ig_post_like_users
+  DROP CONSTRAINT IF EXISTS ig_post_like_users_post_id_fkey,
+  ADD CONSTRAINT ig_post_like_users_post_id_fkey FOREIGN KEY (post_id)
+    REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE;
+
+ALTER TABLE ig_post_comments
+  DROP CONSTRAINT IF EXISTS ig_post_comments_post_id_fkey,
+  ADD CONSTRAINT ig_post_comments_post_id_fkey FOREIGN KEY (post_id)
+    REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -162,7 +162,7 @@ CREATE TABLE IF NOT EXISTS ig_ext_users (
 
 CREATE TABLE IF NOT EXISTS ig_ext_posts (
     post_id VARCHAR(50) PRIMARY KEY,
-    shortcode VARCHAR(50) UNIQUE REFERENCES insta_post(shortcode),
+    shortcode VARCHAR(50) UNIQUE REFERENCES insta_post(shortcode) ON DELETE CASCADE,
     user_id VARCHAR(50) REFERENCES ig_ext_users(user_id),
     caption_text TEXT,
     created_at TIMESTAMP,
@@ -175,7 +175,7 @@ CREATE TABLE IF NOT EXISTS ig_ext_posts (
 
 CREATE TABLE IF NOT EXISTS ig_ext_media_items (
     media_id VARCHAR(50) PRIMARY KEY,
-    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id),
+    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE,
     media_type INT,
     is_video BOOLEAN,
     original_width INT,
@@ -195,7 +195,7 @@ CREATE TABLE IF NOT EXISTS ig_ext_tagged_users (
 );
 
 CREATE TABLE IF NOT EXISTS ig_ext_hashtags (
-    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id),
+    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE,
     hashtag VARCHAR(100),
     PRIMARY KEY (post_id, hashtag)
 );
@@ -218,7 +218,7 @@ CREATE TABLE IF NOT EXISTS ig_hashtag_info (
 
 -- Statistik lanjutan untuk setiap post
 CREATE TABLE IF NOT EXISTS ig_post_metrics (
-    post_id VARCHAR(50) PRIMARY KEY REFERENCES ig_ext_posts(post_id),
+    post_id VARCHAR(50) PRIMARY KEY REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE,
     play_count INT,
     save_count INT,
     share_count INT,
@@ -229,7 +229,7 @@ CREATE TABLE IF NOT EXISTS ig_post_metrics (
 
 -- Relational table for individual likes
 CREATE TABLE IF NOT EXISTS ig_post_like_users (
-    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id),
+    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE,
     user_id VARCHAR(50) REFERENCES ig_ext_users(user_id),
     username VARCHAR(100),
     PRIMARY KEY (post_id, user_id)
@@ -238,7 +238,7 @@ CREATE TABLE IF NOT EXISTS ig_post_like_users (
 -- Store individual comments for a post
 CREATE TABLE IF NOT EXISTS ig_post_comments (
     comment_id VARCHAR(50) PRIMARY KEY,
-    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id),
+    post_id VARCHAR(50) REFERENCES ig_ext_posts(post_id) ON DELETE CASCADE,
     user_id VARCHAR(50) REFERENCES ig_ext_users(user_id),
     text TEXT,
     created_at TIMESTAMP


### PR DESCRIPTION
## Summary
- cascade `ig_ext_posts.shortcode` to `insta_post`
- cascade deletes from `ig_ext_posts.post_id` to dependent tables
- add migration to drop and recreate these foreign keys with cascading

## Testing
- `npm run lint`
- `CI=1 npm test`
- ran migration and verified cascade behavior by inserting and deleting a sample post


------
https://chatgpt.com/codex/tasks/task_e_6894533f335c832788fae0f5164ba365