### PR TITLE
feat: accept single client id on dashboard register

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -101,8 +101,9 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  let { username, password, role_id, client_ids = [], whatsapp } = req.body;
+  let { username, password, role_id, client_ids, client_id, whatsapp } = req.body;
   const status = false;
+  const clientIds = client_ids || (client_id ? [client_id] : []);
   if (!username || !password || !whatsapp) {
     return res
       .status(400)
@@ -147,7 +148,7 @@ router.post('/dashboard-register', async (req, res) => {
     role_id = roleRow.role_id;
   }
 
-  if (roleRow.role_name === 'operator' && (!client_ids || client_ids.length === 0)) {
+  if (roleRow.role_name === 'operator' && clientIds.length === 0) {
     return res
       .status(400)
       .json({ success: false, message: 'minimal satu client harus dipilih' });
@@ -162,12 +163,12 @@ router.post('/dashboard-register', async (req, res) => {
     user_id: null,
     whatsapp,
   });
-  if (client_ids && client_ids.length > 0) {
-    await dashboardUserModel.addClients(dashboard_user_id, client_ids);
+  if (clientIds.length > 0) {
+    await dashboardUserModel.addClients(dashboard_user_id, clientIds);
   }
   notifyAdmin(
     `\uD83D\uDCCB Permintaan User Approval dengan data sebagai berikut :\nUsername: ${username}\nID: ${dashboard_user_id}\nRole: ${roleRow?.role_name || '-'}\nWhatsApp: ${whatsapp}\nClient ID: ${
-      client_ids.length ? client_ids.join(', ') : '-'
+      clientIds.length ? clientIds.join(', ') : '-'
     }\n\nBalas approvedash#${username} untuk menyetujui atau denydash#${username} untuk menolak.`
   );
   if (waReady && whatsapp) {

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -289,6 +289,26 @@ describe('POST /dashboard-register', () => {
       );
   });
 
+  test('accepts single client_id field', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ role_id: 1, role_name: 'operator' }] })
+      .mockResolvedValueOnce({ rows: [{ dashboard_user_id: 'd1', status: false }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/api/auth/dashboard-register')
+      .send({ username: 'dash', password: 'pass', whatsapp: '0812-1234x', client_id: 'c1' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('INSERT INTO dashboard_user_clients'),
+      [expect.any(String), 'c1']
+    );
+  });
+
   test('creates default role when missing', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [] })


### PR DESCRIPTION
## Summary
- allow dashboard registration to accept either `client_id` or `client_ids`
- test registration with single `client_id`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a930995883279f63a89047e1ae2a