### PR TITLE
feat: add role id reference to dashboard user

### DIFF
--- a/docs/database_structure.md
+++ b/docs/database_structure.md
@@ -71,12 +71,12 @@ Pivot table linking users to roles.
 
 ### `dashboard_user`
 Credentials for the web dashboard login.
-- `user_id` – primary key generated with `uuid.v4()`
+- `dashboard_user_id` – primary key generated with `uuid.v4()`
 - `username` – unique login name
 - `password_hash` – bcrypt hashed password
-- `role` – permission level such as `admin` or `operator`
+- `role_id` – foreign key referencing `roles(role_id)`
 - `status` – boolean indicating whether the account is active
-- `client_id` – optional link to `clients`
+- `user_id` – optional link to `user(user_id)`
 - `whatsapp` – contact number used for notifications
 - `created_at`, `updated_at` – timestamps
 

--- a/sql/migrations/20251015_dashboardUserRoleId.sql
+++ b/sql/migrations/20251015_dashboardUserRoleId.sql
@@ -1,0 +1,19 @@
+-- Add role_id to dashboard_user and migrate existing data
+ALTER TABLE dashboard_user
+  ADD COLUMN IF NOT EXISTS role_id INT REFERENCES roles(role_id);
+
+-- Ensure all roles exist in roles table
+INSERT INTO roles (role_name)
+SELECT DISTINCT role FROM dashboard_user
+ON CONFLICT (role_name) DO NOTHING;
+
+-- Migrate role data
+UPDATE dashboard_user du
+SET role_id = r.role_id
+FROM roles r
+WHERE du.role = r.role_name;
+
+-- Enforce not null and drop old column
+ALTER TABLE dashboard_user
+  ALTER COLUMN role_id SET NOT NULL,
+  DROP COLUMN IF EXISTS role;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE dashboard_user (
   dashboard_user_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   username TEXT UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
-  role TEXT NOT NULL,
+  role_id INT NOT NULL REFERENCES roles(role_id),
   status BOOLEAN DEFAULT TRUE,
   user_id VARCHAR REFERENCES "user"(user_id),
   whatsapp VARCHAR,


### PR DESCRIPTION
## Summary
- add migration to replace dashboard_user.role with role_id
- update schema, model, and auth routes to use role_id and join roles
- document new dashboard_user structure

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17fcdbc988327a226304cd3eae05f