### PR TITLE
Align Insta likes rekap filters with TikTok logic

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -80,7 +80,7 @@ export async function getLikesByShortcode(shortcode) {
  */
 
 export async function getRekapLikesByClient(client_id, periode = "harian", tanggal, start_date, end_date) {
-  let tanggalFilter = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
+  let tanggalFilter = "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
   if (start_date && end_date) {
     params.push(start_date, end_date);
@@ -90,9 +90,9 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
   } else if (periode === 'mingguan') {
     if (tanggal) {
       params.push(tanggal);
-      tanggalFilter = "date_trunc('week', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', $2::date)";
+      tanggalFilter = "date_trunc('week', p.created_at) = date_trunc('week', $2::date)";
     } else {
-      tanggalFilter = "date_trunc('week', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', NOW() AT TIME ZONE 'Asia/Jakarta')";
+      tanggalFilter = "date_trunc('week', p.created_at) = date_trunc('week', NOW())";
     }
   } else if (periode === 'bulanan') {
     if (tanggal) {
@@ -104,7 +104,7 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     }
   } else if (tanggal) {
     params.push(tanggal);
-    tanggalFilter = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date";
+    tanggalFilter = "p.created_at::date = $2::date";
   }
 
   // Ambil jumlah post IG untuk periode (termasuk yang belum memiliki data like)

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -20,7 +20,7 @@ test('harian with specific date uses date filter', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'harian', '2023-10-05');
-  const expected = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date";
+  const expected = "p.created_at::date = $2::date";
   expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
 });
@@ -29,7 +29,7 @@ test('mingguan with date truncs week', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'mingguan', '2023-10-05');
-  const expected = "date_trunc('week', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('week', $2::date)";
+  const expected = "date_trunc('week', p.created_at) = date_trunc('week', $2::date)";
   expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
 });


### PR DESCRIPTION
## Summary
- Align Instagram likes rekap date filters with TikTok comment tracking logic, using direct timestamps for daily and weekly modes
- Update unit tests to match the new rekap filter behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b8418c788327abb5b6178aff3bea