### PR TITLE
feat: notify user on dashboard approval

### DIFF
--- a/src/controller/dashboardUserController.js
+++ b/src/controller/dashboardUserController.js
@@ -1,0 +1,29 @@
+import * as dashboardUserModel from '../model/dashboardUserModel.js';
+import { formatToWhatsAppId, safeSendMessage } from '../utils/waHelper.js';
+import waClient, { waReady } from '../service/waService.js';
+import { sendSuccess } from '../utils/response.js';
+
+export async function approveDashboardUser(req, res, next) {
+  try {
+    if (req.dashboardUser.role !== 'admin') {
+      return res.status(403).json({ success: false, message: 'Forbidden' });
+    }
+    const { id } = req.params;
+    const usr = await dashboardUserModel.findById(id);
+    if (!usr) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+    const updated = await dashboardUserModel.updateStatus(id, true);
+    if (waReady && usr.whatsapp) {
+      const wid = formatToWhatsAppId(usr.whatsapp);
+      await safeSendMessage(
+        waClient,
+        wid,
+        `✅ Registrasi dashboard Anda telah disetujui.\nUsername: ${usr.username}`
+      );
+    }
+    sendSuccess(res, updated);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -2,11 +2,13 @@
 import { Router } from "express";
 import { getDashboardStats } from "../controller/dashboardController.js";
 import { analyzeInstagramJson } from "../controller/socialMediaController.js";
+import { approveDashboardUser } from "../controller/dashboardUserController.js";
 import { verifyDashboardToken } from "../middleware/dashboardAuth.js";
 const router = Router();
 
 router.use(verifyDashboardToken);
 router.get("/stats", getDashboardStats);
 router.post("/social-media/instagram/analysis", analyzeInstagramJson);
+router.put("/users/:id/approve", approveDashboardUser);
 
 export default router;


### PR DESCRIPTION
## Summary
- send WhatsApp approval notice when dashboard user is approved
- expose endpoint for admin to approve dashboard users

## Testing
- `npm run lint`
- `npm test` *(fails: instaLikeModel.test.js, tiktokCommentModel.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689c0ec90aa083278a6da4154163d5cf