### PR TITLE
Filter reports by post creation date

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -98,7 +98,8 @@ export async function getReportsTodayByClient(client_id) {
     [client_id]
   );
   const clientType = typeRes.rows[0]?.client_type;
-  let joinClause = 'JOIN "user" u ON u.user_id = r.user_id';
+  let joinClause =
+    'JOIN insta_post p ON p.shortcode = r.shortcode JOIN "user" u ON u.user_id = r.user_id';
   let whereClause = 'u.client_id = $1';
   if (clientType === 'direktorat') {
     joinClause +=
@@ -108,6 +109,7 @@ export async function getReportsTodayByClient(client_id) {
   const res = await query(
     `SELECT r.* FROM link_report r ${joinClause}
      WHERE ${whereClause} AND r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
+       AND p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ORDER BY r.created_at ASC`,
     [client_id]
   );

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -73,7 +73,7 @@ test('findLinkReportByShortcode joins with insta_post', async () => {
   );
 });
 
-test('getReportsTodayByClient filters by client', async () => {
+test('getReportsTodayByClient joins insta_post and filters by date', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ client_type: 'instansi' }] })
     .mockResolvedValueOnce({ rows: [{ shortcode: 'x' }] });
@@ -84,11 +84,11 @@ test('getReportsTodayByClient filters by client', async () => {
     expect.stringContaining('SELECT client_type FROM clients'),
     ['POLRES']
   );
-  expect(mockQuery).toHaveBeenNthCalledWith(
-    2,
-    expect.stringContaining('JOIN "user" u ON u.user_id = r.user_id'),
-    ['POLRES']
-  );
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain('JOIN insta_post p ON p.shortcode = r.shortcode');
+  expect(sql).toContain('JOIN "user" u ON u.user_id = r.user_id');
+  expect(sql).toContain("p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date");
+  expect(sql).toContain("r.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date");
 });
 
 test('getReportsTodayByShortcode filters by client and shortcode', async () => {


### PR DESCRIPTION
## Summary
- Join `insta_post` in `getReportsTodayByClient` and filter both report and post dates to the target day
- Test that daily reports only include posts created on the same day

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a31fa20c8327b0d48b11a7a6e204