### PR TITLE
Use role query for directorate user list

### DIFF
--- a/src/controller/userController.js
+++ b/src/controller/userController.js
@@ -177,28 +177,42 @@ export const getUserList = async (req, res, next) => {
           .status(400)
           .json({ success: false, message: 'client_id wajib diisi' });
       }
+      const loweredClientId = clientId.toLowerCase();
+      const direktorateRoles = ['ditbinmas', 'ditlantas', 'bidhumas'];
 
-      const client = await clientService.findClientById(clientId);
-      const clientType = client?.client_type?.toLowerCase();
-
-      if (clientType === 'direktorat') {
+      if (direktorateRoles.includes(loweredClientId)) {
         const filterClientId =
-          tokenClientId &&
-          tokenClientId.toLowerCase() !== clientId.toLowerCase()
+          tokenClientId && tokenClientId.toLowerCase() !== loweredClientId
             ? tokenClientId
             : null;
         if (filterClientId) {
           users = await userModel.getUsersByDirektorat(
-            clientId.toLowerCase(),
+            loweredClientId,
             filterClientId
           );
         } else {
-          users = await userModel.getUsersByDirektorat(clientId.toLowerCase());
+          users = await userModel.getUsersByDirektorat(loweredClientId);
         }
-      } else if (clientType === 'org' && role !== 'operator') {
-        users = await userModel.getUsersByClient(clientId, role);
       } else {
-        users = await userModel.getUsersByClient(clientId, role);
+        const client = await clientService.findClientById(clientId);
+        const clientType = client?.client_type?.toLowerCase();
+
+        if (clientType === 'direktorat') {
+          const filterClientId =
+            tokenClientId && tokenClientId.toLowerCase() !== loweredClientId
+              ? tokenClientId
+              : null;
+          if (filterClientId) {
+            users = await userModel.getUsersByDirektorat(
+              loweredClientId,
+              filterClientId
+            );
+          } else {
+            users = await userModel.getUsersByDirektorat(loweredClientId);
+          }
+        } else {
+          users = await userModel.getUsersByClient(clientId, role);
+        }
       }
     }
     sendSuccess(res, users);

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -226,7 +226,7 @@ test('ditbinmas role with matching client_id shows all users', async () => {
 
   await getUserList(req, res, () => {});
 
-  expect(mockFindClientById).toHaveBeenCalledWith('ditbinmas');
+  expect(mockFindClientById).not.toHaveBeenCalled();
   expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
   expect(status).toHaveBeenCalledWith(200);
   expect(json).toHaveBeenCalledWith({ success: true, data: [{ user_id: '1', ditbinmas: true }] });
@@ -245,7 +245,7 @@ test('ditbinmas role with different client_id filters users by client', async ()
 
   await getUserList(req, res, () => {});
 
-  expect(mockFindClientById).toHaveBeenCalledWith('ditbinmas');
+  expect(mockFindClientById).not.toHaveBeenCalled();
   expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'c1');
   expect(status).toHaveBeenCalledWith(200);
   expect(json).toHaveBeenCalledWith({ success: true, data: [{ user_id: '2', ditbinmas: true }] });


### PR DESCRIPTION
## Summary
- Avoid client lookup when querying directorate users by using role names directly
- Adjust controller tests to expect role-based queries without client checks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a341bf714c8327979e3d51e04313fe