### PR TITLE
feat: support directorate role in instagram likes

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -22,6 +22,7 @@ export async function getInstaRekapLikes(req, res) {
   const startDate =
     req.query.start_date || req.query.tanggal_mulai;
   const endDate = req.query.end_date || req.query.tanggal_selesai;
+  const role = req.user?.role;
     if (!client_id) {
       return res.status(400).json({ success: false, message: "client_id wajib diisi" });
     }
@@ -42,7 +43,8 @@ export async function getInstaRekapLikes(req, res) {
       periode,
       tanggal,
       startDate,
-      endDate
+      endDate,
+      role
     );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -84,13 +84,19 @@ export async function getRekapLikesByClient(
   periode = "harian",
   tanggal,
   start_date,
-  end_date
+  end_date,
+  role
 ) {
   const clientTypeRes = await query(
     'SELECT client_type FROM clients WHERE client_id = $1',
     [client_id]
   );
   const clientType = clientTypeRes.rows[0]?.client_type;
+
+  const roleFlag =
+    role && ['ditbinmas', 'ditlantas', 'bidhumas'].includes(role.toLowerCase())
+      ? role.toLowerCase()
+      : null;
 
   const params = [client_id];
   let tanggalFilter =
@@ -131,6 +137,14 @@ export async function getRekapLikesByClient(
       JOIN roles r ON ur.role_id = r.role_id
       WHERE ur.user_id = u.user_id AND LOWER(r.role_name) = LOWER($1)
     )`;
+  } else if (roleFlag) {
+    const roleIndex = params.length + 1;
+    userWhere = `LOWER(u.client_id) = LOWER($1) AND EXISTS (
+      SELECT 1 FROM user_roles ur
+      JOIN roles r ON ur.role_id = r.role_id
+      WHERE ur.user_id = u.user_id AND LOWER(r.role_name) = LOWER($${roleIndex})
+    )`;
+    params.push(roleFlag);
   }
 
   const { rows } = await query(`

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -43,7 +43,7 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const json = jest.fn();
   const res = { json };
   await getInstaRekapLikes(req, res);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
@@ -70,7 +70,7 @@ test('allows authorized client_id', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getInstaRekapLikes(req, res);
   expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -102,3 +102,14 @@ test('filters users by role for directorate clients', async () => {
   expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
 });
+
+test('filters users by role flag for non-directorate clients', async () => {
+  mockClientType('regular');
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  const sql = mockQuery.mock.calls[1][0];
+  const params = mockQuery.mock.calls[1][1];
+  expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
+  expect(params).toEqual(['c1', 'ditbinmas']);
+});


### PR DESCRIPTION
## Summary
- include user role when requesting Instagram like recaps
- filter likes recap by directorate role for non-directorate clients

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f476a3988327a41369b228ae1951