### PR TITLE
Normalize WhatsApp number in dashboard registration

### DIFF
--- a/docs/frontend_login_scaling.md
+++ b/docs/frontend_login_scaling.md
@@ -26,8 +26,8 @@ CREATE TABLE dashboard_user (
 - `role` can be `admin`, `operator` or other roles required by the dashboard.
 - `status` is `true` when the account is active. Admin registrations start as `false` and must be approved via WhatsApp.
 
-- `client_id` links an account to a specific organisation if needed.
-- `whatsapp` stores the contact number for operator verification.
+ - `client_id` links an account to a specific organisation if needed.
+ - `whatsapp` stores the contact number for operator verification and should contain digits only.
 
 ## 2. Registration Endpoint
 

--- a/docs/login_api.md
+++ b/docs/login_api.md
@@ -51,6 +51,8 @@ All return a JSON Web Token (JWT) that must be included in subsequent requests.
 }
 ```
 
+The `whatsapp` field should contain digits only; any non-numeric characters will be removed before storage.
+
 ### Dashboard Login
 `POST /api/auth/dashboard-login`
 ```json

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -99,13 +99,20 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  const { username, password, role = 'operator', client_id = null, whatsapp } = req.body;
+  let { username, password, role = 'operator', client_id = null, whatsapp } = req.body;
   const status = false;
   if (!username || !password || !whatsapp) {
     return res
       .status(400)
       .json({ success: false, message: 'username, password, dan whatsapp wajib diisi' });
   }
+  const normalizedWhatsapp = String(whatsapp).replace(/\D/g, '');
+  if (normalizedWhatsapp.length < 8) {
+    return res
+      .status(400)
+      .json({ success: false, message: 'whatsapp tidak valid' });
+  }
+  whatsapp = normalizedWhatsapp;
   const existing = await dashboardUserModel.findByUsername(username);
   if (existing) {
     return res

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -245,7 +245,7 @@ describe('POST /dashboard-register', () => {
 
     const res = await request(app)
       .post('/api/auth/dashboard-register')
-      .send({ username: 'dash', password: 'pass', whatsapp: '0812' });
+      .send({ username: 'dash', password: 'pass', whatsapp: '0812-1234x' });
 
     expect(res.status).toBe(201);
     expect(res.body.success).toBe(true);
@@ -258,17 +258,27 @@ describe('POST /dashboard-register', () => {
     expect(mockQuery).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('INSERT INTO dashboard_user'),
-      [expect.any(String), 'dash', expect.any(String), 'operator', false, null, '0812']
+      [expect.any(String), 'dash', expect.any(String), 'operator', false, null, '08121234']
     );
   });
 
+  test('returns 400 when whatsapp invalid', async () => {
+    const res = await request(app)
+      .post('/api/auth/dashboard-register')
+      .send({ username: 'dash', password: 'pass', whatsapp: '123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/whatsapp tidak valid/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
 
   test('returns 400 when username exists', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ user_id: 'x' }] });
 
     const res = await request(app)
       .post('/api/auth/dashboard-register')
-      .send({ username: 'dash', password: 'pass', whatsapp: '0812' });
+      .send({ username: 'dash', password: 'pass', whatsapp: '0812-1234' });
 
     expect(res.status).toBe(400);
     expect(res.body.success).toBe(false);


### PR DESCRIPTION
## Summary
- Sanitize `whatsapp` field and validate length during dashboard registration
- Cover sanitized and invalid WhatsApp cases in auth route tests
- Document requirement that WhatsApp numbers must be numeric

## Testing
- `npm run lint`
- `npm test` *(fails: tests/instaLikeModel.test.js, tests/tiktokCommentModel.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689c17c7c52883278bd820f6e79a0883