### PR TITLE
feat(auth): validate operator client access

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -199,6 +199,11 @@ router.post('/dashboard-login', async (req, res) => {
       .status(403)
       .json({ success: false, message: 'Akun belum disetujui' });
   }
+  if (!user.client_ids || user.client_ids.length === 0) {
+    return res
+      .status(400)
+      .json({ success: false, message: 'Operator belum memiliki klien yang diizinkan' });
+  }
   const payload = { dashboard_user_id: user.dashboard_user_id, user_id: user.user_id, role: user.role, role_id: user.role_id, client_ids: user.client_ids };
   const token = jwt.sign(payload, process.env.JWT_SECRET, {
     expiresIn: '2h',

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -369,6 +369,33 @@ describe('POST /dashboard-login', () => {
       });
   });
 
+  test('returns 400 when operator has no allowed clients', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+            {
+              dashboard_user_id: 'd1',
+              username: 'dash',
+              password_hash: await bcrypt.hash('pass', 10),
+              role: 'admin',
+              role_id: 2,
+              status: true,
+              client_ids: [],
+              user_id: null
+            }
+        ]
+      });
+
+    const res = await request(app)
+      .post('/api/auth/dashboard-login')
+      .send({ username: 'dash', password: 'pass' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe('Operator belum memiliki klien yang diizinkan');
+    expect(mockRedis.sAdd).not.toHaveBeenCalled();
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
   test('returns 401 when password wrong', async () => {
       mockQuery.mockResolvedValueOnce({
         rows: [


### PR DESCRIPTION
## Summary
- ensure operators without assigned clients cannot log in
- cover operator login without clients in auth route tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a1e0f1488327a31c63e77fcfe2f4