### PR TITLE
Cascade link_report entries with post deletion

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -128,6 +128,7 @@ Follower and media statistics.
 - `shortcode` and `user_id` form the primary key
 - `instagram_link`, `facebook_link`, `twitter_link`, `tiktok_link`, `youtube_link`
 - `created_at` – timestamp when the report was submitted
+- Rows cascade when the related `insta_post` is removed
 
 ### `login_log`
 Stores login events for auditing.

--- a/sql/migrations/20250808_linkReportCascade.sql
+++ b/sql/migrations/20250808_linkReportCascade.sql
@@ -1,0 +1,6 @@
+-- Ensure link_report entries are removed when the referenced post is deleted
+ALTER TABLE link_report
+  DROP CONSTRAINT IF EXISTS link_report_shortcode_fkey,
+  ADD CONSTRAINT link_report_shortcode_fkey FOREIGN KEY (shortcode)
+    REFERENCES insta_post(shortcode) ON DELETE CASCADE;
+

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -252,7 +252,7 @@ CREATE TABLE visitor_logs (
 );
 
 CREATE TABLE IF NOT EXISTS link_report (
-    shortcode VARCHAR REFERENCES insta_post(shortcode),
+    shortcode VARCHAR REFERENCES insta_post(shortcode) ON DELETE CASCADE,
     user_id VARCHAR REFERENCES "user"(user_id),
     instagram_link TEXT,
     facebook_link TEXT,


### PR DESCRIPTION
## Summary
- cascade delete link_report entries when related insta_post is removed
- document link_report cascading behavior
- add migration to drop/recreate foreign key with ON DELETE CASCADE

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894928f47ac83278e7059cd906d3bdf