### PR TITLE
fix: accept role name in dashboard registration

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -101,7 +101,7 @@ router.post('/penmas-login', async (req, res) => {
 });
 
 router.post('/dashboard-register', async (req, res) => {
-  let { username, password, role_id, client_ids, client_id, whatsapp } = req.body;
+  let { username, password, role_id, role, client_ids, client_id, whatsapp } = req.body;
   const status = false;
   const clientIds = client_ids || (client_id ? [client_id] : []);
   if (!username || !password || !whatsapp) {
@@ -132,6 +132,16 @@ router.post('/dashboard-register', async (req, res) => {
     if (!roleRow) {
       return res.status(400).json({ success: false, message: 'role_id tidak valid' });
     }
+  } else if (role) {
+    const { rows } = await query(
+      'SELECT role_id, role_name FROM roles WHERE LOWER(role_name) = LOWER($1)',
+      [role]
+    );
+    roleRow = rows[0];
+    if (!roleRow) {
+      return res.status(400).json({ success: false, message: 'role tidak valid' });
+    }
+    role_id = roleRow.role_id;
   } else {
     const { rows } = await query(
       'SELECT role_id, role_name FROM roles WHERE LOWER(role_name) = LOWER($1)',

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -309,6 +309,24 @@ describe('POST /dashboard-register', () => {
     );
   });
 
+  test('creates dashboard user with specified role name', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ role_id: 5, role_name: 'ditbinmas' }] })
+      .mockResolvedValueOnce({ rows: [{ dashboard_user_id: 'd1', status: false }] });
+
+    const res = await request(app)
+      .post('/api/auth/dashboard-register')
+      .send({ username: 'dash', password: 'pass', whatsapp: '0812-1234x', role: 'ditbinmas' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(mockQuery.mock.calls[1][0]).toContain('FROM roles');
+    expect(mockQuery.mock.calls[1][1]).toEqual(['ditbinmas']);
+    expect(mockQuery.mock.calls[2][1][3]).toBe(5);
+    expect(mockWAClient.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
   test('creates default role when missing', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [] })


### PR DESCRIPTION
## Summary
- allow dashboard registration to accept `role` by name
- add test for role-based registration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bd1a15408327b31dcbf05cfae209