### PR TITLE
fix: account for all posts in monthly like recap

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -107,11 +107,10 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     tanggalFilter = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date";
   }
 
-  // Ambil jumlah post IG (yang memiliki data like) untuk periode
+  // Ambil jumlah post IG untuk periode (termasuk yang belum memiliki data like)
   const { rows: postRows } = await query(
     `SELECT COUNT(DISTINCT p.shortcode) AS jumlah_post
      FROM insta_post p
-     JOIN insta_like l ON l.shortcode = p.shortcode
      WHERE p.client_id = $1 AND ${tanggalFilter}`,
     params
   );

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -79,6 +79,14 @@ test('query normalizes instagram usernames', async () => {
   );
 });
 
+test('counts posts even when no likes recorded', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '10' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('POLRES');
+  const firstQuery = mockQuery.mock.calls[0][0];
+  expect(firstQuery).not.toMatch(/JOIN insta_like/i);
+});
+
 test('marks sudahMelaksanakan when reaching 50% threshold', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '5' }] })


### PR DESCRIPTION
## Summary
- count all Instagram posts when computing monthly recap thresholds
- add regression test for posts without like data

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a0b9f4cc8327b911736ecdc3417c