### PR TITLE
feat: restrict social routes to dashboard tokens

### DIFF
--- a/src/middleware/dashboardAuth.js
+++ b/src/middleware/dashboardAuth.js
@@ -9,8 +9,11 @@ export async function verifyDashboardToken(req, res, next) {
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
     const exists = await redis.get(`login_token:${token}`);
-    if (!exists || !String(exists).startsWith('dashboard:')) {
+    if (!exists) {
       return res.status(401).json({ success: false, message: 'Invalid token' });
+    }
+    if (!String(exists).startsWith('dashboard:')) {
+      return res.status(403).json({ success: false, message: 'Forbidden' });
     }
     req.dashboardUser = payload;
     next();

--- a/src/routes/amplifyRoutes.js
+++ b/src/routes/amplifyRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { getAmplifyRekap } from '../controller/amplifyController.js';
-import { authRequired } from '../middleware/authMiddleware.js';
+import { verifyDashboardToken } from '../middleware/dashboardAuth.js';
 
 const router = Router();
 
-router.get('/rekap', authRequired, getAmplifyRekap);
+router.get('/rekap', verifyDashboardToken, getAmplifyRekap);
 export default router;

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -12,19 +12,20 @@ import {
   getRapidInstagramPostsStore,
   getRapidInstagramPostsByMonth,
 } from "../controller/instaController.js";
-import { authRequired } from "../middleware/authMiddleware.js"; // tambahkan import ini
+import { verifyDashboardToken } from "../middleware/dashboardAuth.js";
 
 const router = Router();
 
-router.get("/rekap-likes", authRequired, getInstaRekapLikes);
-router.get("/posts", authRequired, getInstaPosts);
-router.get("/posts-khusus", authRequired, getInstaPostsKhusus);
-router.get("/rapid-posts", authRequired, getRapidInstagramPosts);
-router.get("/rapid-posts-month", authRequired, getRapidInstagramPostsByMonth);
-router.get("/rapid-posts-store", authRequired, getRapidInstagramPostsStore);
-router.get("/rapid-profile", authRequired, getRapidInstagramProfile);
-router.get("/rapid-info", authRequired, getRapidInstagramInfo);
-router.get("/profile", authRequired, getInstagramProfile);
-router.get("/instagram-user", authRequired, getInstagramUser);
+router.use(verifyDashboardToken);
+router.get("/rekap-likes", getInstaRekapLikes);
+router.get("/posts", getInstaPosts);
+router.get("/posts-khusus", getInstaPostsKhusus);
+router.get("/rapid-posts", getRapidInstagramPosts);
+router.get("/rapid-posts-month", getRapidInstagramPostsByMonth);
+router.get("/rapid-posts-store", getRapidInstagramPostsStore);
+router.get("/rapid-profile", getRapidInstagramProfile);
+router.get("/rapid-info", getRapidInstagramInfo);
+router.get("/profile", getInstagramProfile);
+router.get("/instagram-user", getInstagramUser);
 
 export default router;

--- a/src/routes/tiktokRoutes.js
+++ b/src/routes/tiktokRoutes.js
@@ -7,15 +7,16 @@ import {
   getRapidTiktokPosts,
   getRapidTiktokInfo
 } from '../controller/tiktokController.js';
-import { authRequired } from '../middleware/authMiddleware.js';
+import { verifyDashboardToken } from '../middleware/dashboardAuth.js';
 
 const router = Router();
 
-router.get('/comments', authRequired, getTiktokComments);
-router.get('/rekap-komentar', authRequired, getTiktokRekapKomentar);
-router.get('/posts', authRequired, getTiktokPosts);
-router.get('/rapid-profile', authRequired, getRapidTiktokProfile);
-router.get('/rapid-posts', authRequired, getRapidTiktokPosts);
-router.get('/rapid-info', authRequired, getRapidTiktokInfo);
+router.use(verifyDashboardToken);
+router.get('/comments', getTiktokComments);
+router.get('/rekap-komentar', getTiktokRekapKomentar);
+router.get('/posts', getTiktokPosts);
+router.get('/rapid-profile', getRapidTiktokProfile);
+router.get('/rapid-posts', getRapidTiktokPosts);
+router.get('/rapid-info', getRapidTiktokInfo);
 
 export default router;


### PR DESCRIPTION
## Summary
- add 403 response when non-dashboard tokens access verifyDashboardToken
- guard Amplify, Insta, and Tiktok routes with dashboard-only middleware

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1846cb03483279bd2f600c81092b5