### PR TITLE
Restrict ORG user queries by client and role

### DIFF
--- a/src/controller/userController.js
+++ b/src/controller/userController.js
@@ -126,7 +126,13 @@ export const deleteUser = async (req, res, next) => {
 // --- Query DB: User by client_id (aktif)
 export const getUsersByClient = async (req, res, next) => {
   try {
-    const users = await userModel.getUsersByClient(req.params.client_id);
+    const role = req.user?.role?.toLowerCase();
+    const tokenClientId = req.user?.client_id;
+    let clientId = req.params.client_id;
+    if (['ditbinmas', 'ditlantas', 'bidhumas'].includes(role) && tokenClientId) {
+      clientId = tokenClientId;
+    }
+    const users = await userModel.getUsersByClient(clientId, role);
     sendSuccess(res, users);
   } catch (err) {
     next(err);
@@ -136,7 +142,13 @@ export const getUsersByClient = async (req, res, next) => {
 // --- Query DB: User by client_id (full, semua status)
 export const getUsersByClientFull = async (req, res, next) => {
   try {
-    const users = await userModel.getUsersByClientFull(req.params.client_id);
+    const role = req.user?.role?.toLowerCase();
+    const tokenClientId = req.user?.client_id;
+    let clientId = req.params.client_id;
+    if (['ditbinmas', 'ditlantas', 'bidhumas'].includes(role) && tokenClientId) {
+      clientId = tokenClientId;
+    }
+    const users = await userModel.getUsersByClientFull(clientId, role);
     sendSuccess(res, users);
   } catch (err) {
     next(err);
@@ -146,7 +158,7 @@ export const getUsersByClientFull = async (req, res, next) => {
 // --- API: Ambil daftar user untuk User Directory, hanya dari client tertentu ---
 export const getUserList = async (req, res, next) => {
   try {
-    const role = req.user?.role;
+    const role = req.user?.role?.toLowerCase();
     const tokenClientId = req.user?.client_id;
     let users;
 
@@ -156,7 +168,7 @@ export const getUserList = async (req, res, next) => {
           .status(400)
           .json({ success: false, message: 'client_id wajib diisi' });
       }
-      users = await userModel.getUsersByClient(tokenClientId);
+      users = await userModel.getUsersByClient(tokenClientId, role);
     } else if (['ditbinmas', 'ditlantas', 'bidhumas'].includes(role)) {
       if (!tokenClientId) {
         return res
@@ -175,7 +187,7 @@ export const getUserList = async (req, res, next) => {
           .status(400)
           .json({ success: false, message: 'client_id wajib diisi' });
       }
-      users = await userModel.getUsersByClient(clientId);
+      users = await userModel.getUsersByClient(clientId, role);
     }
     sendSuccess(res, users);
   } catch (err) {

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -18,11 +18,13 @@ jest.unstable_mockModule('../src/model/userModel.js', () => ({
 
 let createUser;
 let getUserList;
+let getUsersByClientCtrl;
 
 beforeAll(async () => {
   const mod = await import('../src/controller/userController.js');
   createUser = mod.createUser;
   getUserList = mod.getUserList;
+  getUsersByClientCtrl = mod.getUsersByClient;
 });
 
 beforeEach(() => {
@@ -231,4 +233,18 @@ test('ditbinmas role with different client_id filters users by client', async ()
   expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'c1');
   expect(status).toHaveBeenCalledWith(200);
   expect(json).toHaveBeenCalledWith({ success: true, data: [{ user_id: '2', ditbinmas: true }] });
+});
+
+test('getUsersByClient uses token client and role for ditbinmas', async () => {
+  mockGetUsersByClient.mockResolvedValue([{ user_id: '1' }]);
+  const req = { params: { client_id: 'other' }, user: { role: 'ditbinmas', client_id: 'C1' } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { status, json };
+
+  await getUsersByClientCtrl(req, res, () => {});
+
+  expect(mockGetUsersByClient).toHaveBeenCalledWith('C1', 'ditbinmas');
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({ success: true, data: [{ user_id: '1' }] });
 });


### PR DESCRIPTION
## Summary
- Filter user queries for ORG clients by both client ID and requester's role
- Derive client ID from auth context for non-operator dashboard roles
- Add tests covering role-based filtering and controller behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a330fe2ee48327b73295b77f54fe19