### PR TITLE
Handle missing redirect_uris in Google Contacts auth

### DIFF
--- a/docs/google_contacts_integration.md
+++ b/docs/google_contacts_integration.md
@@ -13,7 +13,7 @@ This guide explains how to configure and use the Google Contacts integration in 
    - Set `GOOGLE_SERVICE_ACCOUNT` to the JSON key content or path.
    - Set `GOOGLE_IMPERSONATE_EMAIL` to the Workspace user to impersonate.
    - Optionally override `GOOGLE_CONTACT_SCOPE` if a different scope is required.
-   - Alternatively, place `credentials.json` and `token.json` in the project root for OAuth authentication.
+   - Alternatively, place `credentials.json` and `token.json` in the project root for OAuth authentication. The `credentials.json` file must include a `redirect_uris` array.
 
 ## Usage
 The service in `src/service/googleContactsService.js` exposes helpers for searching and saving contacts.

--- a/src/service/googleContactsService.js
+++ b/src/service/googleContactsService.js
@@ -18,8 +18,14 @@ export async function authorize() {
     );
     return null;
   }
-  const { client_secret, client_id, redirect_uris } =
-    credentials.installed || credentials.web;
+  const credsData = credentials.installed || credentials.web;
+  const { client_secret, client_id, redirect_uris = [] } = credsData || {};
+  if (!redirect_uris.length) {
+    console.warn(
+      '[GOOGLE CONTACT] redirect_uris missing in credentials.json, skipping contact save.'
+    );
+    return null;
+  }
   const oAuth2Client = new google.auth.OAuth2(
     client_id,
     client_secret,

--- a/tests/googleContactsService.test.js
+++ b/tests/googleContactsService.test.js
@@ -67,6 +67,27 @@ describe('saveContactIfNew', () => {
       JSON.stringify({ installed: { client_id: 'id', client_secret: 'secret', redirect_uris: ['uri'] } })
     );
   });
+  test('skips when redirect_uris missing', async () => {
+    await fs.writeFile(
+      'credentials.json',
+      JSON.stringify({ installed: { client_id: 'id', client_secret: 'secret' } })
+    );
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await saveContactIfNew('22222@c.us');
+
+    expect(mockPeople).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[GOOGLE CONTACT] redirect_uris missing in credentials.json, skipping contact save.'
+    );
+
+    warnSpy.mockRestore();
+    await fs.writeFile(
+      'credentials.json',
+      JSON.stringify({ installed: { client_id: 'id', client_secret: 'secret', redirect_uris: ['uri'] } })
+    );
+  });
   test('skips existing contact', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ phone_number: '123' }] });
     await saveContactIfNew('12345@c.us');


### PR DESCRIPTION
## Summary
- avoid crash in Google Contacts authorization when `redirect_uris` is missing
- document requirement for `redirect_uris` in credentials
- test redirect_uris handling in Google Contacts service

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b6364eac83279cc3f11191283fdd