### PR TITLE
Add error handling for dashboard registration

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -99,8 +99,9 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  let { username, password, role = 'operator', client_id = null, whatsapp } = req.body;
-  const status = false;
+  try {
+    let { username, password, role = 'operator', client_id = null, whatsapp } = req.body;
+    const status = false;
   if (!username || !password || !whatsapp) {
     return res
       .status(400)
@@ -138,6 +139,10 @@ router.post('/dashboard-register', async (req, res) => {
   return res
     .status(201)
     .json({ success: true, user_id: user.user_id, status: user.status });
+  } catch (err) {
+    console.error('[AUTH] dashboard-register error:', err.message);
+    return res.status(500).json({ success: false, message: 'internal server error' });
+  }
 });
 
 router.post('/dashboard-login', async (req, res) => {


### PR DESCRIPTION
## Summary
- add try/catch around dashboard user registration to prevent server crash and return proper errors

## Testing
- `npm run lint`
- `npm test` *(fails: tests/instaLikeModel.test.js, tests/tiktokCommentModel.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689c1a788a54832799e5c9d339865983