### PR TITLE
Use 20% threshold for Instagram like attendance

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -48,6 +48,7 @@ export async function absensiLikes(client_id, opts = {}) {
   }
 
   const totalKonten = shortcodes.length;
+  const threshold = Math.ceil(totalKonten * 0.2);
   let sudah = [], belum = [];
 
   Object.values(userStats).forEach((u) => {
@@ -56,7 +57,7 @@ export async function absensiLikes(client_id, opts = {}) {
     } else if (
       u.insta &&
       u.insta.trim() !== "" &&
-      u.count >= Math.ceil(totalKonten / 2)
+      u.count >= threshold
     ) {
       sudah.push(u);
     } else {
@@ -122,7 +123,7 @@ export async function absensiLikes(client_id, opts = {}) {
             let ket = "";
             if (!u.count || u.count === 0) {
               ket = `(0/${totalKonten} konten)`;
-            } else if (u.count > 0 && u.count < Math.ceil(totalKonten / 2)) {
+            } else if (u.count > 0 && u.count < threshold) {
               ket = `(${u.count}/${totalKonten} konten)`;
             }
             return (

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -113,6 +113,7 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     params
   );
   const max_like = parseInt(postRows[0]?.jumlah_post || "0", 10);
+  const threshold = Math.ceil(max_like * 0.2);
 
   // CTE
   const { rows } = await query(`
@@ -159,6 +160,7 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     }
     // Tambahkan field display_nama (opsional, untuk frontend)
     user.display_nama = user.title ? `${user.title} ${user.nama}` : user.nama;
+    user.sudahMelaksanakan = user.jumlah_like >= threshold;
   }
 
   return rows;

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -797,6 +797,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       (sc) => `https://www.instagram.com/p/${sc}`
     );
     const totalKonten = shortcodes.length;
+    const threshold = Math.ceil(totalKonten * 0.2);
 
     // Rekap likes untuk setiap user: hitung berapa konten yang di-like
     const userStats = {};
@@ -824,7 +825,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       } else if (
         u.insta &&
         u.insta.trim() !== "" &&
-        u.count >= Math.ceil(totalKonten / 2)
+        u.count >= threshold
       ) {
         sudah.push(u);
       } else {
@@ -868,7 +869,9 @@ Ketik *angka* menu, atau *batal* untuk keluar.
             (u) =>
               `- ${formatNama(u)} : ${
                 u.insta ? u.insta : "belum mengisi data insta"
-              } (0 konten)${!u.insta ? " (belum mengisi data insta)" : ""}`
+              } (${u.count} konten)${
+                !u.insta ? " (belum mengisi data insta)" : ""
+              }`
           )
           .join("\n") + "\n\n";
     });

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -85,3 +85,43 @@ test('query normalizes instagram usernames', async () => {
     ['1']
   );
 });
+
+test('marks sudahMelaksanakan when reaching 20% threshold', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '5' }] })
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          user_id: 'u1',
+          title: 'Aiptu',
+          nama: 'Budi',
+          username: 'budi',
+          divisi: 'BAG',
+          exception: false,
+          jumlah_like: 1,
+        },
+      ],
+    });
+  const rows = await getRekapLikesByClient('POLRES');
+  expect(rows[0].sudahMelaksanakan).toBe(true);
+});
+
+test('marks belum when below 20% threshold', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '10' }] })
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          user_id: 'u1',
+          title: 'Aiptu',
+          nama: 'Budi',
+          username: 'budi',
+          divisi: 'BAG',
+          exception: false,
+          jumlah_like: 1,
+        },
+      ],
+    });
+  const rows = await getRekapLikesByClient('POLRES');
+  expect(rows[0].sudahMelaksanakan).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Mark users as complete after liking at least 20% of a client's Instagram posts
- Reflect the new threshold in WA rekap messages and show actual like counts for incomplete users
- Add tests confirming `sudahMelaksanakan` is set based on the 20% rule

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68981d422c448327b45e94f8c535dad4