### PR TITLE
feat: make client filter optional in getUsersByDirektorat

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -329,8 +329,13 @@ export async function getUsersByDirektorat(flag, clientId = null) {
       JOIN roles r1 ON r1.role_id = ur1.role_id
       WHERE ur1.user_id = u.user_id
         AND r1.role_name = $1
-    )
-      AND EXISTS (
+    )`;
+
+  const hasClientId =
+    Array.isArray(clientId) ? clientId.length > 0 : typeof clientId === 'string' && clientId.trim() !== '';
+
+  if (hasClientId) {
+    sql += ` AND EXISTS (
         SELECT 1
         FROM user_roles ur2
         JOIN roles r2 ON r2.role_id = ur2.role_id
@@ -338,12 +343,11 @@ export async function getUsersByDirektorat(flag, clientId = null) {
         AND LOWER(r2.role_name) = LOWER(u.client_id)
       )`;
 
-  if (clientId) {
-    if (Array.isArray(clientId) && clientId.length > 0) {
+    if (Array.isArray(clientId)) {
       sql += ` AND LOWER(u.client_id) = ANY($${p})`;
       params.push(clientId.map((c) => String(c).toLowerCase()));
       p += 1;
-    } else if (typeof clientId === 'string' && clientId.trim() !== '') {
+    } else {
       sql += ` AND LOWER(u.client_id) = LOWER($${p})`;
       params.push(clientId.trim());
       p += 1;

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -187,7 +187,7 @@ test('getUsersByDirektorat queries by flag', async () => {
   expect(sql).toContain('user_roles');
   expect(sql).toContain('r1.role_name = $1');
   expect(sql).toContain('EXISTS');
-  expect(sql).toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
+  expect(sql).not.toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
 });
 
 test('getUsersByDirektorat filters by client and flag', async () => {
@@ -197,7 +197,8 @@ test('getUsersByDirektorat filters by client and flag', async () => {
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
   expect(sql).toContain('LOWER(u.client_id) = LOWER($2)');
-  expect(sql).toContain('EXISTS');
+  expect(sql).toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
+  expect(sql.match(/EXISTS/g).length).toBeGreaterThanOrEqual(2);
 });
 
 test('getClientsByRole returns lowercase client ids', async () => {


### PR DESCRIPTION
## Summary
- avoid filtering users by client when no clientId provided
- adjust tests for optional client filter

## Testing
- `npm run lint`
- `npm test` *(fails: tests/authRoutes.test.js timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a3466b3f888327b61d37d5179c2242