### PR TITLE
Adjust Instagram like completion threshold to 50%

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -48,7 +48,8 @@ export async function absensiLikes(client_id, opts = {}) {
   }
 
   const totalKonten = shortcodes.length;
-  const threshold = Math.ceil(totalKonten * 0.2);
+  // User must like at least 50% of content to be considered complete
+  const threshold = Math.ceil(totalKonten * 0.5);
   let sudah = [], belum = [];
 
   Object.values(userStats).forEach((u) => {

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -112,8 +112,9 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     `SELECT COUNT(*) AS jumlah_post FROM insta_post WHERE client_id = $1 AND ${tanggalFilter}`,
     params
   );
+  // A user is considered complete when they like at least 50% of posts
   const max_like = parseInt(postRows[0]?.jumlah_post || "0", 10);
-  const threshold = Math.ceil(max_like * 0.2);
+  const threshold = Math.ceil(max_like * 0.5);
 
   // CTE
   const { rows } = await query(`

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -797,7 +797,8 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       (sc) => `https://www.instagram.com/p/${sc}`
     );
     const totalKonten = shortcodes.length;
-    const threshold = Math.ceil(totalKonten * 0.2);
+    // Require at least 50% of content liked to mark as complete
+    const threshold = Math.ceil(totalKonten * 0.5);
 
     // Rekap likes untuk setiap user: hitung berapa konten yang di-like
     const userStats = {};

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -86,7 +86,7 @@ test('query normalizes instagram usernames', async () => {
   );
 });
 
-test('marks sudahMelaksanakan when reaching 20% threshold', async () => {
+test('marks sudahMelaksanakan when reaching 50% threshold', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '5' }] })
     .mockResolvedValueOnce({
@@ -98,7 +98,7 @@ test('marks sudahMelaksanakan when reaching 20% threshold', async () => {
           username: 'budi',
           divisi: 'BAG',
           exception: false,
-          jumlah_like: 1,
+          jumlah_like: 3,
         },
       ],
     });
@@ -106,7 +106,7 @@ test('marks sudahMelaksanakan when reaching 20% threshold', async () => {
   expect(rows[0].sudahMelaksanakan).toBe(true);
 });
 
-test('marks belum when below 20% threshold', async () => {
+test('marks belum when below 50% threshold', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '10' }] })
     .mockResolvedValueOnce({
@@ -118,7 +118,7 @@ test('marks belum when below 20% threshold', async () => {
           username: 'budi',
           divisi: 'BAG',
           exception: false,
-          jumlah_like: 1,
+          jumlah_like: 4,
         },
       ],
     });


### PR DESCRIPTION
## Summary
- Require users to like at least half of available Instagram posts to be considered complete
- Update WhatsApp and absentee handlers to use 50% threshold
- Align tests with new threshold logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68988be5aac483278ce32946a743edec