### PR TITLE
Use username for dashboard approval

### DIFF
--- a/docs/frontend_login_scaling.md
+++ b/docs/frontend_login_scaling.md
@@ -34,7 +34,7 @@ Expose `/api/auth/dashboard-register`:
 1. Validate `username`, `password` and optional `role` and `client_id`.
 2. Ensure the username is unique in `dashboard_user`.
 3. Hash the password with `bcrypt.hash` and insert the new row with `status=false`.
-4. Send a WhatsApp notification to administrators. They can approve using `approvedash#<id>` or reject with `denydash#<id>`.
+4. Send a WhatsApp notification to administrators containing the username, ID, role, and client ID. They can approve using `approvedash#<username>` or reject with `denydash#<username>`.
 5. Return `201 Created` with the new `user_id` and current status.
 
 

--- a/docs/login_api.md
+++ b/docs/login_api.md
@@ -49,7 +49,7 @@ All return a JSON Web Token (JWT) that must be included in subsequent requests.
 ```
 
 To register a dashboard user send a similar payload to `/api/auth/dashboard-register` with optional `role` and `client_id`.
-Every new dashboard account is created with `status` set to `false` and an approval request is sent to the WhatsApp administrators. They can approve using `approvedash#<id>`.
+Every new dashboard account is created with `status` set to `false` and an approval request containing the username, ID, role, and client ID is sent to the WhatsApp administrators. They can approve using `approvedash#<username>` or reject with `denydash#<username>`.
 
 
 ## 2. Example `curl`

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -123,7 +123,9 @@ router.post('/dashboard-register', async (req, res) => {
     client_id,
   });
   notifyAdmin(
-    `\uD83D\uDCCB Permintaan user dashboard baru\nUsername: ${username}\nRole: ${role}\nID: ${user_id}\nBalas approvedash#${user_id} untuk menyetujui atau denydash#${user_id} untuk menolak.`
+    `\uD83D\uDCCB Permintaan User Approval dengan data sebagai berikut :\nUsername: ${username}\nID: ${user_id}\nRole: ${role}\nClient ID: ${
+      client_id ?? '-'
+    }\n\nBalas approvedash#${username} untuk menyetujui atau denydash#${username} untuk menolak.`
   );
   return res
     .status(201)

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1604,33 +1604,35 @@ Ketik *angka* menu, atau *batal* untuk keluar.
   // === APPROVE / DENY DASHBOARD ADMIN
   // =========================
   if (text.toLowerCase().startsWith("approvedash#")) {
-    const [, id] = text.split("#");
-    if (!id) {
-      await waClient.sendMessage(chatId, "Format salah! Gunakan: approvedash#id");
+    const [, usernameRaw] = text.split("#");
+    const username = usernameRaw?.trim();
+    if (!username) {
+      await waClient.sendMessage(chatId, "Format salah! Gunakan: approvedash#username");
       return;
     }
-    const usr = await dashboardUserModel.findById(id);
+    const usr = await dashboardUserModel.findByUsername(username);
     if (!usr) {
-      await waClient.sendMessage(chatId, `❌ ID ${id} tidak ditemukan.`);
+      await waClient.sendMessage(chatId, `❌ Username ${username} tidak ditemukan.`);
       return;
     }
-    await dashboardUserModel.updateStatus(id, true);
+    await dashboardUserModel.updateStatus(usr.user_id, true);
     await waClient.sendMessage(chatId, `✅ User ${usr.username} disetujui.`);
     return;
   }
 
   if (text.toLowerCase().startsWith("denydash#")) {
-    const [, id] = text.split("#");
-    if (!id) {
-      await waClient.sendMessage(chatId, "Format salah! Gunakan: denydash#id");
+    const [, usernameRaw] = text.split("#");
+    const username = usernameRaw?.trim();
+    if (!username) {
+      await waClient.sendMessage(chatId, "Format salah! Gunakan: denydash#username");
       return;
     }
-    const usr = await dashboardUserModel.findById(id);
+    const usr = await dashboardUserModel.findByUsername(username);
     if (!usr) {
-      await waClient.sendMessage(chatId, `❌ ID ${id} tidak ditemukan.`);
+      await waClient.sendMessage(chatId, `❌ Username ${username} tidak ditemukan.`);
       return;
     }
-    await dashboardUserModel.updateStatus(id, false);
+    await dashboardUserModel.updateStatus(usr.user_id, false);
     await waClient.sendMessage(chatId, `❌ User ${usr.username} ditolak.`);
     return;
   }


### PR DESCRIPTION
## Summary
- include full user data in dashboard approval notifications
- process WhatsApp dashboard approvals by username

## Testing
- `npm run lint`
- `npm test` *(fails: instaLikeModel.test.js, tiktokCommentModel.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6899f248e2a08327a0899e607ea8e42c