### PR TITLE
Add date range filtering to link rekap

### DIFF
--- a/src/controller/amplifyController.js
+++ b/src/controller/amplifyController.js
@@ -5,12 +5,17 @@ export async function getAmplifyRekap(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || 'harian';
   const tanggal = req.query.tanggal;
+  const startDate = req.query.start_date;
+  const endDate = req.query.end_date;
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }
   try {
-    sendConsoleDebug({ tag: 'AMPLIFY', msg: `getAmplifyRekap ${client_id} ${periode} ${tanggal || ''}` });
-    const data = await getRekapLinkByClient(client_id, periode, tanggal);
+    sendConsoleDebug({
+      tag: 'AMPLIFY',
+      msg: `getAmplifyRekap ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}`
+    });
+    const data = await getRekapLinkByClient(client_id, periode, tanggal, startDate, endDate);
     res.json({ success: true, data });
   } catch (err) {
     sendConsoleDebug({ tag: 'AMPLIFY', msg: `Error getAmplifyRekap: ${err.message}` });

--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -117,12 +117,18 @@ export async function getReportsTodayByShortcode(client_id, shortcode) {
 export async function getRekapLinkByClient(
   client_id,
   periode = 'harian',
-  tanggal
+  tanggal,
+  start_date,
+  end_date
 ) {
   let dateFilterPost = "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   let dateFilterReport = "r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
-  if (periode === 'semua') {
+  if (start_date && end_date) {
+    params.push(start_date, end_date);
+    dateFilterPost = 'p.created_at::date BETWEEN $2::date AND $3::date';
+    dateFilterReport = 'r.created_at::date BETWEEN $2::date AND $3::date';
+  } else if (periode === 'semua') {
     dateFilterPost = '1=1';
     dateFilterReport = '1=1';
   } else if (periode === 'mingguan') {

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -119,3 +119,20 @@ test('getRekapLinkByClient uses provided date', async () => {
     ['POLRES', '2024-01-02']
   );
 });
+
+test('getRekapLinkByClient uses BETWEEN for date range', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '2' }] })
+    .mockResolvedValueOnce({ rows: [] });
+  await getRekapLinkByClient('POLRES', 'harian', null, '2024-01-01', '2024-01-31');
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('BETWEEN $2::date AND $3::date'),
+    ['POLRES', '2024-01-01', '2024-01-31']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining('BETWEEN $2::date AND $3::date'),
+    ['POLRES', '2024-01-01', '2024-01-31']
+  );
+});


### PR DESCRIPTION
## Summary
- allow amplify rekap endpoint to accept start_date and end_date
- support date range filtering in link report model
- test date range filtering via SQL BETWEEN clause

## Testing
- `npm test -- --runInBand`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68969ffbd02c83279531b9072a5ba940