### PR TITLE
Deduplicate Instagram posts and mark amplify participation

### DIFF
--- a/src/model/instaPostKhususModel.js
+++ b/src/model/instaPostKhususModel.js
@@ -78,7 +78,10 @@ export async function getPostsTodayByClient(client_id) {
 
 export async function getPostsByClientId(client_id) {
   const res = await query(
-    `SELECT * FROM insta_post_khusus WHERE client_id = $1 ORDER BY created_at DESC`,
+    `SELECT DISTINCT ON (shortcode) *
+     FROM insta_post_khusus
+     WHERE client_id = $1
+     ORDER BY shortcode, created_at DESC`,
     [client_id]
   );
   return res.rows;

--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -78,7 +78,10 @@ export async function getPostsTodayByClient(client_id) {
 
 export async function getPostsByClientId(client_id) {
   const res = await query(
-    `SELECT * FROM insta_post WHERE client_id = $1 ORDER BY created_at DESC`,
+    `SELECT DISTINCT ON (shortcode) *
+     FROM insta_post
+     WHERE client_id = $1
+     ORDER BY shortcode, created_at DESC`,
     [client_id]
   );
   return res.rows;

--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -205,6 +205,7 @@ export async function getRekapLinkByClient(
       user.jumlah_link = parseInt(user.jumlah_link, 10) || 0;
     }
     user.display_nama = user.title ? `${user.title} ${user.nama}` : user.nama;
+    user.sudahMelaksanakan = user.jumlah_link > 0;
   }
 
   return rows;

--- a/tests/instaPostKhususModel.test.js
+++ b/tests/instaPostKhususModel.test.js
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery
+}));
+
+let findByClientId;
+beforeAll(async () => {
+  ({ findByClientId } = await import('../src/model/instaPostKhususModel.js'));
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('findByClientId uses DISTINCT ON to avoid duplicates', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await findByClientId('c1');
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('DISTINCT ON (shortcode)'),
+    ['c1']
+  );
+});

--- a/tests/instaPostModel.test.js
+++ b/tests/instaPostModel.test.js
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+jest.unstable_mockModule('../src/repository/db.js', () => ({
+  query: mockQuery
+}));
+
+let findByClientId;
+beforeAll(async () => {
+  ({ findByClientId } = await import('../src/model/instaPostModel.js'));
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+test('findByClientId uses DISTINCT ON to avoid duplicates', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await findByClientId('c1');
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('DISTINCT ON (shortcode)'),
+    ['c1']
+  );
+});

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -137,3 +137,23 @@ test('getRekapLinkByClient handles start_date and end_date', async () => {
     ['POLRES', '2024-01-01', '2024-01-31']
   );
 });
+
+test('getRekapLinkByClient marks sudahMelaksanakan when user has links', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '1' }] })
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          user_id: 'u1',
+          title: 'Aiptu',
+          nama: 'Budi',
+          username: 'budi',
+          divisi: 'Humas',
+          exception: false,
+          jumlah_link: 1
+        }
+      ]
+    });
+  const rows = await getRekapLinkByClient('POLRES');
+  expect(rows[0].sudahMelaksanakan).toBe(true);
+});


### PR DESCRIPTION
## Summary
- ensure insta_post and insta_post_khusus queries return distinct shortcodes
- flag rekap link rows with `sudahMelaksanakan` when a user contributes at least one link
- add regression tests for distinct queries and amplify participation flag

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689818b7ff248327b5e118b2781528ef