### PR TITLE
Cascade delete for tagged user media links

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -1,6 +1,6 @@
 # Database Structure
 
-*Last updated: 2025-07-18*
+*Last updated: 2025-08-07*
 
 This document describes the main tables inside Cicero_V2 and their relationships.
 The SQL schema is located at [sql/schema.sql](../sql/schema.sql) and is designed
@@ -24,7 +24,7 @@ for PostgreSQL but can work with MySQL or SQLite via the DB adapter.
 | ig_ext_users | RapidAPI user reference |
 | ig_ext_posts | RapidAPI post reference |
 | ig_ext_media_items | media items within a post |
-| ig_ext_tagged_users | tagged users inside a media item |
+| ig_ext_tagged_users | tagged users inside a media item; `media_id` cascades with `ig_ext_media_items` |
 | ig_ext_hashtags | hashtags detected in posts |
 | ig_hashtag_info | metadata for individual hashtags |
 | ig_post_metrics | advanced engagement metrics |

--- a/sql/migrations/20250807_taggedUsersCascade.sql
+++ b/sql/migrations/20250807_taggedUsersCascade.sql
@@ -1,0 +1,5 @@
+-- Add cascading deletes for ig_ext_tagged_users
+ALTER TABLE ig_ext_tagged_users
+  DROP CONSTRAINT IF EXISTS ig_ext_tagged_users_media_id_fkey,
+  ADD CONSTRAINT ig_ext_tagged_users_media_id_fkey FOREIGN KEY (media_id)
+    REFERENCES ig_ext_media_items(media_id) ON DELETE CASCADE;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -187,7 +187,7 @@ CREATE TABLE IF NOT EXISTS ig_ext_media_items (
 );
 
 CREATE TABLE IF NOT EXISTS ig_ext_tagged_users (
-    media_id VARCHAR(50) REFERENCES ig_ext_media_items(media_id),
+    media_id VARCHAR(50) REFERENCES ig_ext_media_items(media_id) ON DELETE CASCADE,
     user_id VARCHAR(50) REFERENCES ig_ext_users(user_id),
     x REAL,
     y REAL,


### PR DESCRIPTION
## Summary
- cascade delete tagged-user records when their parent media item is removed
- document ig_ext_tagged_users to note cascading media_id
- add migration to update ig_ext_tagged_users media_id foreign key

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689490da3bd4832783042fc960c16809