### PR TITLE
Simplify Instagram like recap model

### DIFF
--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -17,162 +17,55 @@ beforeEach(() => {
 });
 
 test('harian with specific date uses date filter', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'harian', '2023-10-05');
   const expected = "p.created_at::date = $2::date";
-  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
-  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
+  expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining(expected), ['1', '2023-10-05']);
 });
 
 test('mingguan with date truncs week', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'mingguan', '2023-10-05');
   const expected = "date_trunc('week', p.created_at) = date_trunc('week', $2::date)";
-  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-05']);
-  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
+  expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining(expected), ['1', '2023-10-05']);
 });
 
 test('bulanan converts month string', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'bulanan', '2023-10');
   const expected = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
-  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining(expected), ['1', '2023-10-01']);
-  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-01']);
+  expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining(expected), ['1', '2023-10-01']);
 });
 
 test('semua uses no date filter', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'semua');
-  expect(mockQuery).toHaveBeenNthCalledWith(1, expect.stringContaining('1=1'), ['1']);
-  expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining('1=1'), ['1']);
+  expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('1=1'), ['1']);
 });
 
 test('date range uses between filter', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1', 'harian', undefined, '2023-10-01', '2023-10-07');
   const expected = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    1,
-    expect.stringContaining(expected),
-    ['1', '2023-10-01', '2023-10-07']
-  );
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    2,
-    expect.stringContaining(expected),
-    ['1', '2023-10-01', '2023-10-07']
-  );
+  expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining(expected), ['1', '2023-10-01', '2023-10-07']);
 });
 
 test('query normalizes instagram usernames', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1');
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    2,
-    expect.stringContaining('jsonb_array_elements(l.likes)'),
-    ['1']
-  );
+  expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('jsonb_array_elements(l.likes)'), ['1']);
 });
 
-test('counts posts even when no likes recorded', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ jumlah_post: '10' }] });
-  mockQuery.mockResolvedValueOnce({ rows: [] });
-  await getRekapLikesByClient('POLRES');
-  const firstQuery = mockQuery.mock.calls[0][0];
-  expect(firstQuery).not.toMatch(/JOIN insta_like/i);
-});
-
-test('marks sudahMelaksanakan when reaching 50% threshold', async () => {
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ jumlah_post: '5' }] })
-    .mockResolvedValueOnce({
-      rows: [
-        {
-          user_id: 'u1',
-          title: 'Aiptu',
-          nama: 'Budi',
-          username: 'budi',
-          divisi: 'BAG',
-          exception: false,
-          jumlah_like: 3,
-        },
-      ],
-    });
-  const rows = await getRekapLikesByClient('POLRES');
-  expect(rows[0].sudahMelaksanakan).toBe(true);
-});
-
-test('marks belum when below 50% threshold', async () => {
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ jumlah_post: '10' }] })
-    .mockResolvedValueOnce({
-      rows: [
-        {
-          user_id: 'u1',
-          title: 'Aiptu',
-          nama: 'Budi',
-          username: 'budi',
-          divisi: 'BAG',
-          exception: false,
-          jumlah_like: 4,
-        },
-      ],
-    });
-  const rows = await getRekapLikesByClient('POLRES');
-  expect(rows[0].sudahMelaksanakan).toBe(false);
-});
-
-test('bulanan does not revert sudahMelaksanakan to false when posts grow', async () => {
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ jumlah_post: '4' }] })
-    .mockResolvedValueOnce({
-      rows: [
-        {
-          user_id: 'u1',
-          title: 'Aiptu',
-          nama: 'Budi',
-          username: 'budi',
-          divisi: 'BAG',
-          exception: false,
-          jumlah_like: 1,
-        },
-      ],
-    });
-  const rows = await getRekapLikesByClient('POLRES', 'bulanan');
-  expect(rows[0].sudahMelaksanakan).toBe(true);
-});
-
-test('deduplicates posts and likes so completed users are not penalized', async () => {
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ jumlah_post: '1' }] })
-    .mockResolvedValueOnce({
-      rows: [
-        {
-          user_id: 'u1',
-          title: 'Aiptu',
-          nama: 'Budi',
-          username: 'budi',
-          divisi: 'BAG',
-          exception: false,
-          jumlah_like: 1,
-        },
-      ],
-    });
-  const rows = await getRekapLikesByClient('POLRES');
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    1,
-    expect.stringContaining('COUNT(DISTINCT p.shortcode)'),
-    ['POLRES']
-  );
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    2,
-    expect.stringContaining('COUNT(DISTINCT shortcode) AS jumlah_like'),
-    ['POLRES']
-  );
-  expect(rows[0].sudahMelaksanakan).toBe(true);
+test('parses jumlah_like as integer', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{
+    user_id: 'u1',
+    title: 'Aiptu',
+    nama: 'Budi',
+    username: 'budi',
+    divisi: 'BAG',
+    exception: false,
+    jumlah_like: '3',
+  }] });
+  const rows = await getRekapLikesByClient('1');
+  expect(rows[0].jumlah_like).toBe(3);
 });


### PR DESCRIPTION
## Summary
- streamline getRekapLikesByClient to match frontend request and remove unused logic
- update unit tests for revised recap behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993f7890c88327bad78c3b576d19de