### PR TITLE
Fix JSON containment for Insta likes rekap

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -134,7 +134,7 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
       COALESCE(COUNT(DISTINCT vl.shortcode), 0) AS jumlah_like
     FROM "user" u
     LEFT JOIN valid_likes vl
-      ON vl.likes @> to_jsonb(u.insta)
+      ON vl.likes::jsonb @> to_jsonb(ARRAY[u.insta])
     WHERE u.client_id = $1
       AND u.status = true
       AND u.insta IS NOT NULL


### PR DESCRIPTION
## Summary
- correct JSON containment when matching usernames in Instagram like rekap query

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d74a3330832790ed50a5b1b8583b