### PR TITLE
fix: align IG like recap with frontend structure

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -122,10 +122,10 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
         l.shortcode,
         p.client_id,
         p.created_at,
-        lower(replace(trim(lk.like_obj->>'username'), '@', '')) AS username
+        lower(replace(trim(lk.username), '@', '')) AS username
       FROM insta_like l
       JOIN insta_post p ON p.shortcode = l.shortcode
-      JOIN LATERAL jsonb_array_elements(l.likes) AS lk(like_obj) ON TRUE
+      JOIN LATERAL jsonb_array_elements_text(l.likes) AS lk(username) ON TRUE
       WHERE p.client_id = $1
         AND ${tanggalFilter}
     ),

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -81,7 +81,7 @@ test('query normalizes instagram usernames', async () => {
   await getRekapLikesByClient('1');
   expect(mockQuery).toHaveBeenNthCalledWith(
     2,
-    expect.stringContaining('jsonb_array_elements(l.likes)'),
+    expect.stringContaining('jsonb_array_elements_text(l.likes)'),
     ['1']
   );
 });


### PR DESCRIPTION
## Summary
- parse username strings in instagram like recap query to match frontend expectations
- adjust like recap unit test accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689834b0b7948327a3fc52ab59935fe6