### PR TITLE
Add date range filters for analytics endpoints

### DIFF
--- a/src/controller/dashboardController.js
+++ b/src/controller/dashboardController.js
@@ -13,12 +13,14 @@ export async function getDashboardStats(req, res) {
 
     const periode = req.query.periode || 'harian';
     const tanggal = req.query.tanggal;
+    const start_date = req.query.start_date;
+    const end_date = req.query.end_date;
 
     const [clients, users, igPostCount, ttPostCount] = await Promise.all([
       getAllClients(),
       getAllUsers(client_id), // <- ini
-      countInstaPostsByClient(client_id, periode, tanggal),
-      countTiktokPostsByClient(client_id, periode, tanggal),
+      countInstaPostsByClient(client_id, periode, tanggal, start_date, end_date),
+      countTiktokPostsByClient(client_id, periode, tanggal, start_date, end_date),
     ]);
 
     // === FILTER HANYA USER AKTIF

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -19,12 +19,14 @@ export async function getInstaRekapLikes(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || "harian";
   const tanggal = req.query.tanggal;
+  const start_date = req.query.start_date;
+  const end_date = req.query.end_date;
   if (!client_id) {
     return res.status(400).json({ success: false, message: "client_id wajib diisi" });
   }
   try {
-    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''}` });
-    const data = await getRekapLikesByClient(client_id, periode, tanggal);
+    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${start_date || ''} ${end_date || ''}` });
+    const data = await getRekapLikesByClient(client_id, periode, tanggal, start_date, end_date);
     res.json({ success: true, data });
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaRekapLikes: ${err.message}` });

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -64,11 +64,13 @@ export async function getTiktokRekapKomentar(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || 'harian';
   const tanggal = req.query.tanggal;
+  const start_date = req.query.start_date;
+  const end_date = req.query.end_date;
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }
   try {
-    const data = await getRekapKomentarByClient(client_id, periode, tanggal);
+    const data = await getRekapKomentarByClient(client_id, periode, tanggal, start_date, end_date);
     res.json({ success: true, data });
   } catch (err) {
     const code = err.statusCode || err.response?.status || 500;

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -79,10 +79,13 @@ export async function getLikesByShortcode(shortcode) {
  * @returns {Promise<Array>}
  */
 
-export async function getRekapLikesByClient(client_id, periode = "harian", tanggal) {
+export async function getRekapLikesByClient(client_id, periode = "harian", tanggal, start_date, end_date) {
   let tanggalFilter = "created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
-  if (periode === 'semua') {
+  if (start_date && end_date) {
+    params.push(start_date, end_date);
+    tanggalFilter = 'created_at::date BETWEEN $2::date AND $3::date';
+  } else if (periode === 'semua') {
     tanggalFilter = '1=1';
   } else if (periode === 'mingguan') {
     if (tanggal) {

--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -88,10 +88,13 @@ export async function findByClientId(client_id) {
   return getPostsByClientId(client_id);
 }
 
-export async function countPostsByClient(client_id, periode = 'harian', tanggal) {
+export async function countPostsByClient(client_id, periode = 'harian', tanggal, start_date, end_date) {
   let dateFilter = "created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
-  if (periode === 'semua') {
+  if (start_date && end_date) {
+    params.push(start_date, end_date);
+    dateFilter = 'created_at::date BETWEEN $2::date AND $3::date';
+  } else if (periode === 'semua') {
     dateFilter = '1=1';
   } else if (periode === 'mingguan') {
     if (tanggal) {

--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -65,12 +65,17 @@ export const findByVideoId = getCommentsByVideoId;
 export async function getRekapKomentarByClient(
   client_id,
   periode = "harian",
-  tanggal
+  tanggal,
+  start_date,
+  end_date
 ) {
   let tanggalFilter =
     "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
-  if (periode === "semua") {
+  if (start_date && end_date) {
+    params.push(start_date, end_date);
+    tanggalFilter = "p.created_at::date BETWEEN $2::date AND $3::date";
+  } else if (periode === "semua") {
     tanggalFilter = "1=1";
   } else if (periode === "mingguan") {
     if (tanggal) {

--- a/src/model/tiktokPostModel.js
+++ b/src/model/tiktokPostModel.js
@@ -76,10 +76,13 @@ export async function getPostsByClientId(client_id) {
 
 export const findByClientId = getPostsByClientId;
 
-export async function countPostsByClient(client_id, periode = 'harian', tanggal) {
+export async function countPostsByClient(client_id, periode = 'harian', tanggal, start_date, end_date) {
   let dateFilter = "created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
-  if (periode === 'semua') {
+  if (start_date && end_date) {
+    params.push(start_date, end_date);
+    dateFilter = 'created_at::date BETWEEN $2::date AND $3::date';
+  } else if (periode === 'semua') {
     dateFilter = '1=1';
   } else if (periode === 'mingguan') {
     if (tanggal) {

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -57,3 +57,20 @@ test('semua uses no date filter', async () => {
   expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining('1=1'), ['1']);
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining('1=1'), ['1']);
 });
+
+test('date range uses between filter', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('1', 'harian', undefined, '2023-10-01', '2023-10-07');
+  const expected = 'created_at::date BETWEEN $2::date AND $3::date';
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining(expected),
+    ['1', '2023-10-01', '2023-10-07']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining(expected),
+    ['1', '2023-10-01', '2023-10-07']
+  );
+});


### PR DESCRIPTION
## Summary
- support `start_date`/`end_date` parameters in Instagram and TikTok recap controllers
- allow dashboard stats to count posts within a selected date range
- implement date range filtering logic in post and comment models and add unit coverage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895edd7d1408327bf5da956dac02a67