### PR TITLE
fix: deduplicate insta like rekap

### DIFF
--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -20,23 +20,16 @@ test('harian with specific date uses date filter', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'harian', '2023-10-05');
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    1,
-    expect.stringContaining("(created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date"),
-    ['1', '2023-10-05']
-  );
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    2,
-    expect.stringContaining("(created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date"),
-    ['1', '2023-10-05']
-  );
+  const expected = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date";
+  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
+  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
 });
 
 test('mingguan with date truncs week', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'mingguan', '2023-10-05');
-  const expected = "date_trunc('week', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', $2::date)";
+  const expected = "date_trunc('week', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', $2::date)";
   expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
 });
@@ -45,7 +38,7 @@ test('bulanan converts month string', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'bulanan', '2023-10');
-  const expected = "date_trunc('month', created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
+  const expected = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
   expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-01']);
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-01']);
 });
@@ -62,7 +55,7 @@ test('date range uses between filter', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'harian', undefined, '2023-10-01', '2023-10-07');
-  const expected = "(created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
+  const expected = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
   expect(mockQuery).toHaveBeenNthCalledWith(
     1,
     expect.stringContaining(expected),
@@ -124,4 +117,34 @@ test('marks belum when below 50% threshold', async () => {
     });
   const rows = await getRekapLikesByClient('POLRES');
   expect(rows[0].sudahMelaksanakan).toBe(false);
+});
+
+test('deduplicates posts and likes so completed users are not penalized', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '1' }] })
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          user_id: 'u1',
+          title: 'Aiptu',
+          nama: 'Budi',
+          username: 'budi',
+          divisi: 'BAG',
+          exception: false,
+          jumlah_like: 1,
+        },
+      ],
+    });
+  const rows = await getRekapLikesByClient('POLRES');
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('COUNT(DISTINCT p.shortcode)'),
+    ['POLRES']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining('COUNT(DISTINCT shortcode) AS jumlah_like'),
+    ['POLRES']
+  );
+  expect(rows[0].sudahMelaksanakan).toBe(true);
 });


### PR DESCRIPTION
## Summary
- ensure rekap count only unique posts with like data
- align date filtering to use `p.created_at`
- cover duplicate post/like scenarios with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68989d504534832798e0805df268bc94