### PR TITLE
Filter directorate users by matching client role

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -60,7 +60,7 @@ export async function absensiLikes(client_id, opts = {}) {
     }
 
     const allUsers = (
-      await getUsersByDirektorat(roleName)
+      await getUsersByDirektorat(roleName, polresIds)
     ).filter((u) => u.status === true);
     const usersByClient = {};
     allUsers.forEach((u) => {

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -119,7 +119,10 @@ test('directorate summarizes across clients', async () => {
 
   expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas');
   expect(mockGetShortcodesTodayByClient).toHaveBeenCalledWith('ditbinmas');
-  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', [
+    'POLRESA',
+    'POLRESB',
+  ]);
   expect(msg).toMatch(/Polres\*: \*POLRES A\*[\s\S]*Sudah melaksanakan\* : \*1 user\*[\s\S]*Belum melaksanakan\* : \*0 user\*[\s\S]*Belum input username\* : \*1 user/);
   expect(msg).toMatch(/Polres\*: \*POLRES B\*[\s\S]*Sudah melaksanakan\* : \*0 user\*[\s\S]*Belum melaksanakan\* : \*1 user\*[\s\S]*Belum input username\* : \*0 user/);
 });

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -121,6 +121,8 @@ test('getUsersByDirektorat queries by flag', async () => {
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
   expect(sql).toContain('r.role_name = $1');
+  expect(sql).toContain('EXISTS');
+  expect(sql).toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
 });
 
 test('getUsersByDirektorat filters by client and flag', async () => {
@@ -129,7 +131,8 @@ test('getUsersByDirektorat filters by client and flag', async () => {
   expect(users).toEqual([{ user_id: '3', bidhumas: true, ditbinmas: false, ditlantas: false }]);
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
-  expect(sql).toContain('u.client_id = $2');
+  expect(sql).toContain('LOWER(u.client_id) = LOWER($2)');
+  expect(sql).toContain('EXISTS');
 });
 
 test('getClientsByRole returns lowercase client ids', async () => {


### PR DESCRIPTION
## Summary
- ensure `getUsersByDirektorat` only returns users whose role matches their client_id and allow filtering by multiple client IDs
- use the client list when summarizing directorate Instagram likes to fetch relevant users
- update tests for new filtering logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a31a4c382483279bb4742a5a22e161