### PR TITLE
feat: summarize insta like users

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -1,0 +1,21 @@
+# Insta Rekap Likes API
+
+The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
+
+## Response
+
+```
+{
+  "success": true,
+  "data": [ /* user like rows */ ],
+  "chartHeight": 300,
+  "usersWithLikes": ["alice", "charlie"],
+  "usersWithoutLikes": ["bob"],
+  "usersWithLikesCount": 2,
+  "usersWithoutLikesCount": 1
+}
+```
+
+- **usersWithLikes** – usernames with `jumlah_like > 0`.
+- **usersWithoutLikes** – usernames with `jumlah_like = 0`.
+- Count fields provide totals for each category.

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -48,7 +48,21 @@ export async function getInstaRekapLikes(req, res) {
     );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);
-    res.json({ success: true, data, chartHeight });
+
+    const usersWithLikes = data.filter((u) => u.jumlah_like > 0).map((u) => u.username);
+    const usersWithoutLikes = data
+      .filter((u) => u.jumlah_like === 0)
+      .map((u) => u.username);
+
+    res.json({
+      success: true,
+      data,
+      chartHeight,
+      usersWithLikes,
+      usersWithoutLikes,
+      usersWithLikesCount: usersWithLikes.length,
+      usersWithoutLikesCount: usersWithoutLikes.length,
+    });
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaRekapLikes: ${err.message}` });
     const code = err.statusCode || err.response?.status || 500;

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -74,3 +74,27 @@ test('allows authorized client_id', async () => {
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 
+test('returns user like summaries', async () => {
+  const rows = [
+    { username: 'alice', jumlah_like: 3 },
+    { username: 'bob', jumlah_like: 0 },
+    { username: 'charlie', jumlah_like: 1 }
+  ];
+  mockGetRekap.mockResolvedValue(rows);
+  const req = {
+    query: { client_id: 'c1' },
+    user: { client_ids: ['c1'] }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getInstaRekapLikes(req, res);
+  expect(json).toHaveBeenCalledWith(
+    expect.objectContaining({
+      usersWithLikes: ['alice', 'charlie'],
+      usersWithoutLikes: ['bob'],
+      usersWithLikesCount: 2,
+      usersWithoutLikesCount: 1
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- add user like summaries to getInstaRekapLikes response
- document Insta Rekap Likes API response shape
- test controller like summary counts and arrays

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a30f7356f083278982bdc047bad49f