### PR TITLE
test: cover user reactivation path

### DIFF
--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -77,7 +77,7 @@ test('operator assigns ditbinmas role when specified', async () => {
   expect(json).toHaveBeenCalledWith({ success: true, data: { user_id: '3' } });
 });
 
-test('ditbinmas updates existing user', async () => {
+test('reactivates existing user and attaches ditbinmas role', async () => {
   mockFindUserById
     .mockResolvedValueOnce({ user_id: '1', status: false })
     .mockResolvedValueOnce({ user_id: '1', status: true, ditbinmas: true, nama: 'B' });
@@ -90,6 +90,8 @@ test('ditbinmas updates existing user', async () => {
 
   expect(mockUpdateUserField).toHaveBeenCalledWith('1', 'status', true);
   expect(mockUpdateUserField).toHaveBeenCalledWith('1', 'ditbinmas', true);
+  expect(mockUpdateUserField).toHaveBeenCalledTimes(2);
+  expect(mockCreateUser).not.toHaveBeenCalled();
   expect(status).toHaveBeenCalledWith(200);
   expect(json).toHaveBeenCalledWith({
     success: true,


### PR DESCRIPTION
## Summary
- add test for reactivating existing user and assigning new role

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cca872d88327bec8979e213b2f2d