### PR TITLE
Apply Asia/Jakarta timezone in date range filters

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -84,7 +84,7 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
   const params = [client_id];
   if (start_date && end_date) {
     params.push(start_date, end_date);
-    tanggalFilter = 'created_at::date BETWEEN $2::date AND $3::date';
+    tanggalFilter = "(created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
   } else if (periode === 'semua') {
     tanggalFilter = '1=1';
   } else if (periode === 'mingguan') {

--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -126,8 +126,8 @@ export async function getRekapLinkByClient(
   const params = [client_id];
   if (start_date && end_date) {
     params.push(start_date, end_date);
-    dateFilterPost = 'p.created_at::date BETWEEN $2::date AND $3::date';
-    dateFilterReport = 'r.created_at::date BETWEEN $2::date AND $3::date';
+    dateFilterPost = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
+    dateFilterReport = "(r.created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
   } else if (periode === 'semua') {
     dateFilterPost = '1=1';
     dateFilterReport = '1=1';

--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -74,7 +74,7 @@ export async function getRekapKomentarByClient(
   const params = [client_id];
   if (start_date && end_date) {
     params.push(start_date, end_date);
-    tanggalFilter = "p.created_at::date BETWEEN $2::date AND $3::date";
+    tanggalFilter = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
   } else if (periode === "semua") {
     tanggalFilter = "1=1";
   } else if (periode === "mingguan") {

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -62,7 +62,7 @@ test('date range uses between filter', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'harian', undefined, '2023-10-01', '2023-10-07');
-  const expected = 'created_at::date BETWEEN $2::date AND $3::date';
+  const expected = "(created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
   expect(mockQuery).toHaveBeenNthCalledWith(
     1,
     expect.stringContaining(expected),


### PR DESCRIPTION
## Summary
- ensure Insta like aggregation uses Asia/Jakarta timezone for ranged queries
- apply same timezone handling for TikTok comment aggregation
- include Asia/Jakarta timezone in link report range filters and update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a1d05584832786685c8d0feb098f