### PR TITLE
Fix directorate user lookup to ignore client_id

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -35,18 +35,28 @@ async function buildClientFilter(clientId, alias = 'u', index = 1, roleFilter = 
     [clientId]
   );
   const clientType = rows[0]?.client_type?.toLowerCase();
-  const placeholder = `$${index}`;
-  const params = [clientId];
+
   let clause;
+  const params = [];
 
   if (clientType === 'direktorat') {
-    clause = `EXISTS (
+    const roleName = roleFilter || clientId;
+    if (roleName) {
+      const rolePlaceholder = `$${index}`;
+      clause = `EXISTS (
         SELECT 1 FROM user_roles ur
         JOIN roles r ON ur.role_id = r.role_id
-        WHERE ur.user_id = ${alias}.user_id AND r.role_name = ${placeholder}
+        WHERE ur.user_id = ${alias}.user_id AND r.role_name = ${rolePlaceholder}
       )`;
+      params.push(roleName);
+    } else {
+      clause = '1=1';
+    }
   } else {
-    clause = `${alias}.client_id = ${placeholder}`;
+    const clientPlaceholder = `$${index}`;
+    clause = `${alias}.client_id = ${clientPlaceholder}`;
+    params.push(clientId);
+
     const allowedRoles = ['ditbinmas', 'ditlantas', 'bidhumas'];
     if (roleFilter && allowedRoles.includes(roleFilter.toLowerCase())) {
       const rolePlaceholder = `$${index + 1}`;


### PR DESCRIPTION
## Summary
- use role-based filtering for direktorat clients instead of client_id

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33ec687bc8327bf93aecb74f5aa72