### PR TITLE
feat: notify dashboard registration via whatsapp

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -11,6 +11,7 @@ import {
   formatToWhatsAppId,
   getAdminWAIds,
   normalizeWhatsappNumber,
+  safeSendMessage,
 } from "../utils/waHelper.js";
 import redis from "../config/redis.js";
 import waClient, { waReady } from "../service/waService.js";
@@ -20,7 +21,7 @@ import { insertLoginLog } from "../model/loginLogModel.js";
 function notifyAdmin(message) {
   if (!waReady) return;
   for (const wa of getAdminWAIds()) {
-    waClient.sendMessage(wa, message).catch(() => {});
+    safeSendMessage(waClient, wa, message);
   }
 }
 
@@ -161,6 +162,14 @@ router.post('/dashboard-register', async (req, res) => {
       client_ids.length ? client_ids.join(', ') : '-'
     }\n\nBalas approvedash#${username} untuk menyetujui atau denydash#${username} untuk menolak.`
   );
+  if (waReady && whatsapp) {
+    const wid = formatToWhatsAppId(whatsapp);
+    safeSendMessage(
+      waClient,
+      wid,
+      "\uD83D\uDCCB Permintaan registrasi dashboard Anda telah diterima dan menunggu persetujuan admin."
+    );
+  }
   return res
     .status(201)
     .json({ success: true, dashboard_user_id: user.dashboard_user_id, status: user.status });


### PR DESCRIPTION
## Summary
- send dashboard registration request to admin via safe WhatsApp sender
- notify registrants on WhatsApp that their dashboard signup is pending approval
- test dashboard registration flow to ensure WhatsApp notifications

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a198a941448327a89de98043f4b233