### PR TITLE
Include directorate users in Instagram rekap likes

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -19,3 +19,10 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
 - **usersWithLikes** – usernames with `jumlah_like > 0`.
 - **usersWithoutLikes** – usernames with `jumlah_like = 0`.
 - Count fields provide totals for each category.
+
+### Directorate Clients
+
+When `client_id` refers to a directorate client, the endpoint aggregates user data
+across **all** client IDs that have a user role matching the directorate name.
+For example, requesting rekap likes for `ditbinmas` will include users from every
+client who has the role `ditbinmas`.

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -132,7 +132,7 @@ export async function getRekapLikesByClient(
 
   let userWhere = 'LOWER(u.client_id) = LOWER($1)';
   if (clientType === 'direktorat') {
-    params.push(role);
+    params.push(client_id);
     userWhere = `EXISTS (
       SELECT 1 FROM user_roles ur
       JOIN roles r ON ur.role_id = r.role_id

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -93,7 +93,7 @@ test('filters users by client_id for non-directorate clients', async () => {
 test('filters users by role for directorate clients', async () => {
   mockClientType('direktorat');
   mockQuery.mockResolvedValueOnce({ rows: [] });
-  await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  await getRekapLikesByClient('ditbinmas', 'harian');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
   expect(sql).toContain('user_roles ur');
@@ -102,7 +102,7 @@ test('filters users by role for directorate clients', async () => {
   expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
   expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['c1', 'ditbinmas']);
+  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
 });
 
 test('filters users by role flag for non-directorate clients', async () => {
@@ -144,13 +144,13 @@ test('aggregates likes across multiple client IDs for directorate role', async (
       },
     ],
   });
-  const rows = await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  const rows = await getRekapLikesByClient('ditbinmas', 'harian');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
   expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
   expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['c1', 'ditbinmas']);
+  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
   expect(rows).toHaveLength(2);
   expect(rows.map(r => r.client_id)).toEqual(['c1', 'c2']);
 });


### PR DESCRIPTION
## Summary
- Aggregate attendance for directorate clients across all matching-role users
- Document directorate behavior for Instagram rekap likes
- Extend tests for new directorate user aggregation logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a315841b148327a21b2e748443b598