### PR TITLE
refine user listing for directorate roles

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -53,7 +53,7 @@ Holds users belonging to a client.
 - `insta`, `tiktok` – social media handles
 - `client_id` – foreign key referencing `clients(client_id)`
 - `status` – boolean flag
-- `ditbinmas`, `ditlantas` – boolean flags for directorate assignment
+- `ditbinmas`, `ditlantas`, `bidhumas` – boolean flags for directorate assignment
 - `premium_status` – boolean flag indicating active subscription
 - `premium_end_date` – date the premium access expires
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE "user" (
   status BOOLEAN DEFAULT TRUE,
   ditbinmas BOOLEAN DEFAULT FALSE,
   ditlantas BOOLEAN DEFAULT FALSE,
+  bidhumas BOOLEAN DEFAULT FALSE,
   premium_status BOOLEAN DEFAULT FALSE,
   premium_end_date DATE
 );

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -93,6 +93,15 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
     } else {
       tanggalFilter = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
     }
+  } else if (periode === 'mingguan') {
+    if (tanggal) {
+      params.push(tanggal);
+      tanggalFilter = "date_trunc('week', p.created_at) = date_trunc('week', $2::date)";
+    } else {
+      tanggalFilter = "date_trunc('week', p.created_at) = date_trunc('week', NOW())";
+    }
+  } else if (periode === 'semua') {
+    tanggalFilter = '1=1';
   } else if (tanggal) {
     params.push(tanggal);
     tanggalFilter = "p.created_at::date = $2::date";

--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -70,38 +70,38 @@ export async function getRekapKomentarByClient(
   end_date
 ) {
   let tanggalFilter =
-    "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
+    "c.updated_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   const params = [client_id];
   if (start_date && end_date) {
     params.push(start_date, end_date);
-    tanggalFilter = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
+    tanggalFilter = "(c.updated_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
   } else if (periode === "semua") {
     tanggalFilter = "1=1";
   } else if (periode === "mingguan") {
     if (tanggal) {
       params.push(tanggal);
       tanggalFilter =
-        "date_trunc('week', p.created_at) = date_trunc('week', $2::date)";
+        "date_trunc('week', c.updated_at) = date_trunc('week', $2::date)";
     } else {
-      tanggalFilter = "date_trunc('week', p.created_at) = date_trunc('week', NOW())";
+      tanggalFilter = "date_trunc('week', c.updated_at) = date_trunc('week', NOW())";
     }
   } else if (periode === "bulanan") {
     if (tanggal) {
       const monthDate = tanggal.length === 7 ? `${tanggal}-01` : tanggal;
       params.push(monthDate);
       tanggalFilter =
-        "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
+        "date_trunc('month', c.updated_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
     } else {
       tanggalFilter =
-        "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
+        "date_trunc('month', c.updated_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', NOW() AT TIME ZONE 'Asia/Jakarta')";
     }
   } else if (tanggal) {
     params.push(tanggal);
-    tanggalFilter = "p.created_at::date = $2::date";
+    tanggalFilter = "c.updated_at::date = $2::date";
   }
 
   const { rows: postRows } = await query(
-    `SELECT COUNT(*) AS jumlah_post FROM tiktok_post p WHERE p.client_id = $1 AND ${tanggalFilter}`,
+    `SELECT COUNT(*) AS jumlah_post FROM tiktok_post p JOIN tiktok_comment c ON c.video_id = p.video_id WHERE p.client_id = $1 AND ${tanggalFilter}`,
     params
   );
   const max_comment = parseInt(postRows[0]?.jumlah_post || "0", 10);
@@ -110,7 +110,7 @@ export async function getRekapKomentarByClient(
 const { rows } = await query(`
     WITH valid_comments AS (
       SELECT c.video_id,
-             p.created_at,
+             c.updated_at,
              lower(replace(trim(cmt), '@', '')) AS username
       FROM tiktok_comment c
       JOIN tiktok_post p ON p.video_id = c.video_id

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -180,6 +180,7 @@ export async function updateUserField(user_id, field, value) {
     "jabatan",
     "ditbinmas",
     "ditlantas",
+    "bidhumas",
     "premium_status",
     "premium_end_date",
   ];
@@ -206,7 +207,7 @@ export async function getExceptionUsersByClient(client_id) {
 // Ambil user dengan flag direktorat binmas atau lantas
 export async function getDirektoratUsers(clientId = null) {
   let sql =
-    'SELECT * FROM "user" WHERE ditbinmas = true OR ditlantas = true';
+    'SELECT * FROM "user" WHERE (ditbinmas = true OR ditlantas = true OR bidhumas = true)';
   const params = [];
   if (clientId) {
     sql += ' AND client_id = $1';
@@ -218,7 +219,7 @@ export async function getDirektoratUsers(clientId = null) {
 
 // Ambil user berdasarkan flag direktorat tertentu (ditbinmas/ditlantas)
 export async function getUsersByDirektorat(flag, clientId = null) {
-  if (!['ditbinmas', 'ditlantas'].includes(flag)) {
+  if (!['ditbinmas', 'ditlantas', 'bidhumas'].includes(flag)) {
     throw new Error('Direktorat flag tidak valid');
   }
   let sql = `SELECT * FROM "user" WHERE ${flag} = true`;
@@ -282,8 +283,8 @@ export async function createUser(userData) {
   // Sesuaikan dengan struktur dan database-mu!
   normalizeUserFields(userData);
   const q = `
-    INSERT INTO "user" (user_id, nama, title, divisi, jabatan, status, whatsapp, insta, tiktok, client_id, exception, ditbinmas, ditlantas)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+    INSERT INTO "user" (user_id, nama, title, divisi, jabatan, status, whatsapp, insta, tiktok, client_id, exception, ditbinmas, ditlantas, bidhumas)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
     RETURNING *;
   `;
   const params = [
@@ -299,7 +300,8 @@ export async function createUser(userData) {
     userData.client_id || null,
     userData.exception ?? false,
     userData.ditbinmas ?? false,
-    userData.ditlantas ?? false
+    userData.ditlantas ?? false,
+    userData.bidhumas ?? false
   ];
   const res = await query(q, params);
   return res.rows[0];

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -35,7 +35,13 @@ test('operator adds user with defaults', async () => {
 
   await createUser(req, res, () => {});
 
-  expect(mockCreateUser).toHaveBeenCalledWith({ user_id: '1', nama: 'A', ditbinmas: false, ditlantas: false });
+  expect(mockCreateUser).toHaveBeenCalledWith({
+    user_id: '1',
+    nama: 'A',
+    ditbinmas: false,
+    ditlantas: false,
+    bidhumas: false,
+  });
   expect(status).toHaveBeenCalledWith(201);
   expect(json).toHaveBeenCalledWith({ success: true, data: { user_id: '1' } });
 });
@@ -69,11 +75,13 @@ test('ditlantas creates new user with flag', async () => {
 
   await createUser(req, res, () => {});
 
-  expect(mockCreateUser).toHaveBeenCalledWith({
-    user_id: '2',
-    nama: 'B',
-    client_id: 'c2',
-    ditlantas: true
-  });
+  expect(mockCreateUser).toHaveBeenCalledWith(
+    expect.objectContaining({
+      user_id: '2',
+      nama: 'B',
+      client_id: 'c2',
+      ditlantas: true,
+    })
+  );
   expect(status).toHaveBeenCalledWith(201);
 });

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -64,6 +64,7 @@ test('createUser inserts with directorate flags', async () => {
       false,
       true,
       false,
+      false,
     ]
   );
 });
@@ -95,5 +96,15 @@ test('getUsersByDirektorat queries by flag', async () => {
   expect(mockQuery).toHaveBeenCalledWith(
     'SELECT * FROM "user" WHERE ditbinmas = true',
     []
+  );
+});
+
+test('getUsersByDirektorat filters by client and flag', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '3' }] });
+  const users = await getUsersByDirektorat('bidhumas', 'c1');
+  expect(users).toEqual([{ user_id: '3' }]);
+  expect(mockQuery).toHaveBeenCalledWith(
+    'SELECT * FROM "user" WHERE bidhumas = true AND client_id = $1',
+    ['c1']
   );
 });


### PR DESCRIPTION
## Summary
- support new `bidhumas` flag alongside `ditbinmas` and `ditlantas`
- restrict user listing for directorate accounts based on `client_id` and role
- add weekly and "semua" period filters for like analytics and use comment timestamps for TikTok comment analytics

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9428b7208327941709ec29953f40