### PR TITLE
Support directorate client roles in recap queries

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -163,7 +163,10 @@ export async function getRekapLinkByClient(
   const maxLink = parseInt(postRows[0]?.jumlah_post || '0', 10) * 5;
 
   const { rows } = await query(
-    `WITH link_sum AS (
+    `WITH cli AS (
+       SELECT client_type FROM clients WHERE client_id = $1
+     ),
+     link_sum AS (
        SELECT r.user_id,
          SUM(
            (CASE WHEN r.instagram_link IS NOT NULL AND r.instagram_link <> '' THEN 1 ELSE 0 END) +
@@ -187,7 +190,15 @@ export async function getRekapLinkByClient(
        COALESCE(ls.jumlah_link, 0) AS jumlah_link
      FROM "user" u
      LEFT JOIN link_sum ls ON ls.user_id = u.user_id
-     WHERE u.client_id = $1 AND u.status = true
+     WHERE u.status = true
+       AND (
+         (SELECT client_type FROM cli) <> 'direktorat' AND u.client_id = $1
+         OR (SELECT client_type FROM cli) = 'direktorat' AND (
+           ($1 = 'ditbinmas' AND u.ditbinmas = true) OR
+           ($1 = 'ditlantas' AND u.ditlantas = true) OR
+           ($1 = 'bidhumas' AND u.bidhumas = true)
+         )
+       )
      GROUP BY u.user_id, u.title, u.nama, u.insta, u.divisi, u.exception, ls.jumlah_link
      ORDER BY jumlah_link DESC, u.nama ASC`,
     params

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -69,3 +69,11 @@ test('parses jumlah_like as integer', async () => {
   const rows = await getRekapLikesByClient('1');
   expect(rows[0].jumlah_like).toBe(3);
 });
+
+test('includes directorate role filter when client_id is ditbinmas', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('ditbinmas');
+  const sql = mockQuery.mock.calls[0][0];
+  expect(sql).toContain("clients WHERE client_id = $1");
+  expect(sql).toContain('u.ditbinmas = true');
+});

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -115,7 +115,7 @@ test('getRekapLinkByClient uses provided date', async () => {
   );
   expect(mockQuery).toHaveBeenNthCalledWith(
     2,
-    expect.stringContaining('WITH link_sum AS'),
+    expect.stringContaining('link_sum AS'),
     ['POLRES', '2024-01-02']
   );
 });
@@ -156,4 +156,14 @@ test('getRekapLinkByClient marks sudahMelaksanakan when user has links', async (
     });
   const rows = await getRekapLinkByClient('POLRES');
   expect(rows[0].sudahMelaksanakan).toBe(true);
+});
+
+test('getRekapLinkByClient includes directorate role filter for ditbinmas', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] })
+    .mockResolvedValueOnce({ rows: [] });
+  await getRekapLinkByClient('ditbinmas');
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain('clients WHERE client_id = $1');
+  expect(sql).toContain('u.ditbinmas = true');
 });

--- a/tests/tiktokCommentModel.test.js
+++ b/tests/tiktokCommentModel.test.js
@@ -29,3 +29,13 @@ test('getRekapKomentarByClient uses updated_at BETWEEN for date range', async ()
   expect(mockQuery.mock.calls[1][0]).toContain('BETWEEN $2::date AND $3::date');
   expect(mockQuery.mock.calls[1][1]).toEqual(['POLRES', '2024-01-01', '2024-01-31']);
 });
+
+test('getRekapKomentarByClient includes directorate role filter for ditbinmas', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] })
+    .mockResolvedValueOnce({ rows: [] });
+  await getRekapKomentarByClient('ditbinmas');
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain('clients WHERE client_id = $1');
+  expect(sql).toContain('u.ditbinmas = true');
+});


### PR DESCRIPTION
## Summary
- Detect directorate clients and filter recap users by matching role flag
- Apply directorate role logic to Instagram like, amplify link (regular & special), and TikTok comment recap queries
- Cover new logic with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d992d797c8327982b56873587e72c