### PR TITLE
Filter non-operator like recap by user role

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -29,3 +29,9 @@ across **all** client IDs that have a user role matching the directorate name.
 For example, requesting rekap likes for `ditbinmas` will include users from every
 client who has the role `ditbinmas`. Passing `clientId=c1` will limit the
 results to users from client `c1` only.
+
+### Organization Clients with Non-Operator Roles
+
+When requesting data for a regular organization and the authenticated user role is
+not `operator`, only users having the same role as the requester are included in
+the response.

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -94,10 +94,7 @@ export async function getRekapLikesByClient(
   );
   const clientType = clientTypeRes.rows[0]?.client_type;
 
-  const roleFlag =
-    role && ['ditbinmas', 'ditlantas', 'bidhumas'].includes(role.toLowerCase())
-      ? role.toLowerCase()
-      : null;
+  const roleLower = role ? role.toLowerCase() : null;
 
   const params = [client_id];
   let tanggalFilter =
@@ -146,14 +143,14 @@ export async function getRekapLikesByClient(
       postClientFilter = `LOWER(p.client_id) = LOWER($${idx})`;
       userWhere += ` AND LOWER(u.client_id) = LOWER($${idx})`;
     }
-  } else if (roleFlag) {
+  } else if (roleLower && roleLower !== 'operator') {
     const roleIndex = params.length + 1;
     userWhere = `LOWER(u.client_id) = LOWER($1) AND EXISTS (
       SELECT 1 FROM user_roles ur
       JOIN roles r ON ur.role_id = r.role_id
       WHERE ur.user_id = u.user_id AND LOWER(r.role_name) = LOWER($${roleIndex})
     )`;
-    params.push(roleFlag);
+    params.push(roleLower);
   }
 
   const { rows } = await query(`

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -105,7 +105,7 @@ test('filters users by role for directorate clients', async () => {
   expect(params).toEqual(['ditbinmas']);
 });
 
-test('filters users by role flag for non-directorate clients', async () => {
+test('filters users by role for non-directorate clients', async () => {
   mockClientType('regular');
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditbinmas');
@@ -114,6 +114,15 @@ test('filters users by role flag for non-directorate clients', async () => {
   expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
   expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
   expect(params).toEqual(['c1', 'ditbinmas']);
+});
+
+test('skips role filter for operator role on non-directorate clients', async () => {
+  mockClientType('regular');
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'operator');
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
+  expect(sql).not.toContain('user_roles');
 });
 
 test('aggregates likes across multiple client IDs for directorate role', async () => {


### PR DESCRIPTION
## Summary
- broaden Instagram like recap query to filter by any non-operator role
- document behavior for organization clients when user role is non-operator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34f46347483279e1ec3443b2c3ac3