### PR TITLE
Add client authorization check for rekap handlers

### DIFF
--- a/src/controller/amplifyController.js
+++ b/src/controller/amplifyController.js
@@ -11,6 +11,9 @@ export async function getAmplifyRekap(req, res) {
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }
+  if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
+    return res.status(403).json({ success: false, message: 'client_id tidak diizinkan' });
+  }
   try {
     sendConsoleDebug({
       tag: 'AMPLIFY',

--- a/src/controller/amplifyKhususController.js
+++ b/src/controller/amplifyKhususController.js
@@ -8,6 +8,9 @@ export async function getAmplifyKhususRekap(req, res) {
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }
+  if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
+    return res.status(403).json({ success: false, message: 'client_id tidak diizinkan' });
+  }
   try {
     sendConsoleDebug({ tag: 'AMPLIFY_KHUSUS', msg: `getAmplifyKhususRekap ${client_id} ${periode} ${tanggal || ''}` });
     const data = await getRekapLinkByClient(client_id, periode, tanggal);

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -25,6 +25,11 @@ export async function getInstaRekapLikes(req, res) {
   if (!client_id) {
     return res.status(400).json({ success: false, message: "client_id wajib diisi" });
   }
+  if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
+    return res
+      .status(403)
+      .json({ success: false, message: "client_id tidak diizinkan" });
+  }
   try {
     sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}` });
     const data = await getRekapLikesByClient(

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -70,6 +70,11 @@ export async function getTiktokRekapKomentar(req, res) {
   if (!client_id) {
     return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
   }
+  if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
+    return res
+      .status(403)
+      .json({ success: false, message: 'client_id tidak diizinkan' });
+  }
   try {
     const data = await getRekapKomentarByClient(
       client_id,

--- a/tests/amplifyControllerDateRange.test.js
+++ b/tests/amplifyControllerDateRange.test.js
@@ -34,3 +34,30 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
+test('returns 403 when client_id unauthorized', async () => {
+  const req = {
+    query: { client_id: 'c2' },
+    user: { client_ids: ['c1'] }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getAmplifyRekap(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(json).toHaveBeenCalledWith({ success: false, message: 'client_id tidak diizinkan' });
+  expect(mockGetRekap).not.toHaveBeenCalled();
+});
+
+test('allows authorized client_id', async () => {
+  mockGetRekap.mockResolvedValue([]);
+  const req = {
+    query: { client_id: 'c1' },
+    user: { client_ids: ['c1', 'c2'] }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getAmplifyRekap(req, res);
+  expect(res.status).not.toHaveBeenCalledWith(403);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+});
+

--- a/tests/amplifyKhususController.test.js
+++ b/tests/amplifyKhususController.test.js
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+
+const mockGetRekap = jest.fn();
+jest.unstable_mockModule('../src/model/linkReportKhususModel.js', () => ({
+  getRekapLinkByClient: mockGetRekap
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendConsoleDebug: jest.fn()
+}));
+
+let getAmplifyKhususRekap;
+beforeAll(async () => {
+  ({ getAmplifyKhususRekap } = await import('../src/controller/amplifyKhususController.js'));
+});
+
+beforeEach(() => {
+  mockGetRekap.mockReset();
+});
+
+test('returns 403 when client_id unauthorized', async () => {
+  const req = { query: { client_id: 'c2' }, user: { client_ids: ['c1'] } };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getAmplifyKhususRekap(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(json).toHaveBeenCalledWith({ success: false, message: 'client_id tidak diizinkan' });
+  expect(mockGetRekap).not.toHaveBeenCalled();
+});
+
+test('allows authorized client_id', async () => {
+  mockGetRekap.mockResolvedValue([]);
+  const req = { query: { client_id: 'c1' }, user: { client_ids: ['c1'] } };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getAmplifyKhususRekap(req, res);
+  expect(res.status).not.toHaveBeenCalledWith(403);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined);
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+});

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -47,3 +47,30 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
+test('returns 403 when client_id unauthorized', async () => {
+  const req = {
+    query: { client_id: 'c2' },
+    user: { client_ids: ['c1'] }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getInstaRekapLikes(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(json).toHaveBeenCalledWith({ success: false, message: 'client_id tidak diizinkan' });
+  expect(mockGetRekap).not.toHaveBeenCalled();
+});
+
+test('allows authorized client_id', async () => {
+  mockGetRekap.mockResolvedValue([]);
+  const req = {
+    query: { client_id: 'c1' },
+    user: { client_ids: ['c1', 'c2'] }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getInstaRekapLikes(req, res);
+  expect(res.status).not.toHaveBeenCalledWith(403);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+});
+

--- a/tests/tiktokControllerDateRange.test.js
+++ b/tests/tiktokControllerDateRange.test.js
@@ -42,3 +42,30 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
+test('returns 403 when client_id unauthorized', async () => {
+  const req = {
+    query: { client_id: 'c2' },
+    user: { client_ids: ['c1'] }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getTiktokRekapKomentar(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(json).toHaveBeenCalledWith({ success: false, message: 'client_id tidak diizinkan' });
+  expect(mockGetRekap).not.toHaveBeenCalled();
+});
+
+test('allows authorized client_id', async () => {
+  mockGetRekap.mockResolvedValue([]);
+  const req = {
+    query: { client_id: 'c1' },
+    user: { client_ids: ['c1', 'c2'] }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getTiktokRekapKomentar(req, res);
+  expect(res.status).not.toHaveBeenCalledWith(403);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+});
+


### PR DESCRIPTION
## Summary
- Verify requested client_id against authenticated user's client_ids in rekap handlers
- Return 403 when client_id not authorized
- Cover authorized and unauthorized client scenarios with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a188d8e5688327a5a960378be1de4b