### PR TITLE
Fix directorate role filtering for Instagram likes recap

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -132,10 +132,11 @@ export async function getRekapLikesByClient(
 
   let userWhere = 'LOWER(u.client_id) = LOWER($1)';
   if (clientType === 'direktorat') {
+    params.push(role);
     userWhere = `EXISTS (
       SELECT 1 FROM user_roles ur
       JOIN roles r ON ur.role_id = r.role_id
-      WHERE ur.user_id = u.user_id AND LOWER(r.role_name) = LOWER($1)
+      WHERE ur.user_id = u.user_id AND LOWER(r.role_name) = LOWER($${params.length})
     )`;
   } else if (roleFlag) {
     const roleIndex = params.length + 1;


### PR DESCRIPTION
## Summary
- include requester role in `getRekapLikesByClient` params for directorate users and reference it in `userWhere`
- keep CTE filtering by original client id
- add tests covering directorate users with multiple client ids

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a30d861410832785a91a981fa8501d