### PR TITLE
feat: use UUID for dashboard user key

### DIFF
--- a/sql/migrations/20251013_dashboardUserPkUserId.sql
+++ b/sql/migrations/20251013_dashboardUserPkUserId.sql
@@ -1,0 +1,23 @@
+-- Add dashboard_user_id primary key and optional user_id reference
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE dashboard_user
+  DROP CONSTRAINT IF EXISTS dashboard_user_pkey;
+
+ALTER TABLE dashboard_user
+  ALTER COLUMN user_id TYPE VARCHAR,
+  ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE dashboard_user
+  ADD COLUMN IF NOT EXISTS dashboard_user_id UUID DEFAULT gen_random_uuid();
+
+UPDATE dashboard_user
+SET dashboard_user_id = gen_random_uuid()
+WHERE dashboard_user_id IS NULL;
+
+ALTER TABLE dashboard_user
+  ADD CONSTRAINT dashboard_user_pkey PRIMARY KEY (dashboard_user_id);
+
+ALTER TABLE dashboard_user
+  ADD CONSTRAINT dashboard_user_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES "user"(user_id);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 CREATE TABLE clients (
   client_id VARCHAR PRIMARY KEY,
   nama VARCHAR NOT NULL,
@@ -49,12 +51,13 @@ CREATE TABLE penmas_user (
 );
 
 CREATE TABLE dashboard_user (
-  user_id TEXT PRIMARY KEY,
+  dashboard_user_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   username TEXT UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
   role TEXT NOT NULL,
   status BOOLEAN DEFAULT TRUE,
   client_id VARCHAR REFERENCES clients(client_id),
+  user_id VARCHAR REFERENCES "user"(user_id),
   whatsapp VARCHAR,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()

--- a/src/model/dashboardUserModel.js
+++ b/src/model/dashboardUserModel.js
@@ -18,16 +18,17 @@ export async function findByWhatsApp(wa) {
 
 export async function createUser(data) {
   const res = await query(
-    `INSERT INTO dashboard_user (user_id, username, password_hash, role, status, client_id, whatsapp)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
+    `INSERT INTO dashboard_user (dashboard_user_id, username, password_hash, role, status, client_id, user_id, whatsapp)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
      RETURNING *`,
     [
-      data.user_id,
+      data.dashboard_user_id,
       data.username,
       data.password_hash,
       data.role,
       data.status,
       data.client_id,
+      data.user_id ?? null,
       data.whatsapp,
     ]
   );
@@ -35,16 +36,14 @@ export async function createUser(data) {
 }
 
 export async function findById(id) {
-  const res = await query('SELECT * FROM dashboard_user WHERE user_id=$1', [id]);
+  const res = await query('SELECT * FROM dashboard_user WHERE dashboard_user_id=$1', [id]);
   return res.rows[0] || null;
 }
 
 export async function updateStatus(id, status) {
   const res = await query(
-    'UPDATE dashboard_user SET status=$2, updated_at=NOW() WHERE user_id=$1 RETURNING *',
+    'UPDATE dashboard_user SET status=$2, updated_at=NOW() WHERE dashboard_user_id=$1 RETURNING *',
     [id, status]
-
   );
   return res.rows[0];
 }
-

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1669,7 +1669,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       await waClient.sendMessage(chatId, `❌ Username ${username} tidak ditemukan.`);
       return;
     }
-    await dashboardUserModel.updateStatus(usr.user_id, true);
+    await dashboardUserModel.updateStatus(usr.dashboard_user_id, true);
     await waClient.sendMessage(chatId, `✅ User ${usr.username} disetujui.`);
     if (usr.whatsapp) {
       await safeSendMessage(
@@ -1693,7 +1693,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       await waClient.sendMessage(chatId, `❌ Username ${username} tidak ditemukan.`);
       return;
     }
-    await dashboardUserModel.updateStatus(usr.user_id, false);
+    await dashboardUserModel.updateStatus(usr.dashboard_user_id, false);
     await waClient.sendMessage(chatId, `❌ User ${usr.username} ditolak.`);
     if (usr.whatsapp) {
       await safeSendMessage(

--- a/tests/dashboardUserController.test.js
+++ b/tests/dashboardUserController.test.js
@@ -33,8 +33,8 @@ beforeEach(() => {
 });
 
 test('approveDashboardUser sends approval message', async () => {
-  mockFindById.mockResolvedValue({ user_id: '1', username: 'user', whatsapp: '0812' });
-  mockUpdateStatus.mockResolvedValue({ user_id: '1', status: true });
+  mockFindById.mockResolvedValue({ dashboard_user_id: '1', username: 'user', whatsapp: '0812' });
+  mockUpdateStatus.mockResolvedValue({ dashboard_user_id: '1', status: true });
 
   const req = { dashboardUser: { role: 'admin' }, params: { id: '1' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -49,12 +49,12 @@ test('approveDashboardUser sends approval message', async () => {
     expect.stringContaining('disetujui')
   );
   expect(res.status).toHaveBeenCalledWith(200);
-  expect(res.json).toHaveBeenCalledWith({ success: true, data: { user_id: '1', status: true } });
+  expect(res.json).toHaveBeenCalledWith({ success: true, data: { dashboard_user_id: '1', status: true } });
 });
 
 test('rejectDashboardUser sends rejection message', async () => {
-  mockFindById.mockResolvedValue({ user_id: '1', username: 'user', whatsapp: '0812' });
-  mockUpdateStatus.mockResolvedValue({ user_id: '1', status: false });
+  mockFindById.mockResolvedValue({ dashboard_user_id: '1', username: 'user', whatsapp: '0812' });
+  mockUpdateStatus.mockResolvedValue({ dashboard_user_id: '1', status: false });
 
   const req = { dashboardUser: { role: 'admin' }, params: { id: '1' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -69,5 +69,5 @@ test('rejectDashboardUser sends rejection message', async () => {
     expect.stringContaining('ditolak')
   );
   expect(res.status).toHaveBeenCalledWith(200);
-  expect(res.json).toHaveBeenCalledWith({ success: true, data: { user_id: '1', status: false } });
+  expect(res.json).toHaveBeenCalledWith({ success: true, data: { dashboard_user_id: '1', status: false } });
 });


### PR DESCRIPTION
## Summary
- add dashboard_user_id UUID primary key and optional user_id FK
- update dashboard auth flow and WA approvals to use new dashboard_user_id
- adjust tests and schema for new dashboard user mapping

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1795196a88327a3b47b90b4dc4882