### PR TITLE
Add WhatsApp notification for rejected dashboard registrations

### DIFF
--- a/src/controller/dashboardUserController.js
+++ b/src/controller/dashboardUserController.js
@@ -27,3 +27,28 @@ export async function approveDashboardUser(req, res, next) {
     next(err);
   }
 }
+
+export async function rejectDashboardUser(req, res, next) {
+  try {
+    if (req.dashboardUser.role !== 'admin') {
+      return res.status(403).json({ success: false, message: 'Forbidden' });
+    }
+    const { id } = req.params;
+    const usr = await dashboardUserModel.findById(id);
+    if (!usr) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+    const updated = await dashboardUserModel.updateStatus(id, false);
+    if (waReady && usr.whatsapp) {
+      const wid = formatToWhatsAppId(usr.whatsapp);
+      await safeSendMessage(
+        waClient,
+        wid,
+        `❌ Registrasi dashboard Anda ditolak.\nUsername: ${usr.username}`
+      );
+    }
+    sendSuccess(res, updated);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -2,7 +2,7 @@
 import { Router } from "express";
 import { getDashboardStats } from "../controller/dashboardController.js";
 import { analyzeInstagramJson } from "../controller/socialMediaController.js";
-import { approveDashboardUser } from "../controller/dashboardUserController.js";
+import { approveDashboardUser, rejectDashboardUser } from "../controller/dashboardUserController.js";
 import { verifyDashboardToken } from "../middleware/dashboardAuth.js";
 const router = Router();
 
@@ -10,5 +10,6 @@ router.use(verifyDashboardToken);
 router.get("/stats", getDashboardStats);
 router.post("/social-media/instagram/analysis", analyzeInstagramJson);
 router.put("/users/:id/approve", approveDashboardUser);
+router.put("/users/:id/reject", rejectDashboardUser);
 
 export default router;

--- a/tests/dashboardUserController.test.js
+++ b/tests/dashboardUserController.test.js
@@ -1,0 +1,73 @@
+import { jest } from '@jest/globals';
+
+const mockFindById = jest.fn();
+const mockUpdateStatus = jest.fn();
+const mockSafeSendMessage = jest.fn();
+
+jest.unstable_mockModule('../src/model/dashboardUserModel.js', () => ({
+  findById: mockFindById,
+  updateStatus: mockUpdateStatus
+}));
+
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  formatToWhatsAppId: (num) => num,
+  safeSendMessage: mockSafeSendMessage
+}));
+
+const mockWaClient = {};
+jest.unstable_mockModule('../src/service/waService.js', () => ({
+  default: mockWaClient,
+  waReady: true
+}));
+
+let controller;
+
+beforeAll(async () => {
+  controller = await import('../src/controller/dashboardUserController.js');
+});
+
+beforeEach(() => {
+  mockFindById.mockReset();
+  mockUpdateStatus.mockReset();
+  mockSafeSendMessage.mockReset();
+});
+
+test('approveDashboardUser sends approval message', async () => {
+  mockFindById.mockResolvedValue({ user_id: '1', username: 'user', whatsapp: '0812' });
+  mockUpdateStatus.mockResolvedValue({ user_id: '1', status: true });
+
+  const req = { dashboardUser: { role: 'admin' }, params: { id: '1' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+
+  await controller.approveDashboardUser(req, res, next);
+
+  expect(mockUpdateStatus).toHaveBeenCalledWith('1', true);
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    mockWaClient,
+    '0812',
+    expect.stringContaining('disetujui')
+  );
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ success: true, data: { user_id: '1', status: true } });
+});
+
+test('rejectDashboardUser sends rejection message', async () => {
+  mockFindById.mockResolvedValue({ user_id: '1', username: 'user', whatsapp: '0812' });
+  mockUpdateStatus.mockResolvedValue({ user_id: '1', status: false });
+
+  const req = { dashboardUser: { role: 'admin' }, params: { id: '1' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+
+  await controller.rejectDashboardUser(req, res, next);
+
+  expect(mockUpdateStatus).toHaveBeenCalledWith('1', false);
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    mockWaClient,
+    '0812',
+    expect.stringContaining('ditolak')
+  );
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ success: true, data: { user_id: '1', status: false } });
+});


### PR DESCRIPTION
## Summary
- notify dashboard users via WhatsApp when registration is rejected
- expose `/users/:id/reject` endpoint for admin responses
- test approval and rejection handlers send WhatsApp messages

## Testing
- `npm run lint`
- `npm test` *(fails: tests/instaLikeModel.test.js, tests/tiktokCommentModel.test.js)*


------
https://chatgpt.com/codex/tasks/task_e_689c315af890832798bee0cc5fb428a0