### PR TITLE
Include default client id in dashboard token

### DIFF
--- a/src/middleware/dashboardAuth.js
+++ b/src/middleware/dashboardAuth.js
@@ -2,7 +2,12 @@ import jwt from 'jsonwebtoken';
 import redis from '../config/redis.js';
 
 export async function verifyDashboardToken(req, res, next) {
-  const token = req.cookies?.token || req.headers.authorization?.split(' ')[1];
+  const authHeader = req.headers.authorization;
+  const token =
+    req.cookies?.token ||
+    (authHeader?.startsWith('Bearer ')
+      ? authHeader.split(' ')[1]
+      : authHeader);
   if (!token) {
     return res.status(401).json({ success: false, message: 'Token required' });
   }
@@ -16,6 +21,7 @@ export async function verifyDashboardToken(req, res, next) {
       return res.status(403).json({ success: false, message: 'Forbidden' });
     }
     req.dashboardUser = payload;
+    req.user = payload;
     next();
   } catch {
     return res.status(401).json({ success: false, message: 'Invalid token' });

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -213,7 +213,16 @@ router.post('/dashboard-login', async (req, res) => {
       .status(400)
       .json({ success: false, message: 'Operator belum memiliki klien yang diizinkan' });
   }
-  const payload = { dashboard_user_id: user.dashboard_user_id, user_id: user.user_id, role: user.role, role_id: user.role_id, client_ids: user.client_ids };
+  const payload = {
+    dashboard_user_id: user.dashboard_user_id,
+    user_id: user.user_id,
+    role: user.role,
+    role_id: user.role_id,
+    client_ids: user.client_ids
+  };
+  if (user.client_ids.length === 1) {
+    payload.client_id = user.client_ids[0];
+  }
   const token = jwt.sign(payload, process.env.JWT_SECRET, {
     expiresIn: '2h',
   });

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -402,7 +402,7 @@ describe('POST /dashboard-login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-      expect(res.body.user).toEqual({ dashboard_user_id: 'd1', user_id: null, role: 'admin', role_id: 2, client_ids: ['c1'] });
+      expect(res.body.user).toEqual({ dashboard_user_id: 'd1', user_id: null, role: 'admin', role_id: 2, client_ids: ['c1'], client_id: 'c1' });
       expect(mockRedis.sAdd).toHaveBeenCalledWith('dashboard_login:d1', res.body.token);
       expect(mockRedis.set).toHaveBeenCalledWith(
         `login_token:${res.body.token}`,


### PR DESCRIPTION
## Summary
- include `client_id` in dashboard login payload when user has a single client
- accept tokens without `Bearer` prefix and expose payload on `req.user`
- update tests for revised payload

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1af41ebd08327b0911c105842120c