### PR TITLE
feat: validate operator client assignment

### DIFF
--- a/src/model/dashboardUserModel.js
+++ b/src/model/dashboardUserModel.js
@@ -40,7 +40,9 @@ export async function createUser(data) {
 }
 
 export async function addClients(dashboardUserId, clientIds = []) {
-  if (!clientIds || clientIds.length === 0) return;
+  if (!clientIds || clientIds.length === 0) {
+    throw new Error('client_ids cannot be empty');
+  }
   const placeholders = clientIds.map((_, i) => `($1, $${i + 2})`).join(', ');
   await query(
     `INSERT INTO dashboard_user_clients (dashboard_user_id, client_id) VALUES ${placeholders} ON CONFLICT DO NOTHING`,

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -147,6 +147,12 @@ router.post('/dashboard-register', async (req, res) => {
     role_id = roleRow.role_id;
   }
 
+  if (roleRow.role_name === 'operator' && (!client_ids || client_ids.length === 0)) {
+    return res
+      .status(400)
+      .json({ success: false, message: 'minimal satu client harus dipilih' });
+  }
+
   const user = await dashboardUserModel.createUser({
     dashboard_user_id,
     username,
@@ -156,7 +162,9 @@ router.post('/dashboard-register', async (req, res) => {
     user_id: null,
     whatsapp,
   });
-  await dashboardUserModel.addClients(dashboard_user_id, client_ids);
+  if (client_ids && client_ids.length > 0) {
+    await dashboardUserModel.addClients(dashboard_user_id, client_ids);
+  }
   notifyAdmin(
     `\uD83D\uDCCB Permintaan User Approval dengan data sebagai berikut :\nUsername: ${username}\nID: ${dashboard_user_id}\nRole: ${roleRow?.role_name || '-'}\nWhatsApp: ${whatsapp}\nClient ID: ${
       client_ids.length ? client_ids.join(', ') : '-'


### PR DESCRIPTION
## Summary
- require at least one client when registering an operator
- throw error when attempting to add an empty client list
- cover operator registration with updated tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a6cccc4883279cc1e58f7d2b582f