### PR TITLE
fix: ensure directorate user listing is case-insensitive

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -299,7 +299,7 @@ export async function getUsersByDirektorat(flag, clientId = null) {
     throw new Error('Direktorat flag tidak valid');
   }
 
-  let sql = `SELECT u.*,\n    bool_or(r.role_name='ditbinmas') AS ditbinmas,\n    bool_or(r.role_name='ditlantas') AS ditlantas,\n    bool_or(r.role_name='bidhumas') AS bidhumas\n  FROM "user" u\n  JOIN user_roles ur ON u.user_id = ur.user_id\n  JOIN roles r ON ur.role_id = r.role_id\n  WHERE r.role_name = $1\n    AND EXISTS (\n      SELECT 1 FROM user_roles ur2\n      JOIN roles r2 ON ur2.role_id = r2.role_id\n      WHERE ur2.user_id = u.user_id AND LOWER(r2.role_name) = LOWER(u.client_id)\n    )`;
+  let sql = `SELECT u.*,\n    bool_or(r.role_name='ditbinmas') AS ditbinmas,\n    bool_or(r.role_name='ditlantas') AS ditlantas,\n    bool_or(r.role_name='bidhumas') AS bidhumas\n  FROM "user" u\n  JOIN user_roles ur ON u.user_id = ur.user_id\n  JOIN roles r ON ur.role_id = r.role_id\n  WHERE LOWER(r.role_name) = LOWER($1)\n    AND EXISTS (\n      SELECT 1 FROM user_roles ur2\n      JOIN roles r2 ON ur2.role_id = r2.role_id\n      WHERE ur2.user_id = u.user_id AND LOWER(r2.role_name) = LOWER(u.client_id)\n    )`;
   const params = [flag];
 
   if (clientId) {

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -185,7 +185,7 @@ test('getUsersByDirektorat queries by flag', async () => {
   expect(users).toEqual([{ user_id: '2', ditbinmas: true, ditlantas: false, bidhumas: false }]);
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
-  expect(sql).toContain('r.role_name = $1');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
   expect(sql).toContain('EXISTS');
   expect(sql).toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
 });


### PR DESCRIPTION
## Summary
- handle role_name comparisons in getUsersByDirektorat without case sensitivity
- update unit test for directorate user retrieval

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a338a0fc8883279148806334782b83