### PR TITLE
Allow specifying MIME type when sending WhatsApp files

### DIFF
--- a/src/handler/menu/clientRequestHandlers.js
+++ b/src/handler/menu/clientRequestHandlers.js
@@ -1357,7 +1357,13 @@ export const clientRequestHandlers = {
       });
       const filePath = await saveLinkReportExcel(rows, client_id, monthName);
       const buffer = await fs.readFile(filePath);
-      await sendWAFile(waClient, buffer, path.basename(filePath), getAdminWAIds());
+      await sendWAFile(
+        waClient,
+        buffer,
+        path.basename(filePath),
+        getAdminWAIds(),
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      );
       await waClient.sendMessage(chatId, "✅ File Excel dikirim ke admin.");
       await fs.unlink(filePath);
     } catch (err) {

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -4,6 +4,9 @@ import pkg from 'whatsapp-web.js';
 const { MessageMedia } = pkg;
 dotenv.config();
 
+const DEFAULT =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
 export function getAdminWhatsAppList() {
   return (process.env.ADMIN_WHATSAPP || '')
     .split(',')
@@ -34,7 +37,7 @@ export async function sendWAFile(
   buffer,
   filename,
   chatIds = null,
-  mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  mimeType = DEFAULT
 ) {
   const targets = chatIds
     ? Array.isArray(chatIds)


### PR DESCRIPTION
## Summary
- add constant default MIME type for WA files and allow overriding
- send link report Excel with explicit MIME type

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2aba127888327be7bc736f236902f