### PR TITLE
feat: support multiple clients for dashboard users

### DIFF
--- a/sql/migrations/20251014_dashboardUserClientsPivot.sql
+++ b/sql/migrations/20251014_dashboardUserClientsPivot.sql
@@ -1,0 +1,7 @@
+ALTER TABLE dashboard_user DROP COLUMN IF EXISTS client_id;
+
+CREATE TABLE IF NOT EXISTS dashboard_user_clients (
+    dashboard_user_id UUID REFERENCES dashboard_user(dashboard_user_id) ON DELETE CASCADE,
+    client_id VARCHAR REFERENCES clients(client_id) ON DELETE CASCADE,
+    PRIMARY KEY (dashboard_user_id, client_id)
+);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -56,11 +56,16 @@ CREATE TABLE dashboard_user (
   password_hash TEXT NOT NULL,
   role TEXT NOT NULL,
   status BOOLEAN DEFAULT TRUE,
-  client_id VARCHAR REFERENCES clients(client_id),
   user_id VARCHAR REFERENCES "user"(user_id),
   whatsapp VARCHAR,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE dashboard_user_clients (
+  dashboard_user_id UUID REFERENCES dashboard_user(dashboard_user_id),
+  client_id VARCHAR REFERENCES clients(client_id),
+  PRIMARY KEY (dashboard_user_id, client_id)
 );
 
 CREATE TABLE insta_post (

--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -92,7 +92,12 @@ export const dashRequestHandlers = {
       await waClient.sendMessage(chatId, "Masukkan Client ID target:");
       return;
     }
-    await performAction(choice, session.client_id, session.role, waClient, chatId);
+    const clientId = session.client_ids?.[0];
+    if (!clientId) {
+      await waClient.sendMessage(chatId, "Tidak ada client terkait.");
+      return;
+    }
+    await performAction(choice, clientId, session.role, waClient, chatId);
     session.step = "main";
     await dashRequestHandlers.main(session, chatId, "", waClient);
   },

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -100,7 +100,7 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  let { username, password, role = 'operator', client_id = null, whatsapp } = req.body;
+  let { username, password, role = 'operator', client_ids = [], whatsapp } = req.body;
   const status = false;
   if (!username || !password || !whatsapp) {
     return res
@@ -128,13 +128,13 @@ router.post('/dashboard-register', async (req, res) => {
     password_hash,
     role,
     status,
-    client_id,
     user_id: null,
     whatsapp,
   });
+  await dashboardUserModel.addClients(dashboard_user_id, client_ids);
   notifyAdmin(
     `\uD83D\uDCCB Permintaan User Approval dengan data sebagai berikut :\nUsername: ${username}\nID: ${dashboard_user_id}\nRole: ${role}\nWhatsApp: ${whatsapp}\nClient ID: ${
-      client_id ?? '-'
+      client_ids.length ? client_ids.join(', ') : '-'
     }\n\nBalas approvedash#${username} untuk menyetujui atau denydash#${username} untuk menolak.`
   );
   return res
@@ -166,7 +166,7 @@ router.post('/dashboard-login', async (req, res) => {
       .status(403)
       .json({ success: false, message: 'Akun belum disetujui' });
   }
-  const payload = { dashboard_user_id: user.dashboard_user_id, user_id: user.user_id, role: user.role, client_id: user.client_id };
+  const payload = { dashboard_user_id: user.dashboard_user_id, user_id: user.user_id, role: user.role, client_ids: user.client_ids };
   const token = jwt.sign(payload, process.env.JWT_SECRET, {
     expiresIn: '2h',
   });

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -355,12 +355,12 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
       );
       return;
     }
-    setSession(chatId, {
-      menu: "dashrequest",
-      step: "main",
-      role: dashUser.role,
-      client_id: dashUser.client_id,
-    });
+      setSession(chatId, {
+        menu: "dashrequest",
+        step: "main",
+        role: dashUser.role,
+        client_ids: dashUser.client_ids,
+      });
     await dashRequestHandlers.main(getSession(chatId), chatId, "", waClient);
     return;
   }

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -248,16 +248,16 @@ describe('POST /dashboard-register', () => {
       expect(res.body.success).toBe(true);
       expect(res.body.status).toBe(false);
       expect(res.body.dashboard_user_id).toBeDefined();
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
-      'SELECT * FROM dashboard_user WHERE username = $1',
-      ['dash']
-    );
       expect(mockQuery).toHaveBeenNthCalledWith(
-        2,
-        expect.stringContaining('INSERT INTO dashboard_user'),
-        [expect.any(String), 'dash', expect.any(String), 'operator', false, null, null, '628121234']
+        1,
+        expect.stringContaining('FROM dashboard_user'),
+        ['dash']
       );
+        expect(mockQuery).toHaveBeenNthCalledWith(
+          2,
+          expect.stringContaining('INSERT INTO dashboard_user'),
+          [expect.any(String), 'dash', expect.any(String), 'operator', false, null, '628121234']
+        );
   });
 
   test('returns 400 when whatsapp invalid', async () => {
@@ -288,15 +288,15 @@ describe('POST /dashboard-login', () => {
   test('logs in dashboard user with correct password', async () => {
       mockQuery.mockResolvedValueOnce({
         rows: [
-          {
-            dashboard_user_id: 'd1',
-            username: 'dash',
-            password_hash: await bcrypt.hash('pass', 10),
-            role: 'admin',
-            status: true,
-            client_id: 'c1',
-            user_id: null
-          }
+            {
+              dashboard_user_id: 'd1',
+              username: 'dash',
+              password_hash: await bcrypt.hash('pass', 10),
+              role: 'admin',
+              status: true,
+              client_ids: ['c1'],
+              user_id: null
+            }
         ]
       });
 
@@ -306,7 +306,7 @@ describe('POST /dashboard-login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-      expect(res.body.user).toEqual({ dashboard_user_id: 'd1', user_id: null, role: 'admin', client_id: 'c1' });
+      expect(res.body.user).toEqual({ dashboard_user_id: 'd1', user_id: null, role: 'admin', client_ids: ['c1'] });
       expect(mockRedis.sAdd).toHaveBeenCalledWith('dashboard_login:d1', res.body.token);
       expect(mockRedis.set).toHaveBeenCalledWith(
         `login_token:${res.body.token}`,
@@ -323,15 +323,15 @@ describe('POST /dashboard-login', () => {
   test('returns 401 when password wrong', async () => {
       mockQuery.mockResolvedValueOnce({
         rows: [
-          {
-            dashboard_user_id: 'd1',
-            username: 'dash',
-            password_hash: await bcrypt.hash('pass', 10),
-            role: 'admin',
-            status: true,
-            client_id: 'c1',
-            user_id: null
-          }
+            {
+              dashboard_user_id: 'd1',
+              username: 'dash',
+              password_hash: await bcrypt.hash('pass', 10),
+              role: 'admin',
+              status: true,
+              client_ids: ['c1'],
+              user_id: null
+            }
         ]
       });
 


### PR DESCRIPTION
## Summary
- add `dashboard_user_clients` pivot table and remove `client_id` from `dashboard_user`
- store and fetch dashboard user client lists
- adjust dashboard registration, login, and WA session handling for multiple clients

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17d4afc648327822b7d60b7fd7101