### PR TITLE
feat: notify dashboard users on approval

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1648,6 +1648,13 @@ Ketik *angka* menu, atau *batal* untuk keluar.
     }
     await dashboardUserModel.updateStatus(usr.user_id, true);
     await waClient.sendMessage(chatId, `✅ User ${usr.username} disetujui.`);
+    if (usr.whatsapp) {
+      await safeSendMessage(
+        waClient,
+        formatToWhatsAppId(usr.whatsapp),
+        `✅ Registrasi dashboard Anda telah disetujui.\nUsername: ${usr.username}`
+      );
+    }
     return;
   }
 
@@ -1665,6 +1672,13 @@ Ketik *angka* menu, atau *batal* untuk keluar.
     }
     await dashboardUserModel.updateStatus(usr.user_id, false);
     await waClient.sendMessage(chatId, `❌ User ${usr.username} ditolak.`);
+    if (usr.whatsapp) {
+      await safeSendMessage(
+        waClient,
+        formatToWhatsAppId(usr.whatsapp),
+        `❌ Registrasi dashboard Anda ditolak.\nUsername: ${usr.username}`
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- send WhatsApp notification to dashboard users when their registration is approved or denied via approvedash/denydash commands

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d282af7688327ae7d7e384da243c7