### PR TITLE
feat: add impersonated JWT for Google People

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -22,6 +22,7 @@ export const env = cleanEnv(process.env, {
   DEBUG_FETCH_INSTAGRAM: bool({ default: false }),
   AMQP_URL: str({ default: 'amqp://localhost' }),
   GOOGLE_SERVICE_ACCOUNT: str({ default: '' }),
+  GOOGLE_IMPERSONATE_EMAIL: str({ default: '' }),
   GOOGLE_CONTACT_SCOPE: str({
     default: 'https://www.googleapis.com/auth/contacts'
   })


### PR DESCRIPTION
## Summary
- add `GOOGLE_IMPERSONATE_EMAIL` env var
- use JWT client with impersonation for Google People API
- log HTTP status code on Google contact save errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894676ce7348327bf17b0128d4d0ebc