### PR TITLE
Refactor directorate flags into role tables

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -54,9 +54,20 @@ Holds users belonging to a client.
 - `desa` – desa binaan for Ditbinmas users
 - `client_id` – foreign key referencing `clients(client_id)`
 - `status` – boolean flag
-- `ditbinmas`, `ditlantas`, `bidhumas` – boolean flags for directorate assignment
 - `premium_status` – boolean flag indicating active subscription
 - `premium_end_date` – date the premium access expires
+- roles are assigned through the `user_roles` pivot table
+
+### `roles`
+Stores available role names.
+- `role_id` – serial primary key
+- `role_name` – unique role identifier
+
+### `user_roles`
+Pivot table linking users to roles.
+- `user_id` – references `user(user_id)`
+- `role_id` – references `roles(role_id)`
+- composite primary key `(user_id, role_id)`
 
 ### `dashboard_user`
 Credentials for the web dashboard login.

--- a/sql/migrations/20251012_create_roles_user_roles.sql
+++ b/sql/migrations/20251012_create_roles_user_roles.sql
@@ -1,0 +1,16 @@
+-- Create roles and user_roles tables and remove old directorate columns
+CREATE TABLE IF NOT EXISTS roles (
+  role_id SERIAL PRIMARY KEY,
+  role_name VARCHAR UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+  user_id VARCHAR REFERENCES "user"(user_id),
+  role_id INTEGER REFERENCES roles(role_id),
+  PRIMARY KEY (user_id, role_id)
+);
+
+ALTER TABLE "user"
+  DROP COLUMN IF EXISTS ditbinmas,
+  DROP COLUMN IF EXISTS ditlantas,
+  DROP COLUMN IF EXISTS bidhumas;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -24,11 +24,19 @@ CREATE TABLE "user" (
   desa VARCHAR,
   client_id VARCHAR REFERENCES clients(client_id),
   status BOOLEAN DEFAULT TRUE,
-  ditbinmas BOOLEAN DEFAULT FALSE,
-  ditlantas BOOLEAN DEFAULT FALSE,
-  bidhumas BOOLEAN DEFAULT FALSE,
   premium_status BOOLEAN DEFAULT FALSE,
   premium_end_date DATE
+);
+
+CREATE TABLE roles (
+  role_id SERIAL PRIMARY KEY,
+  role_name VARCHAR UNIQUE
+);
+
+CREATE TABLE user_roles (
+  user_id VARCHAR REFERENCES "user"(user_id),
+  role_id INTEGER REFERENCES roles(role_id),
+  PRIMARY KEY (user_id, role_id)
 );
 
 CREATE TABLE penmas_user (

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -146,10 +146,10 @@ export async function getRekapLikesByClient(client_id, periode = "harian", tangg
       AND u.insta IS NOT NULL
       AND (
         (SELECT client_type FROM cli) <> 'direktorat' AND u.client_id = $1
-        OR (SELECT client_type FROM cli) = 'direktorat' AND (
-          ($1 = 'ditbinmas' AND u.ditbinmas = true) OR
-          ($1 = 'ditlantas' AND u.ditlantas = true) OR
-          ($1 = 'bidhumas' AND u.bidhumas = true)
+        OR (SELECT client_type FROM cli) = 'direktorat' AND EXISTS (
+          SELECT 1 FROM user_roles ur
+          JOIN roles r ON ur.role_id = r.role_id
+          WHERE ur.user_id = u.user_id AND r.role_name = $1
         )
       )
     ORDER BY jumlah_like DESC, u.nama ASC

--- a/src/model/linkReportKhususModel.js
+++ b/src/model/linkReportKhususModel.js
@@ -187,10 +187,10 @@ export async function getRekapLinkByClient(
      WHERE u.status = true
        AND (
          (SELECT client_type FROM cli) <> 'direktorat' AND u.client_id = $1
-         OR (SELECT client_type FROM cli) = 'direktorat' AND (
-           ($1 = 'ditbinmas' AND u.ditbinmas = true) OR
-           ($1 = 'ditlantas' AND u.ditlantas = true) OR
-           ($1 = 'bidhumas' AND u.bidhumas = true)
+         OR (SELECT client_type FROM cli) = 'direktorat' AND EXISTS (
+           SELECT 1 FROM user_roles ur
+           JOIN roles r ON ur.role_id = r.role_id
+           WHERE ur.user_id = u.user_id AND r.role_name = $1
          )
        )
      GROUP BY u.user_id, u.title, u.nama, u.insta, u.divisi, u.exception, ls.jumlah_link

--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -193,10 +193,10 @@ export async function getRekapLinkByClient(
      WHERE u.status = true
        AND (
          (SELECT client_type FROM cli) <> 'direktorat' AND u.client_id = $1
-         OR (SELECT client_type FROM cli) = 'direktorat' AND (
-           ($1 = 'ditbinmas' AND u.ditbinmas = true) OR
-           ($1 = 'ditlantas' AND u.ditlantas = true) OR
-           ($1 = 'bidhumas' AND u.bidhumas = true)
+         OR (SELECT client_type FROM cli) = 'direktorat' AND EXISTS (
+           SELECT 1 FROM user_roles ur
+           JOIN roles r ON ur.role_id = r.role_id
+           WHERE ur.user_id = u.user_id AND r.role_name = $1
          )
        )
      GROUP BY u.user_id, u.title, u.nama, u.insta, u.divisi, u.exception, ls.jumlah_link

--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -141,10 +141,10 @@ export async function getRekapKomentarByClient(
       AND u.tiktok IS NOT NULL
       AND (
         (SELECT client_type FROM cli) <> 'direktorat' AND u.client_id = $1
-        OR (SELECT client_type FROM cli) = 'direktorat' AND (
-          ($1 = 'ditbinmas' AND u.ditbinmas = true) OR
-          ($1 = 'ditlantas' AND u.ditlantas = true) OR
-          ($1 = 'bidhumas' AND u.bidhumas = true)
+        OR (SELECT client_type FROM cli) = 'direktorat' AND EXISTS (
+          SELECT 1 FROM user_roles ur
+          JOIN roles r ON ur.role_id = r.role_id
+          WHERE ur.user_id = u.user_id AND r.role_name = $1
         )
       )
     ORDER BY jumlah_komentar DESC, u.nama ASC

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -204,7 +204,8 @@ describe('POST /user-register', () => {
   test('creates new user when nrp free', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ user_id: '1' }] });
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: false, ditlantas: false, bidhumas: false }] });
 
     const res = await request(app)
       .post('/api/auth/user-register')
@@ -217,11 +218,7 @@ describe('POST /user-register', () => {
       'SELECT * FROM "user" WHERE user_id = $1',
       ['1']
     );
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('INSERT INTO "user"'),
-      expect.any(Array)
-    );
+    expect(mockQuery.mock.calls[1][0]).toContain('INSERT INTO "user"');
   });
 
   test('returns 400 when nrp exists', async () => {

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -74,6 +74,6 @@ test('includes directorate role filter when client_id is ditbinmas', async () =>
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('ditbinmas');
   const sql = mockQuery.mock.calls[0][0];
-  expect(sql).toContain("clients WHERE client_id = $1");
-  expect(sql).toContain('u.ditbinmas = true');
+  expect(sql).toContain('clients WHERE client_id = $1');
+  expect(sql).toContain('user_roles');
 });

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -165,5 +165,5 @@ test('getRekapLinkByClient includes directorate role filter for ditbinmas', asyn
   await getRekapLinkByClient('ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('clients WHERE client_id = $1');
-  expect(sql).toContain('u.ditbinmas = true');
+  expect(sql).toContain('user_roles');
 });

--- a/tests/tiktokCommentModel.test.js
+++ b/tests/tiktokCommentModel.test.js
@@ -37,5 +37,5 @@ test('getRekapKomentarByClient includes directorate role filter for ditbinmas', 
   await getRekapKomentarByClient('ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('clients WHERE client_id = $1');
-  expect(sql).toContain('u.ditbinmas = true');
+  expect(sql).toContain('user_roles');
 });


### PR DESCRIPTION
## Summary
- replace `ditbinmas`, `ditlantas`, `bidhumas` columns with `roles` and `user_roles` tables
- update user model and related queries to read/write roles via pivot table
- adjust aggregation queries and documentation to use role lookups

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1739a80c88327b754c7f169937167