### PR TITLE
Ensure single Instagram like counts as completed and add logging

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -113,7 +113,12 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     params
   );
   const max_like = parseInt(postRows[0]?.jumlah_post || "0", 10);
-  const threshold = Math.ceil(max_like * 0.2);
+  const threshold = max_like > 0 ? 1 : 0;
+  console.log(
+    `[getRekapLikesByClient] client_id=${client_id} periode=${periode} ` +
+      `tanggal=${tanggal} start_date=${start_date} end_date=${end_date} ` +
+      `max_like=${max_like} threshold=${threshold}`
+  );
 
   // CTE
   const { rows } = await query(`
@@ -161,6 +166,10 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     // Tambahkan field display_nama (opsional, untuk frontend)
     user.display_nama = user.title ? `${user.title} ${user.nama}` : user.nama;
     user.sudahMelaksanakan = user.jumlah_like >= threshold;
+    console.log(
+      `[getRekapLikesByClient] username=${user.username} jumlah_like=${user.jumlah_like} ` +
+        `sudahMelaksanakan=${user.sudahMelaksanakan}`
+    );
   }
 
   return rows;

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -86,7 +86,7 @@ test('query normalizes instagram usernames', async () => {
   );
 });
 
-test('marks sudahMelaksanakan when reaching 20% threshold', async () => {
+test('marks sudahMelaksanakan when has at least one like', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '5' }] })
     .mockResolvedValueOnce({
@@ -106,7 +106,7 @@ test('marks sudahMelaksanakan when reaching 20% threshold', async () => {
   expect(rows[0].sudahMelaksanakan).toBe(true);
 });
 
-test('marks belum when below 20% threshold', async () => {
+test('marks belum when no likes', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '10' }] })
     .mockResolvedValueOnce({
@@ -118,7 +118,7 @@ test('marks belum when below 20% threshold', async () => {
           username: 'budi',
           divisi: 'BAG',
           exception: false,
-          jumlah_like: 1,
+          jumlah_like: 0,
         },
       ],
     });


### PR DESCRIPTION
## Summary
- log parameters and per-user status during Instagram like recap
- mark users as completed after at least one like instead of 20%
- update tests for new threshold logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68981ff593548327bc6c9a0e9a2bd6c1