### PR TITLE
Normalize dashboard WhatsApp input

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -10,6 +10,7 @@ import {
   isAdminWhatsApp,
   formatToWhatsAppId,
   getAdminWAIds,
+  normalizeWhatsappNumber,
 } from "../utils/waHelper.js";
 import redis from "../config/redis.js";
 import waClient, { waReady } from "../service/waService.js";
@@ -106,7 +107,7 @@ router.post('/dashboard-register', async (req, res) => {
       .status(400)
       .json({ success: false, message: 'username, password, dan whatsapp wajib diisi' });
   }
-  const normalizedWhatsapp = String(whatsapp).replace(/\D/g, '');
+  const normalizedWhatsapp = normalizeWhatsappNumber(whatsapp);
   if (normalizedWhatsapp.length < 8) {
     return res
       .status(400)

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -75,6 +75,13 @@ export function formatToWhatsAppId(nohp) {
   return `${number}@c.us`;
 }
 
+// Normalisasi nomor WhatsApp ke awalan 62 tanpa suffix @c.us
+export function normalizeWhatsappNumber(nohp) {
+  let number = String(nohp).replace(/\D/g, "");
+  if (!number.startsWith("62")) number = "62" + number.replace(/^0/, "");
+  return number;
+}
+
 // Format output data client (untuk WA)
 export function formatClientData(obj, title = "") {
   let keysOrder = [

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -258,7 +258,7 @@ describe('POST /dashboard-register', () => {
     expect(mockQuery).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('INSERT INTO dashboard_user'),
-      [expect.any(String), 'dash', expect.any(String), 'operator', false, null, '08121234']
+      [expect.any(String), 'dash', expect.any(String), 'operator', false, null, '628121234']
     );
   });
 


### PR DESCRIPTION
## Summary
- ensure dashboard registration stores WhatsApp numbers with Indonesian country code
- add utility for normalizing WhatsApp numbers
- adjust tests for normalized WhatsApp formatting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b7bd03888327ab506b792d31bade