### PR TITLE
Set role to client_id for direktorat clients

### DIFF
--- a/src/handler/fetchpost/instaFetchPost.js
+++ b/src/handler/fetchpost/instaFetchPost.js
@@ -70,7 +70,7 @@ async function deleteShortcodes(shortcodesToDelete, clientId = null) {
 
 async function getEligibleClients() {
   const res = await query(
-    `SELECT client_ID as id, client_insta FROM clients
+    `SELECT client_id as id, client_insta FROM clients
       WHERE client_status=true
         AND (client_insta_status=true OR client_amplify_status=true)
         AND client_insta IS NOT NULL`


### PR DESCRIPTION
## Summary
- Ensure dashboard and client logins assign role to client_id when client type is 'direktorat'
- Add tests verifying role behavior for directorate clients
- Fix client_id column usage in Instagram fetch query

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32725d89483279fe1972e90625871