### PR TITLE
feat: add date filtering to Instagram like recap

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -18,12 +18,13 @@ import { sendConsoleDebug } from "../middleware/debugHandler.js";
 export async function getInstaRekapLikes(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || "harian";
+  const tanggal = req.query.tanggal;
   if (!client_id) {
     return res.status(400).json({ success: false, message: "client_id wajib diisi" });
   }
   try {
-    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode}` });
-    const data = await getRekapLikesByClient(client_id, periode);
+    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''}` });
+    const data = await getRekapLikesByClient(client_id, periode, tanggal);
     res.json({ success: true, data });
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaRekapLikes: ${err.message}` });

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -1,0 +1,59 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery,
+}));
+
+let getRekapLikesByClient;
+
+beforeAll(async () => {
+  ({ getRekapLikesByClient } = await import('../src/model/instaLikeModel.js'));
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('harian with specific date uses date filter', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('1', 'harian', '2023-10-05');
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('created_at::date = $2::date'),
+    ['1', '2023-10-05']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining('created_at::date = $2::date'),
+    ['1', '2023-10-05']
+  );
+});
+
+test('mingguan with date truncs week', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('1', 'mingguan', '2023-10-05');
+  const expected = "date_trunc('week', created_at) = date_trunc('week', $2::date)";
+  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
+  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
+});
+
+test('bulanan converts month string', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('1', 'bulanan', '2023-10');
+  const expected = "date_trunc('month', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
+  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-01']);
+  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-01']);
+});
+
+test('semua uses no date filter', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('1', 'semua');
+  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining('1=1'), ['1']);
+  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining('1=1'), ['1']);
+});


### PR DESCRIPTION
## Summary
- pass optional `tanggal` to like recap controller
- support harian, mingguan, bulanan, and semua periods with custom dates in `getRekapLikesByClient`
- test recap date filters across periods

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958ab2174c83278e65d369fab6023c