### PR TITLE
docs: update backend overview with frontend link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **Cicero_V2** is an automation system for monitoring, social media attendance, and content analytics (Instagram & TikTok) aimed at organizations and institutions. The backend supports multiple clients, automatically records likes and comments, and sends reports to WhatsApp administrators.
 
+The web dashboard lives in a separate Next.js repository, [Cicero_Web](https://github.com/cicero78M/Cicero_Web), which communicates with this API. Refer to [docs/combined_overview.md](docs/combined_overview.md) for how the repositories interact.
+
 The full architecture is described in [docs/enterprise_architecture.md](docs/enterprise_architecture.md). Scheduled activities are listed in [docs/activity_schedule.md](docs/activity_schedule.md). See [docs/metadata_flow.md](docs/metadata_flow.md) for the metadata flow. Additional guides are available for [server migration](docs/server_migration.md), [RabbitMQ](docs/rabbitmq.md), [Redis](docs/redis.md), [database structure](docs/database_structure.md), [premium subscriptions](docs/premium_subscription.md), [Nginx configuration](docs/reverse_proxy_config.md), [PostgreSQL backups](docs/pg_backup_gdrive.md), [naming conventions](docs/naming_conventions.md), [Login API guide](docs/login_api.md), [WhatsApp user registration guide](docs/wa_user_registration.md), [workflow & usage guide](docs/workflow_usage_guide.md), and [analytics & feedback page design](docs/analyticsFeedbackPage.md).
 
 ## Requirements

--- a/docs/combined_overview.md
+++ b/docs/combined_overview.md
@@ -1,23 +1,26 @@
 # Cicero Repository Suite Overview
-*Last updated: 2025-06-25*
+*Last updated: 2025-07-16*
 
 This document summarizes the three main repositories that make up the **Cicero** platform. Each repository has a specific role, but all work together to provide social media monitoring and reporting.
 
 ## Repositories
 
 ### 1. Cicero_V2 (Backend)
+- [GitHub: cicero78M/Cicero_V2](https://github.com/cicero78M/Cicero_V2)
 - Node.js/Express REST API used for monitoring Instagram and TikTok.
 - Supports multi-client data collection and sends reports via WhatsApp.
 - Cron jobs automate fetching posts and analytics.
 - See [enterprise_architecture.md](enterprise_architecture.md) for architecture details.
 
 ### 2. Cicero_Web (Dashboard)
-- Next.js dashboard found in the separate `Cicero_Web` repository.
+- [GitHub: cicero78M/Cicero_Web](https://github.com/cicero78M/Cicero_Web)
+- Next.js dashboard repository.
 - Communicates with the backend using helper functions in `utils/api.ts`.
 - Pages under `app/` display Instagram and TikTok analytics as well as user directories.
 - Configured through the `NEXT_PUBLIC_API_URL` environment variable.
 
 ### 3. pegiat_medsos_apps (Android App)
+- GitHub repository for the mobile client (pegiat_medsos_apps).
 - Lightweight Android application for field agents.
 - Uses a login screen to obtain a JWT from the backend.
 - Displays profile information and Instagram posts for the logged in user.


### PR DESCRIPTION
## Summary
- reference Cicero_Web frontend repository from backend README
- add GitHub links and refresh dates in combined repository overview

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2a06e2a0832783744006df86e0d5