### PR TITLE
Handle directorate users in link amplification recap

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -93,10 +93,21 @@ export async function deleteLinkReport(shortcode, user_id) {
 }
 
 export async function getReportsTodayByClient(client_id) {
+  const typeRes = await query(
+    'SELECT client_type FROM clients WHERE client_id = $1',
+    [client_id]
+  );
+  const clientType = typeRes.rows[0]?.client_type;
+  let joinClause = 'JOIN "user" u ON u.user_id = r.user_id';
+  let whereClause = 'u.client_id = $1';
+  if (clientType === 'direktorat') {
+    joinClause +=
+      ' JOIN user_roles ur ON ur.user_id = u.user_id JOIN roles ro ON ur.role_id = ro.role_id';
+    whereClause = 'ro.role_name = $1';
+  }
   const res = await query(
-    `SELECT r.* FROM link_report r
-     JOIN "user" u ON u.user_id = r.user_id
-     WHERE u.client_id = $1 AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
+    `SELECT r.* FROM link_report r ${joinClause}
+     WHERE ${whereClause} AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ORDER BY r.created_at ASC`,
     [client_id]
   );
@@ -104,10 +115,21 @@ export async function getReportsTodayByClient(client_id) {
 }
 
 export async function getReportsTodayByShortcode(client_id, shortcode) {
+  const typeRes = await query(
+    'SELECT client_type FROM clients WHERE client_id = $1',
+    [client_id]
+  );
+  const clientType = typeRes.rows[0]?.client_type;
+  let joinClause = 'JOIN "user" u ON u.user_id = r.user_id';
+  let whereClause = 'u.client_id = $1';
+  if (clientType === 'direktorat') {
+    joinClause +=
+      ' JOIN user_roles ur ON ur.user_id = u.user_id JOIN roles ro ON ur.role_id = ro.role_id';
+    whereClause = 'ro.role_name = $1';
+  }
   const res = await query(
-    `SELECT r.* FROM link_report r
-     JOIN "user" u ON u.user_id = r.user_id
-     WHERE u.client_id = $1 AND r.shortcode = $2
+    `SELECT r.* FROM link_report r ${joinClause}
+     WHERE ${whereClause} AND r.shortcode = $2
        AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ORDER BY r.created_at ASC`,
     [client_id, shortcode]


### PR DESCRIPTION
## Summary
- add client type lookup to pull directorate users for link amplification recap
- support role-based filtering when querying daily link reports
- cover directorate scenarios in link report tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2001d84c48327a2e52811f4558096