### PR TITLE
feat: add attendance flag to instagram like recap

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -175,6 +175,7 @@ export async function getRekapLikesByClient(
 
   for (const user of rows) {
     user.jumlah_like = parseInt(user.jumlah_like, 10);
+    user.hadir = user.jumlah_like > 0;
   }
 
   return rows;

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -81,6 +81,37 @@ test('parses jumlah_like as integer', async () => {
   expect(rows[0].jumlah_like).toBe(3);
 });
 
+test('adds hadir flag based on jumlah_like', async () => {
+  mockClientType();
+  mockQuery.mockResolvedValueOnce({ rows: [
+    {
+      user_id: 'u1',
+      title: 'Aiptu',
+      nama: 'Budi',
+      username: 'budi',
+      divisi: 'BAG',
+      exception: false,
+      client_id: 'c1',
+      client_name: 'Client A',
+      jumlah_like: '0',
+    },
+    {
+      user_id: 'u2',
+      title: 'Bripka',
+      nama: 'Sari',
+      username: 'sari',
+      divisi: 'BAG',
+      exception: false,
+      client_id: 'c2',
+      client_name: 'Client B',
+      jumlah_like: '5',
+    },
+  ] });
+  const rows = await getRekapLikesByClient('1');
+  expect(rows[0].hadir).toBe(false);
+  expect(rows[1].hadir).toBe(true);
+});
+
 test('filters users by client_id for non-directorate clients', async () => {
   mockClientType('regular');
   mockQuery.mockResolvedValueOnce({ rows: [] });


### PR DESCRIPTION
## Summary
- include `hadir` flag in Instagram like recap rows
- test attendance flag logic for Instagram likes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f031b3848327b5f23998596bb753