### PR TITLE
Support date range params for tracking endpoints

### DIFF
--- a/src/controller/amplifyController.js
+++ b/src/controller/amplifyController.js
@@ -5,8 +5,9 @@ export async function getAmplifyRekap(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || 'harian';
   const tanggal = req.query.tanggal;
-  const startDate = req.query.start_date;
-  const endDate = req.query.end_date;
+  const startDate =
+    req.query.start_date || req.query.tanggal_mulai;
+  const endDate = req.query.end_date || req.query.tanggal_selesai;
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }

--- a/src/controller/dashboardController.js
+++ b/src/controller/dashboardController.js
@@ -13,8 +13,9 @@ export async function getDashboardStats(req, res) {
 
     const periode = req.query.periode || 'harian';
     const tanggal = req.query.tanggal;
-    const start_date = req.query.start_date;
-    const end_date = req.query.end_date;
+    const start_date =
+      req.query.start_date || req.query.tanggal_mulai;
+    const end_date = req.query.end_date || req.query.tanggal_selesai;
 
     const [clients, users, igPostCount, ttPostCount] = await Promise.all([
       getAllClients(),

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -19,14 +19,21 @@ export async function getInstaRekapLikes(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || "harian";
   const tanggal = req.query.tanggal;
-  const start_date = req.query.start_date;
-  const end_date = req.query.end_date;
+  const startDate =
+    req.query.start_date || req.query.tanggal_mulai;
+  const endDate = req.query.end_date || req.query.tanggal_selesai;
   if (!client_id) {
     return res.status(400).json({ success: false, message: "client_id wajib diisi" });
   }
   try {
-    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${start_date || ''} ${end_date || ''}` });
-    const data = await getRekapLikesByClient(client_id, periode, tanggal, start_date, end_date);
+    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}` });
+    const data = await getRekapLikesByClient(
+      client_id,
+      periode,
+      tanggal,
+      startDate,
+      endDate
+    );
     res.json({ success: true, data });
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaRekapLikes: ${err.message}` });

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -64,13 +64,20 @@ export async function getTiktokRekapKomentar(req, res) {
   const client_id = req.query.client_id;
   const periode = req.query.periode || 'harian';
   const tanggal = req.query.tanggal;
-  const start_date = req.query.start_date;
-  const end_date = req.query.end_date;
+  const startDate =
+    req.query.start_date || req.query.tanggal_mulai;
+  const endDate = req.query.end_date || req.query.tanggal_selesai;
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }
   try {
-    const data = await getRekapKomentarByClient(client_id, periode, tanggal, start_date, end_date);
+    const data = await getRekapKomentarByClient(
+      client_id,
+      periode,
+      tanggal,
+      startDate,
+      endDate
+    );
     res.json({ success: true, data });
   } catch (err) {
     const code = err.statusCode || err.response?.status || 500;

--- a/tests/amplifyControllerDateRange.test.js
+++ b/tests/amplifyControllerDateRange.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+
+const mockGetRekap = jest.fn();
+jest.unstable_mockModule('../src/model/linkReportModel.js', () => ({
+  getRekapLinkByClient: mockGetRekap
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendConsoleDebug: jest.fn()
+}));
+
+let getAmplifyRekap;
+beforeAll(async () => {
+  ({ getAmplifyRekap } = await import('../src/controller/amplifyController.js'));
+});
+
+beforeEach(() => {
+  mockGetRekap.mockReset();
+});
+
+test('accepts tanggal_mulai and tanggal_selesai', async () => {
+  mockGetRekap.mockResolvedValue([]);
+  const req = {
+    query: {
+      client_id: 'c1',
+      periode: 'harian',
+      tanggal_mulai: '2024-01-01',
+      tanggal_selesai: '2024-01-31'
+    }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getAmplifyRekap(req, res);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+});
+

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -1,0 +1,48 @@
+import { jest } from '@jest/globals';
+
+const mockGetRekap = jest.fn();
+jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({
+  getRekapLikesByClient: mockGetRekap
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendConsoleDebug: jest.fn()
+}));
+jest.unstable_mockModule('../src/service/instaPostService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaPostKhususService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instagramApi.js', () => ({
+  fetchInstagramPosts: jest.fn(),
+  fetchInstagramProfile: jest.fn(),
+  fetchInstagramInfo: jest.fn(),
+  fetchInstagramPostsByMonthToken: jest.fn(),
+}));
+jest.unstable_mockModule('../src/service/instaProfileService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instagramUserService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaPostCacheService.js', () => ({}));
+jest.unstable_mockModule('../src/service/profileCacheService.js', () => ({}));
+jest.unstable_mockModule('../src/utils/response.js', () => ({ sendSuccess: jest.fn() }));
+
+let getInstaRekapLikes;
+beforeAll(async () => {
+  ({ getInstaRekapLikes } = await import('../src/controller/instaController.js'));
+});
+
+beforeEach(() => {
+  mockGetRekap.mockReset();
+});
+
+test('accepts tanggal_mulai and tanggal_selesai', async () => {
+  mockGetRekap.mockResolvedValue([]);
+  const req = {
+    query: {
+      client_id: 'c1',
+      periode: 'harian',
+      tanggal_mulai: '2024-01-01',
+      tanggal_selesai: '2024-01-31'
+    }
+  };
+  const json = jest.fn();
+  const res = { json };
+  await getInstaRekapLikes(req, res);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+});
+

--- a/tests/tiktokControllerDateRange.test.js
+++ b/tests/tiktokControllerDateRange.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+
+const mockGetRekap = jest.fn();
+jest.unstable_mockModule('../src/model/tiktokCommentModel.js', () => ({
+  getRekapKomentarByClient: mockGetRekap
+}));
+jest.unstable_mockModule('../src/service/tiktokCommentService.js', () => ({}));
+jest.unstable_mockModule('../src/service/tiktokPostService.js', () => ({}));
+jest.unstable_mockModule('../src/service/clientService.js', () => ({}));
+jest.unstable_mockModule('../src/utils/response.js', () => ({ sendSuccess: jest.fn() }));
+jest.unstable_mockModule('../src/service/tiktokApi.js', () => ({
+  fetchTiktokProfile: jest.fn(),
+  fetchTiktokPosts: jest.fn(),
+  fetchTiktokPostsBySecUid: jest.fn(),
+  fetchTiktokInfo: jest.fn(),
+}));
+jest.unstable_mockModule('../src/service/profileCacheService.js', () => ({}));
+
+let getTiktokRekapKomentar;
+beforeAll(async () => {
+  ({ getTiktokRekapKomentar } = await import('../src/controller/tiktokController.js'));
+});
+
+beforeEach(() => {
+  mockGetRekap.mockReset();
+});
+
+test('accepts tanggal_mulai and tanggal_selesai', async () => {
+  mockGetRekap.mockResolvedValue([]);
+  const req = {
+    query: {
+      client_id: 'c1',
+      periode: 'harian',
+      tanggal_mulai: '2024-01-01',
+      tanggal_selesai: '2024-01-31'
+    }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getTiktokRekapKomentar(req, res);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+});
+


### PR DESCRIPTION
## Summary
- allow tanggal_mulai and tanggal_selesai query params in likes, amplify, tiktok and dashboard controllers
- add tests covering new date range handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975dea79e083278ad6599cc13a9485