### PR TITLE
Add WhatsApp field to dashboard registration

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -65,6 +65,7 @@ Credentials for the web dashboard login.
 - `role` – permission level such as `admin` or `operator`
 - `status` – boolean indicating whether the account is active
 - `client_id` – optional link to `clients`
+- `whatsapp` – contact number used for notifications
 - `created_at`, `updated_at` – timestamps
 
 ### `insta_post`

--- a/docs/frontend_login_scaling.md
+++ b/docs/frontend_login_scaling.md
@@ -15,6 +15,7 @@ CREATE TABLE dashboard_user (
   status BOOLEAN DEFAULT TRUE,
 
   client_id VARCHAR REFERENCES clients(client_id),
+  whatsapp TEXT,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()
 );
@@ -26,15 +27,16 @@ CREATE TABLE dashboard_user (
 - `status` is `true` when the account is active. Admin registrations start as `false` and must be approved via WhatsApp.
 
 - `client_id` links an account to a specific organisation if needed.
+- `whatsapp` stores the contact number for operator verification.
 
 ## 2. Registration Endpoint
 
 Expose `/api/auth/dashboard-register`:
 
-1. Validate `username`, `password` and optional `role` and `client_id`.
+1. Validate `username`, `password`, `whatsapp` and optional `role` and `client_id`.
 2. Ensure the username is unique in `dashboard_user`.
 3. Hash the password with `bcrypt.hash` and insert the new row with `status=false`.
-4. Send a WhatsApp notification to administrators containing the username, ID, role, and client ID. They can approve using `approvedash#<username>` or reject with `denydash#<username>`.
+4. Send a WhatsApp notification to administrators containing the username, ID, role, WhatsApp number, and client ID. They can approve using `approvedash#<username>` or reject with `denydash#<username>`.
 5. Return `201 Created` with the new `user_id` and current status.
 
 

--- a/docs/login_api.md
+++ b/docs/login_api.md
@@ -39,6 +39,18 @@ All return a JSON Web Token (JWT) that must be included in subsequent requests.
 }
 ```
 
+### Dashboard Registration
+`POST /api/auth/dashboard-register`
+```json
+{
+  "username": "admin",
+  "password": "secret",
+  "whatsapp": "628123456789",
+  "client_id": "demo_client",
+  "role": "operator"
+}
+```
+
 ### Dashboard Login
 `POST /api/auth/dashboard-login`
 ```json
@@ -48,8 +60,7 @@ All return a JSON Web Token (JWT) that must be included in subsequent requests.
 }
 ```
 
-To register a dashboard user send a similar payload to `/api/auth/dashboard-register` with optional `role` and `client_id`.
-Every new dashboard account is created with `status` set to `false` and an approval request containing the username, ID, role, and client ID is sent to the WhatsApp administrators. They can approve using `approvedash#<username>` or reject with `denydash#<username>`.
+Every new dashboard account is created with `status` set to `false` and an approval request containing the username, ID, role, WhatsApp number, and client ID is sent to the WhatsApp administrators. They can approve using `approvedash#<username>` or reject with `denydash#<username>`.
 
 
 ## 2. Example `curl`

--- a/sql/migrations/20250924_dashboardUserWhatsapp.sql
+++ b/sql/migrations/20250924_dashboardUserWhatsapp.sql
@@ -1,0 +1,3 @@
+-- Add whatsapp column to dashboard_user
+ALTER TABLE dashboard_user
+  ADD COLUMN IF NOT EXISTS whatsapp VARCHAR;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE dashboard_user (
   role TEXT NOT NULL,
   status BOOLEAN DEFAULT TRUE,
   client_id VARCHAR REFERENCES clients(client_id),
+  whatsapp VARCHAR,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()
 );

--- a/src/model/dashboardUserModel.js
+++ b/src/model/dashboardUserModel.js
@@ -10,8 +10,8 @@ export async function findByUsername(username) {
 
 export async function createUser(data) {
   const res = await query(
-    `INSERT INTO dashboard_user (user_id, username, password_hash, role, status, client_id)
-     VALUES ($1, $2, $3, $4, $5, $6)
+    `INSERT INTO dashboard_user (user_id, username, password_hash, role, status, client_id, whatsapp)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
      RETURNING *`,
     [
       data.user_id,
@@ -20,6 +20,7 @@ export async function createUser(data) {
       data.role,
       data.status,
       data.client_id,
+      data.whatsapp,
     ]
   );
   return res.rows[0];

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -99,12 +99,12 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  const { username, password, role = 'operator', client_id = null } = req.body;
+  const { username, password, role = 'operator', client_id = null, whatsapp } = req.body;
   const status = false;
-  if (!username || !password) {
+  if (!username || !password || !whatsapp) {
     return res
       .status(400)
-      .json({ success: false, message: 'username dan password wajib diisi' });
+      .json({ success: false, message: 'username, password, dan whatsapp wajib diisi' });
   }
   const existing = await dashboardUserModel.findByUsername(username);
   if (existing) {
@@ -121,9 +121,10 @@ router.post('/dashboard-register', async (req, res) => {
     role,
     status,
     client_id,
+    whatsapp,
   });
   notifyAdmin(
-    `\uD83D\uDCCB Permintaan User Approval dengan data sebagai berikut :\nUsername: ${username}\nID: ${user_id}\nRole: ${role}\nClient ID: ${
+    `\uD83D\uDCCB Permintaan User Approval dengan data sebagai berikut :\nUsername: ${username}\nID: ${user_id}\nRole: ${role}\nWhatsApp: ${whatsapp}\nClient ID: ${
       client_id ?? '-'
     }\n\nBalas approvedash#${username} untuk menyetujui atau denydash#${username} untuk menolak.`
   );

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -245,7 +245,7 @@ describe('POST /dashboard-register', () => {
 
     const res = await request(app)
       .post('/api/auth/dashboard-register')
-      .send({ username: 'dash', password: 'pass' });
+      .send({ username: 'dash', password: 'pass', whatsapp: '0812' });
 
     expect(res.status).toBe(201);
     expect(res.body.success).toBe(true);
@@ -258,7 +258,7 @@ describe('POST /dashboard-register', () => {
     expect(mockQuery).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('INSERT INTO dashboard_user'),
-      [expect.any(String), 'dash', expect.any(String), 'operator', false, null]
+      [expect.any(String), 'dash', expect.any(String), 'operator', false, null, '0812']
     );
   });
 
@@ -268,7 +268,7 @@ describe('POST /dashboard-register', () => {
 
     const res = await request(app)
       .post('/api/auth/dashboard-register')
-      .send({ username: 'dash', password: 'pass' });
+      .send({ username: 'dash', password: 'pass', whatsapp: '0812' });
 
     expect(res.status).toBe(400);
     expect(res.body.success).toBe(false);


### PR DESCRIPTION
## Summary
- Require and store WhatsApp numbers for dashboard user registration
- Document new `whatsapp` field in schema and auth guides
- Add migration and tests for dashboard registration payload

## Testing
- `npm run lint`
- `npm test` *(fails: instaLikeModel.test.js, tiktokCommentModel.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689c0bb7576c83279ff9ae4efacbd109