### PR TITLE
feat: add client lookup by role

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -30,6 +30,15 @@ function normalizeUserFields(data) {
 
 // ========== QUERY DATABASE ==========
 
+// Ambil daftar client_id berdasarkan role_name
+export async function getClientsByRole(roleName) {
+  const { rows } = await query(
+    'SELECT DISTINCT LOWER(client_id) AS client_id FROM users WHERE LOWER(role_name) = LOWER($1)',
+    [roleName]
+  );
+  return rows.map((r) => r.client_id);
+}
+
 // Ambil semua user aktif (status = true), tanpa filter insta
 export async function getUsersByClient(client_id) {
   const res = await query(

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -12,6 +12,7 @@ let createUser;
 let updateUserField;
 let updatePremiumStatus;
 let getUsersByDirektorat;
+let getClientsByRole;
 
 beforeAll(async () => {
   const mod = await import('../src/model/userModel.js');
@@ -21,6 +22,7 @@ beforeAll(async () => {
   updateUserField = mod.updateUserField;
   updatePremiumStatus = mod.updatePremiumStatus;
   getUsersByDirektorat = mod.getUsersByDirektorat;
+  getClientsByRole = mod.getClientsByRole;
 });
 
 beforeEach(() => {
@@ -128,4 +130,14 @@ test('getUsersByDirektorat filters by client and flag', async () => {
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
   expect(sql).toContain('u.client_id = $2');
+});
+
+test('getClientsByRole returns lowercase client ids', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ client_id: 'c1' }, { client_id: 'c2' }] });
+  const clients = await getClientsByRole('operator');
+  expect(clients).toEqual(['c1', 'c2']);
+  expect(mockQuery).toHaveBeenCalledWith(
+    'SELECT DISTINCT LOWER(client_id) AS client_id FROM users WHERE LOWER(role_name) = LOWER($1)',
+    ['operator']
+  );
 });


### PR DESCRIPTION
## Summary
- add `getClientsByRole` to retrieve distinct client IDs by role
- cover role-based client lookup with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2d028f1108327bbc623472bce647e