### PR TITLE
Gracefully handle missing Google Contacts credentials

### DIFF
--- a/src/service/googleContactsService.js
+++ b/src/service/googleContactsService.js
@@ -13,7 +13,10 @@ export async function authorize() {
     const content = await fs.readFile(CREDENTIALS_PATH, 'utf8');
     credentials = JSON.parse(content);
   } catch {
-    throw new Error('Missing credentials.json');
+    console.warn(
+      '[GOOGLE CONTACT] credentials.json not found, skipping contact save.'
+    );
+    return null;
   }
   const { client_secret, client_id, redirect_uris } =
     credentials.installed || credentials.web;
@@ -31,7 +34,8 @@ export async function authorize() {
       scope: SCOPES,
     });
     console.log('Authorize this app by visiting this url:', authUrl);
-    throw new Error('Missing token.json');
+    console.warn('[GOOGLE CONTACT] token.json not found, skipping contact save.');
+    return null;
   }
   return oAuth2Client;
 }
@@ -77,6 +81,7 @@ export async function saveContactIfNew(chatId) {
     );
     if (check.rowCount > 0) return;
     const auth = await authorize();
+    if (!auth) return;
     const exists = await searchByNumbers(auth, [phone]);
     if (exists.includes(phone)) {
       await query(

--- a/tests/googleContactsService.test.js
+++ b/tests/googleContactsService.test.js
@@ -48,6 +48,25 @@ beforeEach(() => {
 });
 
 describe('saveContactIfNew', () => {
+  test('skips when credentials.json missing', async () => {
+    await fs.unlink('credentials.json');
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await saveContactIfNew('11111@c.us');
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockPeople).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[GOOGLE CONTACT] credentials.json not found, skipping contact save.'
+    );
+
+    warnSpy.mockRestore();
+    await fs.writeFile(
+      'credentials.json',
+      JSON.stringify({ installed: { client_id: 'id', client_secret: 'secret', redirect_uris: ['uri'] } })
+    );
+  });
   test('skips existing contact', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ phone_number: '123' }] });
     await saveContactIfNew('12345@c.us');


### PR DESCRIPTION
## Summary
- Warn and skip contact save when credentials or token files are missing
- Avoid Google API calls if authorization is unavailable
- Add tests for missing credentials scenario

## Testing
- `npm run lint`
- `npm test` *(fails: instaLikeModel.test.js, tiktokCommentModel.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689c3614b654832796db2c019fce2a3e