### PR TITLE
Allow Android clients to access Amplify and Instagram APIs

### DIFF
--- a/src/controller/amplifyController.js
+++ b/src/controller/amplifyController.js
@@ -14,6 +14,9 @@ export async function getAmplifyRekap(req, res) {
   if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
     return res.status(403).json({ success: false, message: 'client_id tidak diizinkan' });
   }
+  if (req.user?.client_id && req.user.client_id !== client_id) {
+    return res.status(403).json({ success: false, message: 'client_id tidak diizinkan' });
+  }
   try {
     sendConsoleDebug({
       tag: 'AMPLIFY',

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -22,14 +22,19 @@ export async function getInstaRekapLikes(req, res) {
   const startDate =
     req.query.start_date || req.query.tanggal_mulai;
   const endDate = req.query.end_date || req.query.tanggal_selesai;
-  if (!client_id) {
-    return res.status(400).json({ success: false, message: "client_id wajib diisi" });
-  }
-  if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
-    return res
-      .status(403)
-      .json({ success: false, message: "client_id tidak diizinkan" });
-  }
+    if (!client_id) {
+      return res.status(400).json({ success: false, message: "client_id wajib diisi" });
+    }
+    if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
+      return res
+        .status(403)
+        .json({ success: false, message: "client_id tidak diizinkan" });
+    }
+    if (req.user?.client_id && req.user.client_id !== client_id) {
+      return res
+        .status(403)
+        .json({ success: false, message: "client_id tidak diizinkan" });
+    }
   try {
     sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}` });
     const data = await getRekapLikesByClient(
@@ -49,22 +54,31 @@ export async function getInstaRekapLikes(req, res) {
   }
 }
 
-export async function getInstaPosts(req, res) {
-  try {
-    const client_id =
-      req.query.client_id ||
-      req.user?.client_id ||
-      req.headers["x-client-id"];
-    if (!client_id) {
-      return res
-        .status(400)
-        .json({ success: false, message: "client_id wajib diisi" });
-    }
-
-    sendConsoleDebug({ tag: "INSTA", msg: `getInstaPosts ${client_id}` });
-    const posts = await instaPostService.findByClientId(client_id);
-    sendSuccess(res, posts);
-  } catch (err) {
+  export async function getInstaPosts(req, res) {
+    try {
+      const client_id =
+        req.query.client_id ||
+        req.user?.client_id ||
+        req.headers["x-client-id"];
+      if (!client_id) {
+        return res
+          .status(400)
+          .json({ success: false, message: "client_id wajib diisi" });
+      }
+      if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
+        return res
+          .status(403)
+          .json({ success: false, message: "client_id tidak diizinkan" });
+      }
+      if (req.user?.client_id && req.user.client_id !== client_id) {
+        return res
+          .status(403)
+          .json({ success: false, message: "client_id tidak diizinkan" });
+      }
+      sendConsoleDebug({ tag: "INSTA", msg: `getInstaPosts ${client_id}` });
+      const posts = await instaPostService.findByClientId(client_id);
+      sendSuccess(res, posts);
+    } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaPosts: ${err.message}` });
     const code = err.statusCode || err.response?.status || 500;
     res.status(code).json({ success: false, message: err.message });
@@ -342,22 +356,31 @@ export async function getInstagramUser(req, res) {
   }
 }
 
-export async function getInstaPostsKhusus(req, res) {
-  try {
-    const client_id =
-      req.query.client_id ||
-      req.user?.client_id ||
-      req.headers["x-client-id"];
-    if (!client_id) {
-      return res
-        .status(400)
-        .json({ success: false, message: "client_id wajib diisi" });
-    }
-
-    sendConsoleDebug({ tag: "INSTA", msg: `getInstaPostsKhusus ${client_id}` });
-    const posts = await instaPostKhususService.findTodayByClientId(client_id);
-    sendSuccess(res, posts);
-  } catch (err) {
+  export async function getInstaPostsKhusus(req, res) {
+    try {
+      const client_id =
+        req.query.client_id ||
+        req.user?.client_id ||
+        req.headers["x-client-id"];
+      if (!client_id) {
+        return res
+          .status(400)
+          .json({ success: false, message: "client_id wajib diisi" });
+      }
+      if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
+        return res
+          .status(403)
+          .json({ success: false, message: "client_id tidak diizinkan" });
+      }
+      if (req.user?.client_id && req.user.client_id !== client_id) {
+        return res
+          .status(403)
+          .json({ success: false, message: "client_id tidak diizinkan" });
+      }
+      sendConsoleDebug({ tag: "INSTA", msg: `getInstaPostsKhusus ${client_id}` });
+      const posts = await instaPostKhususService.findTodayByClientId(client_id);
+      sendSuccess(res, posts);
+    } catch (err) {
     sendConsoleDebug({
       tag: "INSTA",
       msg: `Error getInstaPostsKhusus: ${err.message}`

--- a/src/routes/amplifyRoutes.js
+++ b/src/routes/amplifyRoutes.js
@@ -1,8 +1,7 @@
 import { Router } from 'express';
 import { getAmplifyRekap } from '../controller/amplifyController.js';
-import { verifyDashboardToken } from '../middleware/dashboardAuth.js';
 
 const router = Router();
 
-router.get('/rekap', verifyDashboardToken, getAmplifyRekap);
+router.get('/rekap', getAmplifyRekap);
 export default router;

--- a/src/routes/instaRoutes.js
+++ b/src/routes/instaRoutes.js
@@ -12,11 +12,8 @@ import {
   getRapidInstagramPostsStore,
   getRapidInstagramPostsByMonth,
 } from "../controller/instaController.js";
-import { verifyDashboardToken } from "../middleware/dashboardAuth.js";
 
 const router = Router();
-
-router.use(verifyDashboardToken);
 router.get("/rekap-likes", getInstaRekapLikes);
 router.get("/posts", getInstaPosts);
 router.get("/posts-khusus", getInstaPostsKhusus);


### PR DESCRIPTION
## Summary
- Remove dashboard-only middleware from Amplify and Instagram routes so Android tokens can access them
- Ensure Amplify and Instagram controllers validate `client_id` against authenticated user

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b3436a488327a9a469b7b2e1bf88