### PR TITLE
fix: honor selected directorate role on user registration

### DIFF
--- a/sql/migrations/20251017_addDirektoratRoles.sql
+++ b/sql/migrations/20251017_addDirektoratRoles.sql
@@ -1,0 +1,5 @@
+INSERT INTO roles (role_name) VALUES
+  ('ditbinmas'),
+  ('ditlantas'),
+  ('bidhumas')
+ON CONFLICT (role_name) DO NOTHING;

--- a/src/controller/userController.js
+++ b/src/controller/userController.js
@@ -48,10 +48,18 @@ export const createUser = async (req, res, next) => {
     }
 
     if (role === 'operator') {
-      if (data.ditbinmas === undefined) data.ditbinmas = false;
-      if (data.ditlantas === undefined) data.ditlantas = false;
-      if (data.bidhumas === undefined) data.bidhumas = false;
-      data.operator = true;
+      const requestedRole = data.role ? data.role.toLowerCase() : undefined;
+      delete data.role;
+
+      if (['ditbinmas', 'ditlantas', 'bidhumas'].includes(requestedRole)) {
+        data[requestedRole] = true;
+        data.operator = false;
+      } else {
+        if (data.ditbinmas === undefined) data.ditbinmas = false;
+        if (data.ditlantas === undefined) data.ditlantas = false;
+        if (data.bidhumas === undefined) data.bidhumas = false;
+        data.operator = true;
+      }
     }
 
     const user = await userModel.createUser(data);

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -55,6 +55,28 @@ test('operator adds user with defaults', async () => {
   expect(json).toHaveBeenCalledWith({ success: true, data: { user_id: '1' } });
 });
 
+test('operator assigns ditbinmas role when specified', async () => {
+  mockCreateUser.mockResolvedValue({ user_id: '3' });
+  const req = {
+    body: { user_id: '3', nama: 'C', role: 'ditbinmas' },
+    user: { role: 'operator', client_id: 'c1' }
+  };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { status, json };
+
+  await createUser(req, res, () => {});
+
+  expect(mockCreateUser).toHaveBeenCalledWith({
+    user_id: '3',
+    nama: 'C',
+    ditbinmas: true,
+    operator: false,
+  });
+  expect(status).toHaveBeenCalledWith(201);
+  expect(json).toHaveBeenCalledWith({ success: true, data: { user_id: '3' } });
+});
+
 test('ditbinmas updates existing user', async () => {
   mockFindUserById.mockResolvedValue({ user_id: '1', status: false });
   mockUpdateUser.mockResolvedValue({ user_id: '1', ditbinmas: true, nama: 'B' });


### PR DESCRIPTION
## Summary
- allow operators to assign ditbinmas/ditlantas/bidhumas during user registration
- seed database with directorate roles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bff9c0988327b1de7fd66a271460