### PR TITLE
docs: document client_id query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Cicero_V2/
 
 The API exposes endpoints for managing clients and users, fetching Instagram and TikTok data, handling OAuth callbacks, and providing dashboard statistics. Endpoints are also available for premium subscription management. Detailed documentation for each route is available in the source code comments.
 
+When a request requires data for a particular client, include the client's identifier as a query parameter:
+
+```
+GET /api/analytics?client_id=demo_client
+```
+
+This allows operators to scope responses to the correct client.
+
 ## Deployment & Environment
 
 1. **Clone and install dependencies**

--- a/docs/frontend_login_scaling.md
+++ b/docs/frontend_login_scaling.md
@@ -58,7 +58,17 @@ Create `verifyDashboardToken` to protect private routes:
 2. Verify the JWT using `process.env.JWT_SECRET` and confirm the token exists in Redis.
 3. Attach `req.dashboardUser` to the request object on success.
 
-## 5. Scaling Notes
+## 5. Client-Specific Requests
+
+Operators who manage multiple clients can pass a `client_id` query parameter when calling endpoints that operate on a specific client's data, for example:
+
+```
+GET /api/analytics?client_id=demo_client
+```
+
+This parameter lets the dashboard switch contexts without requiring separate logins.
+
+## 6. Scaling Notes
 
 - Use HTTPS in production and enforce rate limiting on the login routes.
 - Store active tokens in Redis so the backend can invalidate sessions at any time.


### PR DESCRIPTION
## Summary
- clarify in front-end login guide that endpoints can receive a `client_id` query to fetch specific client data
- add README example showing how to supply `client_id` when requesting analytics

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a3ad7798832799cc72f097d78fa0