### PR TITLE
Ensure ig_ext_posts references are removed before insta_post deletions

### DIFF
--- a/src/handler/fetchpost/instaFetchPost.js
+++ b/src/handler/fetchpost/instaFetchPost.js
@@ -53,6 +53,10 @@ async function getShortcodesToday(clientId = null) {
 
 async function deleteShortcodes(shortcodesToDelete, clientId = null) {
   if (!shortcodesToDelete.length) return;
+  await query(
+    `DELETE FROM ig_ext_posts WHERE shortcode = ANY($1)`,
+    [shortcodesToDelete]
+  );
   const today = new Date();
   const yyyy = today.getFullYear();
   const mm = String(today.getMonth() + 1).padStart(2, "0");


### PR DESCRIPTION
## Summary
- delete ig_ext_posts rows for removed shortcodes before removing the matching insta_post rows to avoid FK issues

## Testing
- `psql -f sql/migrations/20241009_addOnDeleteCascade.sql` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689480a5dc2c83279d0f1e01adfa7d48