### PR TITLE
Normalize Instagram username matching for like attendance

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -6,6 +6,14 @@ import { hariIndo } from "../../../utils/constants.js";
 import { groupByDivision, sortDivisionKeys } from "../../../utils/utilsHelper.js";
 import { findClientById } from "../../../service/clientService.js";
 
+function normalizeUsername(username) {
+  return (username || "")
+    .toString()
+    .trim()
+    .replace(/^@/, "")
+    .toLowerCase();
+}
+
 async function getClientNama(client_id) {
   const res = await query(
     "SELECT nama FROM clients WHERE client_id = $1 LIMIT 1",
@@ -35,12 +43,12 @@ export async function absensiLikes(client_id, opts = {}) {
 
   for (const shortcode of shortcodes) {
     const likes = await getLikesByShortcode(shortcode);
-    const likesSet = new Set((likes || []).map((x) => (x || "").toLowerCase()));
+    const likesSet = new Set((likes || []).map(normalizeUsername));
     users.forEach((u) => {
       if (
         u.insta &&
         u.insta.trim() !== "" &&
-        likesSet.has(u.insta.toLowerCase())
+        likesSet.has(normalizeUsername(u.insta))
       ) {
         userStats[u.user_id].count += 1;
       }
@@ -166,13 +174,13 @@ export async function absensiLikesPerKonten(client_id, opts = {}) {
 
   for (const sc of shortcodes) {
     const likes = await getLikesByShortcode(sc);
-    const likesSet = new Set((likes || []).map((x) => (x || "").toLowerCase()));
+    const likesSet = new Set((likes || []).map(normalizeUsername));
     let userSudah = [];
     let userBelum = [];
     users.forEach((u) => {
       if (u.exception === true) {
         userSudah.push(u); // Selalu ke sudah!
-      } else if (u.insta && u.insta.trim() !== "" && likesSet.has(u.insta.toLowerCase())) {
+      } else if (u.insta && u.insta.trim() !== "" && likesSet.has(normalizeUsername(u.insta))) {
         userSudah.push(u);
       } else {
         userBelum.push(u);

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByClient = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+const mockGetLikesByShortcode = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({ getUsersByClient: mockGetUsersByClient }));
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({ getShortcodesTodayByClient: mockGetShortcodesTodayByClient }));
+jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({ getLikesByShortcode: mockGetLikesByShortcode }));
+
+let absensiLikes;
+
+beforeAll(async () => {
+  ({ absensiLikes } = await import('../src/handler/fetchabsensi/insta/absensiLikesInsta.js'));
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockGetUsersByClient.mockReset();
+  mockGetShortcodesTodayByClient.mockReset();
+  mockGetLikesByShortcode.mockReset();
+});
+
+test('marks user with @username as already liking', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC' }] });
+  mockGetUsersByClient.mockResolvedValueOnce([
+    {
+      user_id: 'u1',
+      title: 'Aiptu',
+      nama: 'Budi',
+      insta: '@TestUser',
+      divisi: 'BAG',
+      exception: false,
+    },
+  ]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
+  mockGetLikesByShortcode.mockResolvedValueOnce(['testuser']);
+
+  const msg = await absensiLikes('POLRES', { mode: 'sudah' });
+
+  expect(msg).toMatch(/Sudah melaksanakan\* : \*1 user\*/);
+  expect(msg).toMatch(/Belum melaksanakan\* : \*0 user\*/);
+});
+


### PR DESCRIPTION
## Summary
- normalize Instagram usernames before comparison in like attendance handlers
- cover username normalization with a new absensiLikes test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898bc72df4c8327b2498ad778eba729