### PR TITLE
Add dynamic chart height to recap endpoints

### DIFF
--- a/src/controller/amplifyController.js
+++ b/src/controller/amplifyController.js
@@ -17,7 +17,9 @@ export async function getAmplifyRekap(req, res) {
       msg: `getAmplifyRekap ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}`
     });
     const data = await getRekapLinkByClient(client_id, periode, tanggal, startDate, endDate);
-    res.json({ success: true, data });
+    const length = Array.isArray(data) ? data.length : 0;
+    const chartHeight = Math.max(length * 30, 300);
+    res.json({ success: true, data, chartHeight });
   } catch (err) {
     sendConsoleDebug({ tag: 'AMPLIFY', msg: `Error getAmplifyRekap: ${err.message}` });
     const code = err.statusCode || err.response?.status || 500;

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -34,7 +34,9 @@ export async function getInstaRekapLikes(req, res) {
       startDate,
       endDate
     );
-    res.json({ success: true, data });
+    const length = Array.isArray(data) ? data.length : 0;
+    const chartHeight = Math.max(length * 30, 300);
+    res.json({ success: true, data, chartHeight });
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaRekapLikes: ${err.message}` });
     const code = err.statusCode || err.response?.status || 500;

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -78,7 +78,9 @@ export async function getTiktokRekapKomentar(req, res) {
       startDate,
       endDate
     );
-    res.json({ success: true, data });
+    const length = Array.isArray(data) ? data.length : 0;
+    const chartHeight = Math.max(length * 30, 300);
+    res.json({ success: true, data, chartHeight });
   } catch (err) {
     const code = err.statusCode || err.response?.status || 500;
     res.status(code).json({ success: false, message: err.message });

--- a/tests/amplifyControllerDateRange.test.js
+++ b/tests/amplifyControllerDateRange.test.js
@@ -31,5 +31,6 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getAmplifyRekap(req, res);
   expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -44,5 +44,6 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const res = { json };
   await getInstaRekapLikes(req, res);
   expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 

--- a/tests/tiktokControllerDateRange.test.js
+++ b/tests/tiktokControllerDateRange.test.js
@@ -39,5 +39,6 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getTiktokRekapKomentar(req, res);
   expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 


### PR DESCRIPTION
## Summary
- Add `chartHeight` in Instagram, amplification link, and TikTok comment recap controllers to scale bar chart views
- Update recap tests to expect the new `chartHeight` field

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dcc869afc8327b807086630e4fd3c