### PR TITLE
Handle legacy Instagram like formats

### DIFF
--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -81,7 +81,7 @@ test('query normalizes instagram usernames', async () => {
   await getRekapLikesByClient('1');
   expect(mockQuery).toHaveBeenNthCalledWith(
     2,
-    expect.stringContaining('jsonb_array_elements_text(l.likes)'),
+    expect.stringContaining('jsonb_array_elements(l.likes)'),
     ['1']
   );
 });


### PR DESCRIPTION
## Summary
- normalize `insta_like` rows so both string and object arrays return usernames
- adjust rekap query to extract usernames from either format
- update tests for new rekap logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68988854985c8327a23172e51ec9d05f