### PR TITLE
feat: support role-wide client lookup for likes

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -22,6 +22,7 @@ export async function getInstaRekapLikes(req, res) {
   const startDate =
     req.query.start_date || req.query.tanggal_mulai;
   const endDate = req.query.end_date || req.query.tanggal_selesai;
+  const role = req.query.role;
     if (!client_id) {
       return res.status(400).json({ success: false, message: "client_id wajib diisi" });
     }
@@ -42,7 +43,8 @@ export async function getInstaRekapLikes(req, res) {
       periode,
       tanggal,
       startDate,
-      endDate
+      endDate,
+      role
     );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -43,7 +43,7 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const json = jest.fn();
   const res = { json };
   await getInstaRekapLikes(req, res);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
@@ -70,7 +70,7 @@ test('allows authorized client_id', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getInstaRekapLikes(req, res);
   expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -86,17 +86,18 @@ test('filters users by client_id for non-directorate clients', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('1');
   const sql = mockQuery.mock.calls[1][0];
-  expect(sql).toContain('u.client_id = $1');
+  expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
   expect(sql).not.toContain('user_roles');
 });
 
 test('filters users by role for directorate clients', async () => {
   mockClientType('direktorat');
   mockQuery.mockResolvedValueOnce({ rows: [] });
-  await getRekapLikesByClient('ditbinmas');
+  await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'kabid');
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('JOIN user_roles');
   expect(sql).toContain('JOIN roles');
-  expect(sql).toContain('r.role_name = $1');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(p.client_id) IN (SELECT LOWER(u.client_id)');
   expect(sql).not.toContain('u.client_id = $1');
 });


### PR DESCRIPTION
## Summary
- allow `getRekapLikesByClient` to aggregate likes for all clients sharing a role
- accept `role` in `getInstaRekapLikes` and forward to model
- update tests for new role parameter

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2cd259f388327967b0d3487cafcbb