### PR TITLE
feat: allow directorate rekap likes filter

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -1,6 +1,8 @@
 # Insta Rekap Likes API
 
 The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
+An optional `clientId` query parameter can further restrict results to a
+specific client when requesting data for a directorate role.
 
 ## Response
 
@@ -25,4 +27,5 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
 When `client_id` refers to a directorate client, the endpoint aggregates user data
 across **all** client IDs that have a user role matching the directorate name.
 For example, requesting rekap likes for `ditbinmas` will include users from every
-client who has the role `ditbinmas`.
+client who has the role `ditbinmas`. Passing `clientId=c1` will limit the
+results to users from client `c1` only.

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -43,7 +43,7 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const json = jest.fn();
   const res = { json };
   await getInstaRekapLikes(req, res);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined, undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
@@ -70,7 +70,7 @@ test('allows authorized client_id', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getInstaRekapLikes(req, res);
   expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined, undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 


### PR DESCRIPTION
## Summary
- allow optional clientId filter for `/api/insta/rekap-likes`
- update rekap likes query to handle directorate roles without implicit client filter
- document new clientId usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34bb0a68c8327bc879526eb7625f3