### PR TITLE
Filter absensi users by role when role matches client

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
+++ b/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
@@ -1,5 +1,5 @@
 import { query } from "../../../db/index.js";
-import { getUsersByClient } from "../../../model/userModel.js";
+import { getUsersByClient, getUsersByDirektorat } from "../../../model/userModel.js";
 import { getShortcodesTodayByClient } from "../../../model/instaPostModel.js";
 import { hariIndo } from "../../../utils/constants.js";
 import { groupByDivision, sortDivisionKeys } from "../../../utils/utilsHelper.js";
@@ -34,7 +34,6 @@ async function getCommentsUsernamesByShortcode(shortcode) {
 export async function absensiKomentarInstagram(client_id, opts = {}) {
   const { clientFilter } = opts;
   const roleFlag = opts.roleFlag;
-  void roleFlag;
   const targetClient = clientFilter || client_id;
 
   const now = new Date();
@@ -43,7 +42,18 @@ export async function absensiKomentarInstagram(client_id, opts = {}) {
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
   const clientNama = await getClientNama(targetClient);
-  const users = await getUsersByClient(targetClient);
+  let users;
+  if (
+    roleFlag &&
+    typeof roleFlag === "string" &&
+    roleFlag.toUpperCase() === targetClient.toUpperCase()
+  ) {
+    users = (await getUsersByDirektorat(roleFlag.toLowerCase(), targetClient)).filter(
+      (u) => u.status === true
+    );
+  } else {
+    users = await getUsersByClient(targetClient);
+  }
   const shortcodes = await getShortcodesTodayByClient(targetClient);
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -1,5 +1,5 @@
 import { query } from "../../../db/index.js";
-import { getUsersByClient } from "../../../model/userModel.js";
+import { getUsersByClient, getUsersByDirektorat } from "../../../model/userModel.js";
 import { getShortcodesTodayByClient } from "../../../model/instaPostModel.js";
 import { getLikesByShortcode } from "../../../model/instaLikeModel.js";
 import { hariIndo } from "../../../utils/constants.js";
@@ -26,7 +26,6 @@ async function getClientNama(client_id) {
 export async function absensiLikes(client_id, opts = {}) {
   const { clientFilter } = opts;
   const roleFlag = opts.roleFlag;
-  void roleFlag;
   const targetClient = clientFilter || client_id;
   const now = new Date();
   const hari = hariIndo[now.getDay()];
@@ -34,7 +33,18 @@ export async function absensiLikes(client_id, opts = {}) {
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
   const clientNama = await getClientNama(targetClient);
-  const users = await getUsersByClient(targetClient);
+  let users;
+  if (
+    roleFlag &&
+    typeof roleFlag === "string" &&
+    roleFlag.toUpperCase() === targetClient.toUpperCase()
+  ) {
+    users = (await getUsersByDirektorat(roleFlag.toLowerCase(), targetClient)).filter(
+      (u) => u.status === true
+    );
+  } else {
+    users = await getUsersByClient(targetClient);
+  }
   const shortcodes = await getShortcodesTodayByClient(targetClient);
 
   if (!shortcodes.length)

--- a/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
+++ b/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
@@ -1,5 +1,5 @@
 import { query } from "../../../db/index.js";
-import { getUsersByClient } from "../../../model/userModel.js";
+import { getUsersByClient, getUsersByDirektorat } from "../../../model/userModel.js";
 import {
   getShortcodesTodayByClient,
 } from "../../../model/instaPostModel.js";
@@ -21,7 +21,6 @@ async function getClientNama(client_id) {
 export async function absensiLink(client_id, opts = {}) {
   const { clientFilter } = opts;
   const roleFlag = opts.roleFlag;
-  void roleFlag;
   const targetClient = clientFilter || client_id;
   const now = new Date();
   const hari = hariIndo[now.getDay()];
@@ -29,7 +28,18 @@ export async function absensiLink(client_id, opts = {}) {
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
   const clientNama = await getClientNama(targetClient);
-  const users = await getUsersByClient(targetClient);
+  let users;
+  if (
+    roleFlag &&
+    typeof roleFlag === "string" &&
+    roleFlag.toUpperCase() === targetClient.toUpperCase()
+  ) {
+    users = (await getUsersByDirektorat(roleFlag.toLowerCase(), targetClient)).filter(
+      (u) => u.status === true
+    );
+  } else {
+    users = await getUsersByClient(targetClient);
+  }
   const shortcodes = await getShortcodesTodayByClient(targetClient);
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;

--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -1,5 +1,5 @@
 import { query } from "../../../db/index.js";
-import { getUsersByClient } from "../../../model/userModel.js";
+import { getUsersByClient, getUsersByDirektorat } from "../../../model/userModel.js";
 import { getPostsTodayByClient } from "../../../model/tiktokPostModel.js";
 import { getCommentsByVideoId } from "../../../model/tiktokCommentModel.js";
 import { hariIndo } from "../../../utils/constants.js";
@@ -39,7 +39,6 @@ function extractUsernamesFromComments(comments) {
 export async function absensiKomentar(client_id, opts = {}) {
   const { clientFilter } = opts;
   const roleFlag = opts.roleFlag;
-  void roleFlag;
   const targetClient = clientFilter || client_id;
   const now = new Date();
   const hari = hariIndo[now.getDay()];
@@ -49,7 +48,18 @@ export async function absensiKomentar(client_id, opts = {}) {
   const clientInfo = await getClientInfo(targetClient);
   const clientNama = clientInfo.nama;
   const tiktokUsername = clientInfo.tiktok;
-  const users = await getUsersByClient(targetClient);
+  let users;
+  if (
+    roleFlag &&
+    typeof roleFlag === "string" &&
+    roleFlag.toUpperCase() === targetClient.toUpperCase()
+  ) {
+    users = (await getUsersByDirektorat(roleFlag.toLowerCase(), targetClient)).filter(
+      (u) => u.status === true
+    );
+  } else {
+    users = await getUsersByClient(targetClient);
+  }
   const posts = await getPostsTodayByClient(targetClient);
 
   sendDebug({

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -2,11 +2,15 @@ import { jest } from '@jest/globals';
 
 const mockQuery = jest.fn();
 const mockGetUsersByClient = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
 const mockGetShortcodesTodayByClient = jest.fn();
 const mockGetLikesByShortcode = jest.fn();
 
 jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
-jest.unstable_mockModule('../src/model/userModel.js', () => ({ getUsersByClient: mockGetUsersByClient }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: mockGetUsersByClient,
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+}));
 jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({ getShortcodesTodayByClient: mockGetShortcodesTodayByClient }));
 jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({ getLikesByShortcode: mockGetLikesByShortcode }));
 
@@ -19,6 +23,7 @@ beforeAll(async () => {
 beforeEach(() => {
   mockQuery.mockReset();
   mockGetUsersByClient.mockReset();
+  mockGetUsersByDirektorat.mockReset();
   mockGetShortcodesTodayByClient.mockReset();
   mockGetLikesByShortcode.mockReset();
 });
@@ -42,5 +47,31 @@ test('marks user with @username as already liking', async () => {
 
   expect(msg).toMatch(/Sudah melaksanakan\* : \*1 user\*/);
   expect(msg).toMatch(/Belum melaksanakan\* : \*0 user\*/);
+});
+
+test('uses role-based users when roleFlag matches client', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC' }] });
+  mockGetUsersByDirektorat.mockResolvedValueOnce([
+    {
+      user_id: 'u1',
+      title: 'Aiptu',
+      nama: 'Budi',
+      insta: '@TestUser',
+      divisi: 'BAG',
+      exception: false,
+      status: true,
+    },
+  ]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
+  mockGetLikesByShortcode.mockResolvedValueOnce(['testuser']);
+
+  const msg = await absensiLikes('POLRES', {
+    mode: 'sudah',
+    roleFlag: 'POLRES',
+  });
+
+  expect(mockGetUsersByDirektorat).toHaveBeenCalled();
+  expect(mockGetUsersByClient).not.toHaveBeenCalled();
+  expect(msg).toMatch(/Sudah melaksanakan\* : \*1 user\*/);
 });
 


### PR DESCRIPTION
## Summary
- scope attendance endpoints to role-matched users when dashboard role equals target client
- cover new role-based filtering with tests for Instagram like attendance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1de1c97408327ab2360525ad3eb38