### PR TITLE
Support directorate Instagram likes recap

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -22,7 +22,6 @@ export async function getInstaRekapLikes(req, res) {
   const startDate =
     req.query.start_date || req.query.tanggal_mulai;
   const endDate = req.query.end_date || req.query.tanggal_selesai;
-  const role = req.query.role;
     if (!client_id) {
       return res.status(400).json({ success: false, message: "client_id wajib diisi" });
     }
@@ -43,8 +42,7 @@ export async function getInstaRekapLikes(req, res) {
       periode,
       tanggal,
       startDate,
-      endDate,
-      role
+      endDate
     );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -42,10 +42,11 @@ export async function absensiLikes(client_id, opts = {}) {
   const { nama: clientNama, clientType } = await getClientInfo(targetClient);
 
   if (clientType === "direktorat") {
-    const polresIds = (await getClientsByRole("ditbinmas")).map((c) =>
+    const roleName = (roleFlag || targetClient).toLowerCase();
+    const polresIds = (await getClientsByRole(roleName)).map((c) =>
       c.toUpperCase()
     );
-    const shortcodes = await getShortcodesTodayByClient("ditbinmas");
+    const shortcodes = await getShortcodesTodayByClient(roleName);
     if (!shortcodes.length)
       return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;
 
@@ -59,7 +60,7 @@ export async function absensiLikes(client_id, opts = {}) {
     }
 
     const allUsers = (
-      await getUsersByDirektorat("ditbinmas")
+      await getUsersByDirektorat(roleName)
     ).filter((u) => u.status === true);
     const usersByClient = {};
     allUsers.forEach((u) => {

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -43,7 +43,7 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const json = jest.fn();
   const res = { json };
   await getInstaRekapLikes(req, res);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
@@ -70,7 +70,7 @@ test('allows authorized client_id', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getInstaRekapLikes(req, res);
   expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -93,11 +93,12 @@ test('filters users by client_id for non-directorate clients', async () => {
 test('filters users by role for directorate clients', async () => {
   mockClientType('direktorat');
   mockQuery.mockResolvedValueOnce({ rows: [] });
-  await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'kabid');
+  await getRekapLikesByClient('ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
-  expect(sql).toContain('JOIN user_roles');
-  expect(sql).toContain('JOIN roles');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(p.client_id) IN (SELECT LOWER(u.client_id)');
-  expect(sql).not.toContain('u.client_id = $1');
+  expect(sql).toContain('user_roles ur');
+  expect(sql).toContain('roles r');
+  expect(sql).toContain('EXISTS');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
+  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
 });


### PR DESCRIPTION
## Summary
- handle Instagram likes attendance for any directorate role
- compute likes recap with role-based filtering and client labels
- simplify controller to use updated recap API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ddde433883278def1134d64fd341