### PR TITLE
feat: seed default role on dashboard registration

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -137,7 +137,11 @@ router.post('/dashboard-register', async (req, res) => {
     );
     roleRow = rows[0];
     if (!roleRow) {
-      return res.status(400).json({ success: false, message: 'role default tidak ditemukan' });
+      const inserted = await query(
+        'INSERT INTO roles (role_name) VALUES ($1) ON CONFLICT (role_name) DO UPDATE SET role_name=EXCLUDED.role_name RETURNING role_id, role_name',
+        ['operator']
+      );
+      roleRow = inserted.rows[0];
     }
     role_id = roleRow.role_id;
   }

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -262,6 +262,31 @@ describe('POST /dashboard-register', () => {
       );
   });
 
+  test('creates default role when missing', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ role_id: 2, role_name: 'operator' }] })
+      .mockResolvedValueOnce({ rows: [{ dashboard_user_id: 'd1', status: false }] });
+
+    const res = await request(app)
+      .post('/api/auth/dashboard-register')
+      .send({ username: 'dash', password: 'pass', whatsapp: '0812-1234x' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('FROM roles'),
+      ['operator']
+    );
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('INSERT INTO roles'),
+      ['operator']
+    );
+  });
+
   test('returns 400 when whatsapp invalid', async () => {
     const res = await request(app)
       .post('/api/auth/dashboard-register')


### PR DESCRIPTION
## Summary
- ensure /api/auth/dashboard-register creates missing default role
- add regression test for missing default role

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18c812ab483278322e648bb8f0429