### PR TITLE
feat: add dashrequest dashboard menu

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
+++ b/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
@@ -1,0 +1,160 @@
+import { query } from "../../../db/index.js";
+import { getUsersByClient } from "../../../model/userModel.js";
+import { getShortcodesTodayByClient } from "../../../model/instaPostModel.js";
+import { hariIndo } from "../../../utils/constants.js";
+import { groupByDivision, sortDivisionKeys } from "../../../utils/utilsHelper.js";
+
+function normalizeUsername(username) {
+  return (username || "")
+    .toString()
+    .trim()
+    .replace(/^@/, "")
+    .toLowerCase();
+}
+
+async function getClientNama(client_id) {
+  const res = await query(
+    "SELECT nama FROM clients WHERE client_id = $1 LIMIT 1",
+    [client_id]
+  );
+  return res.rows[0]?.nama || client_id;
+}
+
+async function getCommentsUsernamesByShortcode(shortcode) {
+  const res = await query(
+    `SELECT DISTINCT iu.username
+     FROM ig_post_comments ic
+     LEFT JOIN instagram_user iu ON ic.user_id = iu.user_id
+     WHERE ic.post_id = $1`,
+    [shortcode]
+  );
+  return res.rows.map((r) => normalizeUsername(r.username));
+}
+
+export async function absensiKomentarInstagram(client_id, opts = {}) {
+  const { clientFilter } = opts;
+  const roleFlag = opts.roleFlag;
+  void roleFlag;
+  const targetClient = clientFilter || client_id;
+
+  const now = new Date();
+  const hari = hariIndo[now.getDay()];
+  const tanggal = now.toLocaleDateString("id-ID");
+  const jam = now.toLocaleTimeString("id-ID", { hour12: false });
+
+  const clientNama = await getClientNama(targetClient);
+  const users = await getUsersByClient(targetClient);
+  const shortcodes = await getShortcodesTodayByClient(targetClient);
+  if (!shortcodes.length)
+    return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;
+
+  const userStats = {};
+  users.forEach((u) => {
+    userStats[u.user_id] = { ...u, count: 0 };
+  });
+
+  for (const sc of shortcodes) {
+    const usernames = await getCommentsUsernamesByShortcode(sc);
+    const set = new Set(usernames);
+    users.forEach((u) => {
+      if (
+        u.insta &&
+        u.insta.trim() !== "" &&
+        set.has(normalizeUsername(u.insta))
+      ) {
+        userStats[u.user_id].count += 1;
+      }
+    });
+  }
+
+  const totalKonten = shortcodes.length;
+  const threshold = Math.ceil(totalKonten * 0.5);
+  let sudah = [], belum = [];
+  Object.values(userStats).forEach((u) => {
+    if (u.exception === true) {
+      sudah.push(u);
+    } else if (
+      u.insta &&
+      u.insta.trim() !== "" &&
+      u.count >= threshold
+    ) {
+      sudah.push(u);
+    } else {
+      belum.push(u);
+    }
+  });
+  belum = belum.filter((u) => !u.exception);
+
+  const kontenLinks = shortcodes.map(
+    (sc) => `https://www.instagram.com/p/${sc}`
+  );
+
+  const mode = opts && opts.mode ? String(opts.mode).toLowerCase() : "all";
+
+  let msg =
+    `Mohon ijin Komandan,\\n\\n` +
+    `📋 *Rekap Akumulasi Komentar Instagram*\\n*Polres*: *${clientNama}*\\n${hari}, ${tanggal}\\nJam: ${jam}\\n\\n` +
+    `*Jumlah Konten:* ${totalKonten}\\n` +
+    `*Daftar Link Konten:*\\n${kontenLinks.length ? kontenLinks.join("\\n") : "-"}\\n\\n` +
+    `*Jumlah user:* ${users.length}\\n` +
+    `✅ *Sudah melaksanakan* : *${sudah.length} user*\\n` +
+    `❌ *Belum melaksanakan* : *${belum.length} user*\\n\\n`;
+
+  if (mode === "all" || mode === "sudah") {
+    msg += `✅ *Sudah melaksanakan* (${sudah.length} user):\\n`;
+    const sudahDiv = groupByDivision(sudah);
+    sortDivisionKeys(Object.keys(sudahDiv)).forEach((div, idx, arr) => {
+      const list = sudahDiv[div];
+      msg += `*${div}* (${list.length} user):\\n`;
+      msg +=
+        list
+          .map((u) => {
+            let ket = "";
+            if (u.count) ket = `(${u.count}/${totalKonten} konten)`;
+            return (
+              `- ${u.title ? u.title + " " : ""}${u.nama} : ` +
+              (u.insta ? `@${u.insta.replace(/^@/, "")}` : "-") +
+              ` ${ket}`
+            );
+          })
+          .join("\\n") + "\\n";
+      if (idx < arr.length - 1) msg += "\\n";
+    });
+    if (Object.keys(sudahDiv).length === 0) msg += "-\\n";
+    msg += "\\n";
+  }
+
+  if (mode === "all" || mode === "belum") {
+    msg += `❌ *Belum melaksanakan* (${belum.length} user):\\n`;
+    const belumDiv = groupByDivision(belum);
+    sortDivisionKeys(Object.keys(belumDiv)).forEach((div, idx, arr) => {
+      const list = belumDiv[div];
+      msg += `*${div}* (${list.length} user):\\n`;
+      msg +=
+        list
+          .map((u) => {
+            let ket = "";
+            if (!u.count || u.count === 0) {
+              ket = `(0/${totalKonten} konten)`;
+            } else if (u.count > 0 && u.count < threshold) {
+              ket = `(${u.count}/${totalKonten} konten)`;
+            }
+            return (
+              `- ${u.title ? u.title + " " : ""}${u.nama} : ` +
+              (u.insta ? `@${u.insta.replace(/^@/, "")}` : "-") +
+              ` ${ket}`
+            );
+          })
+          .join("\\n") + "\\n";
+      if (idx < arr.length - 1) msg += "\\n";
+    });
+    if (Object.keys(belumDiv).length === 0) msg += "-\\n";
+    msg += "\\n";
+  }
+
+  msg += `Terimakasih.`;
+  return msg.trim();
+}
+
+export default absensiKomentarInstagram;
+

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -24,14 +24,18 @@ async function getClientNama(client_id) {
 
 // === AKUMULASI ===
 export async function absensiLikes(client_id, opts = {}) {
+  const { clientFilter } = opts;
+  const roleFlag = opts.roleFlag;
+  void roleFlag;
+  const targetClient = clientFilter || client_id;
   const now = new Date();
   const hari = hariIndo[now.getDay()];
   const tanggal = now.toLocaleDateString("id-ID");
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
-  const clientNama = await getClientNama(client_id);
-  const users = await getUsersByClient(client_id);
-  const shortcodes = await getShortcodesTodayByClient(client_id);
+  const clientNama = await getClientNama(targetClient);
+  const users = await getUsersByClient(targetClient);
+  const shortcodes = await getShortcodesTodayByClient(targetClient);
 
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *Polres*: *${clientNama}* hari ini.`;

--- a/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
+++ b/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
@@ -19,18 +19,22 @@ async function getClientNama(client_id) {
 }
 
 export async function absensiLink(client_id, opts = {}) {
+  const { clientFilter } = opts;
+  const roleFlag = opts.roleFlag;
+  void roleFlag;
+  const targetClient = clientFilter || client_id;
   const now = new Date();
   const hari = hariIndo[now.getDay()];
   const tanggal = now.toLocaleDateString("id-ID");
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
-  const clientNama = await getClientNama(client_id);
-  const users = await getUsersByClient(client_id);
-  const shortcodes = await getShortcodesTodayByClient(client_id);
+  const clientNama = await getClientNama(targetClient);
+  const users = await getUsersByClient(targetClient);
+  const shortcodes = await getShortcodesTodayByClient(targetClient);
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;
 
-  const reports = await getReportsTodayByClient(client_id);
+  const reports = await getReportsTodayByClient(targetClient);
   const userStats = {};
   users.forEach((u) => {
     userStats[u.user_id] = { ...u, count: 0 };

--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -37,27 +37,31 @@ function extractUsernamesFromComments(comments) {
 
 // === AKUMULASI (min 50%) ===
 export async function absensiKomentar(client_id, opts = {}) {
+  const { clientFilter } = opts;
+  const roleFlag = opts.roleFlag;
+  void roleFlag;
+  const targetClient = clientFilter || client_id;
   const now = new Date();
   const hari = hariIndo[now.getDay()];
   const tanggal = now.toLocaleDateString("id-ID");
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
-  const clientInfo = await getClientInfo(client_id);
+  const clientInfo = await getClientInfo(targetClient);
   const clientNama = clientInfo.nama;
   const tiktokUsername = clientInfo.tiktok;
-  const users = await getUsersByClient(client_id);
-  const posts = await getPostsTodayByClient(client_id);
+  const users = await getUsersByClient(targetClient);
+  const posts = await getPostsTodayByClient(targetClient);
 
   sendDebug({
     tag: "ABSEN TTK",
     msg: `Start per-konten absensi. Posts=${posts.length} users=${users.length}`,
-    client_id,
+    client_id: targetClient,
   });
 
   sendDebug({
     tag: "ABSEN TTK",
     msg: `Start absensi komentar. Posts=${posts.length} users=${users.length}`,
-    client_id,
+    client_id: targetClient,
   });
 
   if (!posts.length)

--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -1,0 +1,111 @@
+import { getUsersMissingDataByClient } from "../../model/userModel.js";
+import { absensiLink } from "../fetchabsensi/link/absensiLinkAmplifikasi.js";
+import { absensiLikes } from "../fetchabsensi/insta/absensiLikesInsta.js";
+import { absensiKomentarInstagram } from "../fetchabsensi/insta/absensiKomentarInstagram.js";
+import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
+
+function formatMissingData(users, clientId) {
+  let msg = `*Rekap User Belum Lengkap*\\nClient: *${clientId}*\\n`;
+  if (users.length === 0) {
+    msg += "Semua user telah melengkapi data.";
+    return msg.trim();
+  }
+  msg += `Jumlah: ${users.length} user\\n`;
+  msg += users
+    .map((u) => {
+      const missing = [];
+      if (!u.insta) missing.push("IG");
+      if (!u.tiktok) missing.push("TT");
+      if (!u.whatsapp) missing.push("WA");
+      return `- ${u.nama} (${u.user_id}) kurang: ${missing.join(", ")}`;
+    })
+    .join("\\n");
+  return msg.trim();
+}
+
+async function performAction(action, clientId, role, waClient, chatId) {
+  let msg = "";
+  switch (action) {
+    case "1": {
+      const users = await getUsersMissingDataByClient(clientId);
+      msg = formatMissingData(users, clientId);
+      break;
+    }
+    case "2":
+      msg = await absensiLink(clientId, {
+        roleFlag: role,
+        clientFilter: clientId,
+        mode: "all",
+      });
+      break;
+    case "3":
+      msg = await absensiLikes(clientId, {
+        roleFlag: role,
+        clientFilter: clientId,
+        mode: "all",
+      });
+      break;
+    case "4":
+      msg = await absensiKomentarInstagram(clientId, {
+        roleFlag: role,
+        clientFilter: clientId,
+        mode: "all",
+      });
+      break;
+    case "5":
+      msg = await absensiKomentar(clientId, {
+        roleFlag: role,
+        clientFilter: clientId,
+        mode: "all",
+      });
+      break;
+    default:
+      msg = "Menu tidak dikenal.";
+  }
+  await waClient.sendMessage(chatId, msg.trim());
+}
+
+export const dashRequestHandlers = {
+  async main(session, chatId, _text, waClient) {
+    const menu =
+      "┏━━━ *MENU DASHBOARD* ━━━\n" +
+      "1️⃣ Rekap user belum lengkapi data\n" +
+      "2️⃣ Rekap link Instagram\n" +
+      "3️⃣ Rekap likes Instagram\n" +
+      "4️⃣ Rekap komentar Instagram\n" +
+      "5️⃣ Rekap komentar TikTok\n" +
+      "┗━━━━━━━━━━━━━━━━━┛\n" +
+      "Ketik *angka* menu atau *batal* untuk keluar.";
+    await waClient.sendMessage(chatId, menu);
+    session.step = "choose_menu";
+  },
+
+  async choose_menu(session, chatId, text, waClient) {
+    const choice = text.trim();
+    if (!["1", "2", "3", "4", "5"].includes(choice)) {
+      await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
+      return;
+    }
+    if (session.role === "admin") {
+      session.pendingAction = choice;
+      session.step = "ask_client";
+      await waClient.sendMessage(chatId, "Masukkan Client ID target:");
+      return;
+    }
+    await performAction(choice, session.client_id, session.role, waClient, chatId);
+    session.step = "main";
+    await dashRequestHandlers.main(session, chatId, "", waClient);
+  },
+
+  async ask_client(session, chatId, text, waClient) {
+    const clientId = text.trim().toUpperCase();
+    const action = session.pendingAction;
+    await performAction(action, clientId, session.role, waClient, chatId);
+    delete session.pendingAction;
+    session.step = "main";
+    await dashRequestHandlers.main(session, chatId, "", waClient);
+  },
+};
+
+export default dashRequestHandlers;
+

--- a/src/model/dashboardUserModel.js
+++ b/src/model/dashboardUserModel.js
@@ -8,6 +8,14 @@ export async function findByUsername(username) {
   return res.rows[0] || null;
 }
 
+export async function findByWhatsApp(wa) {
+  const res = await query(
+    'SELECT * FROM dashboard_user WHERE whatsapp = $1',
+    [wa]
+  );
+  return res.rows[0] || null;
+}
+
 export async function createUser(data) {
   const res = await query(
     `INSERT INTO dashboard_user (user_id, username, password_hash, role, status, client_id, whatsapp)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -27,6 +27,7 @@ export const adminCommands = [
   "denysub#",
   "approvedash#",
   "denydash#",
+  "dashrequest",
   "savecontact",
 ];
 


### PR DESCRIPTION
## Summary
- allow dashboard users to trigger `dashrequest` via WhatsApp
- add handler for dashboard requests and Instagram comment recap
- support role and client filters in rekap functions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0afc00b348327bee0f4da389ca67f