### PR TITLE
test: add date range handling tests

### DIFF
--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -120,11 +120,12 @@ test('getRekapLinkByClient uses provided date', async () => {
   );
 });
 
-test('getRekapLinkByClient uses BETWEEN for date range', async () => {
+test('getRekapLinkByClient handles start_date and end_date', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '2' }] })
     .mockResolvedValueOnce({ rows: [] });
   await getRekapLinkByClient('POLRES', 'harian', null, '2024-01-01', '2024-01-31');
+  expect(mockQuery).toHaveBeenCalledTimes(2);
   expect(mockQuery).toHaveBeenNthCalledWith(
     1,
     expect.stringContaining('BETWEEN $2::date AND $3::date'),

--- a/tests/tiktokCommentModel.test.js
+++ b/tests/tiktokCommentModel.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery,
+}));
+
+let getRekapKomentarByClient;
+
+beforeAll(async () => {
+  ({ getRekapKomentarByClient } = await import('../src/model/tiktokCommentModel.js'));
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('getRekapKomentarByClient uses BETWEEN for date range', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '2' }] })
+    .mockResolvedValueOnce({ rows: [] });
+  await getRekapKomentarByClient('POLRES', 'harian', null, '2024-01-01', '2024-01-31');
+  expect(mockQuery).toHaveBeenCalledTimes(2);
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('BETWEEN $2::date AND $3::date'),
+    ['POLRES', '2024-01-01', '2024-01-31']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining('BETWEEN $2::date AND $3::date'),
+    ['POLRES', '2024-01-01', '2024-01-31']
+  );
+});


### PR DESCRIPTION
## Summary
- ensure `getRekapLinkByClient` honours `start_date` and `end_date`
- verify TikTok comments rekap query builds BETWEEN filter with date range

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a1d6fa4c8327820132cdaf1cde5a