### PR TITLE
Include SPKT in division sorting order

### DIFF
--- a/src/utils/utilsHelper.js
+++ b/src/utils/utilsHelper.js
@@ -1,5 +1,5 @@
 export function sortDivisionKeys(keys) {
-  const order = ["BAG", "SAT", "SI", "POLSEK"];
+  const order = ["BAG", "SAT", "SI", "SPKT", "POLSEK"];
   return keys.sort((a, b) => {
     const ia = order.findIndex((prefix) => a.toUpperCase().startsWith(prefix));
     const ib = order.findIndex((prefix) => b.toUpperCase().startsWith(prefix));


### PR DESCRIPTION
## Summary
- ensure SPKT divisions sort correctly alongside BAG, SAT, and SI

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68959d7c9c188327ab80848069447f8a