### PR TITLE
Validate default role when registering dashboard users

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -131,9 +131,15 @@ router.post('/dashboard-register', async (req, res) => {
       return res.status(400).json({ success: false, message: 'role_id tidak valid' });
     }
   } else {
-    const { rows } = await query('SELECT role_id, role_name FROM roles WHERE role_name = $1', ['operator']);
+    const { rows } = await query(
+      'SELECT role_id, role_name FROM roles WHERE LOWER(role_name) = LOWER($1)',
+      ['operator']
+    );
     roleRow = rows[0];
-    role_id = roleRow?.role_id;
+    if (!roleRow) {
+      return res.status(400).json({ success: false, message: 'role default tidak ditemukan' });
+    }
+    role_id = roleRow.role_id;
   }
 
   const user = await dashboardUserModel.createUser({


### PR DESCRIPTION
## Summary
- ensure dashboard user registration fetches default `operator` role case-insensitively and returns an error if missing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18ac7d0848327b3e4fce01464f980