### PR TITLE
Use Asia/Jakarta timezone for insta like filters

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -50,7 +50,7 @@ export async function deleteInstaLikeByShortcode(shortcode) {
  */
 export async function getAllShortcodesToday() {
   const res = await query(
-    `SELECT shortcode FROM insta_like WHERE DATE(updated_at) = CURRENT_DATE`
+    `SELECT shortcode FROM insta_like WHERE (updated_at AT TIME ZONE 'Asia/Jakarta')::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date`
   );
   return res.rows.map(r => r.shortcode);
 }
@@ -80,7 +80,7 @@ export async function getLikesByShortcode(shortcode) {
  */
 
 export async function getRekapLikesByClient(client_id, periode = "harian", tanggal, start_date, end_date) {
-  let tanggalFilter = "created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
+  let tanggalFilter = "(created_at AT TIME ZONE 'Asia/Jakarta')::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
   if (start_date && end_date) {
     params.push(start_date, end_date);
@@ -90,9 +90,9 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
   } else if (periode === 'mingguan') {
     if (tanggal) {
       params.push(tanggal);
-      tanggalFilter = "date_trunc('week', created_at) = date_trunc('week', $2::date)";
+      tanggalFilter = "date_trunc('week', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', $2::date)";
     } else {
-      tanggalFilter = "date_trunc('week', created_at) = date_trunc('week', NOW())";
+      tanggalFilter = "date_trunc('week', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', NOW() AT TIME ZONE 'Asia/Jakarta')";
     }
   } else if (periode === 'bulanan') {
     if (tanggal) {
@@ -104,7 +104,7 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     }
   } else if (tanggal) {
     params.push(tanggal);
-    tanggalFilter = 'created_at::date = $2::date';
+    tanggalFilter = "(created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date";
   }
 
   // Ambil jumlah post IG untuk periode

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -22,12 +22,12 @@ test('harian with specific date uses date filter', async () => {
   await getRekapLikesByClient('1', 'harian', '2023-10-05');
   expect(mockQuery).toHaveBeenNthCalledWith(
     1,
-    expect.stringContaining('created_at::date = $2::date'),
+    expect.stringContaining("(created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date"),
     ['1', '2023-10-05']
   );
   expect(mockQuery).toHaveBeenNthCalledWith(
     2,
-    expect.stringContaining('created_at::date = $2::date'),
+    expect.stringContaining("(created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date"),
     ['1', '2023-10-05']
   );
 });
@@ -36,7 +36,7 @@ test('mingguan with date truncs week', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'mingguan', '2023-10-05');
-  const expected = "date_trunc('week', created_at) = date_trunc('week', $2::date)";
+  const expected = "date_trunc('week', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', $2::date)";
   expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
 });


### PR DESCRIPTION
## Summary
- ensure insta like queries use Asia/Jakarta timezone for daily and weekly periods
- update tests for timezone-aware filters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689828aed2988327992f3def4a58017e