### PR TITLE
Restrict link report submissions to same-day posts

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -9,6 +9,20 @@ export async function createLinkReport(data) {
     throw err;
   }
 
+  const postDate = new Date(exists.created_at).toLocaleDateString('en-CA', {
+    timeZone: 'Asia/Jakarta'
+  });
+  const today = new Date().toLocaleDateString('en-CA', {
+    timeZone: 'Asia/Jakarta'
+  });
+  if (postDate !== today) {
+    const err = new Error('reports can only be created for today\'s posts');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  data.created_at = exists.created_at;
+
   const res = await query(
     `INSERT INTO link_report (
         shortcode, user_id, instagram_link, facebook_link,


### PR DESCRIPTION
## Summary
- enforce same-day validation when creating link reports
- set report timestamp to match original post
- test link report model for date constraint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a739388c8327ab532554292f5dc7