### PR TITLE
Store only usernames when upserting Instagram likes

### DIFF
--- a/src/handler/datamining/fetchDmLikes.js
+++ b/src/handler/datamining/fetchDmLikes.js
@@ -20,7 +20,8 @@ export async function handleFetchLikesInstagramDM(username) {
       await limit(async () => {
         try {
           const likes = await fetchAllInstagramLikesItems(p.post_id);
-          await upsertInstaLike(p.shortcode, likes);
+          const usernames = likes.map(l => l?.username).filter(Boolean);
+          await upsertInstaLike(p.shortcode, usernames);
           for (const u of likes) {
             await upsertIgUser(u);
           }


### PR DESCRIPTION
## Summary
- Extract usernames from fetched likes and store only the username list for each post
- Keep full like objects for user upsert and tracking per-post liked users

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689826add1bc83279231b27b5e36a42a