### PR TITLE
Ensure link_sum respects post date filter

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -196,15 +196,15 @@ export async function getRekapLinkByClient(
            (CASE WHEN r.twitter_link IS NOT NULL AND r.twitter_link <> '' THEN 1 ELSE 0 END) +
            (CASE WHEN r.tiktok_link IS NOT NULL AND r.tiktok_link <> '' THEN 1 ELSE 0 END) +
            (CASE WHEN r.youtube_link IS NOT NULL AND r.youtube_link <> '' THEN 1 ELSE 0 END)
-         ) AS jumlah_link
-       FROM link_report r
-       JOIN insta_post p ON p.shortcode = r.shortcode
-       WHERE p.client_id = $1 AND ${dateFilterReport}
-       GROUP BY r.user_id
-     )
-     SELECT
-       u.user_id,
-       u.title,
+       ) AS jumlah_link
+      FROM link_report r
+      JOIN insta_post p ON p.shortcode = r.shortcode
+      WHERE p.client_id = $1 AND ${dateFilterPost} AND ${dateFilterReport}
+      GROUP BY r.user_id
+    )
+    SELECT
+      u.user_id,
+      u.title,
        u.nama,
        u.insta AS username,
        u.divisi,

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -176,6 +176,28 @@ test('getRekapLinkByClient handles start_date and end_date', async () => {
   );
 });
 
+test('getRekapLinkByClient applies post date filter in link_sum', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] })
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          user_id: 'u1',
+          title: 'Aiptu',
+          nama: 'Budi',
+          username: 'budi',
+          divisi: 'Humas',
+          exception: false,
+          jumlah_link: 1
+        }
+      ]
+    });
+  await getRekapLinkByClient('POLRES');
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain('p.created_at');
+  expect(sql).toContain('r.created_at');
+});
+
 test('getRekapLinkByClient marks sudahMelaksanakan when user has links', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '1' }] })


### PR DESCRIPTION
## Summary
- constrain `link_sum` CTE to filter both `link_report` and `insta_post` by the same date criteria
- add unit test covering lingering link report scenarios to verify combined post and report date filters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a1d359208327bc58062efce2d4df