### PR TITLE
feat: align org profiles with role social links

### DIFF
--- a/src/controller/clientController.js
+++ b/src/controller/clientController.js
@@ -157,6 +157,23 @@ export const getClientProfile = async (req, res, next) => {
       return res.status(404).json({ error: "Client not found" });
     }
 
+    const role = req.user?.role?.toLowerCase();
+    if (
+      role &&
+      role !== "operator" &&
+      role !== "client" &&
+      client.client_type?.toLowerCase() === "org"
+    ) {
+      const roleClient = await clientService.findClientById(role.toUpperCase());
+      if (roleClient) {
+        client.client_insta = roleClient.client_insta;
+        client.client_insta_status = roleClient.client_insta_status;
+        client.client_tiktok = roleClient.client_tiktok;
+        client.client_tiktok_status = roleClient.client_tiktok_status;
+        client.client_amplify_status = roleClient.client_amplify_status;
+      }
+    }
+
     // Sesuaikan key hasil jika ingin (client/profile)
     res.json({ success: true, client });
   } catch (err) {

--- a/tests/clientController.test.js
+++ b/tests/clientController.test.js
@@ -1,0 +1,66 @@
+import { jest } from '@jest/globals';
+
+const mockFindClientById = jest.fn();
+
+jest.unstable_mockModule('../src/service/clientService.js', () => ({
+  findClientById: mockFindClientById,
+}));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaPostService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaLikeService.js', () => ({}));
+jest.unstable_mockModule('../src/service/tiktokPostService.js', () => ({}));
+jest.unstable_mockModule('../src/service/tiktokCommentService.js', () => ({}));
+
+let getClientProfile;
+
+beforeAll(async () => {
+  ({ getClientProfile } = await import('../src/controller/clientController.js'));
+});
+
+afterEach(() => {
+  mockFindClientById.mockReset();
+});
+
+test('uses role client data for social media fields when non-operator org', async () => {
+  mockFindClientById
+    .mockResolvedValueOnce({
+      client_id: 'ORG1',
+      client_type: 'org',
+      client_insta: 'orginsta',
+      client_insta_status: false,
+      client_tiktok: 'orgtiktok',
+      client_tiktok_status: false,
+      client_amplify_status: false,
+    })
+    .mockResolvedValueOnce({
+      client_id: 'DITBINMAS',
+      client_type: 'direktorat',
+      client_insta: 'ditinsta',
+      client_insta_status: true,
+      client_tiktok: 'dittiktok',
+      client_tiktok_status: true,
+      client_amplify_status: true,
+    });
+
+  const req = { params: {}, query: { client_id: 'ORG1' }, body: {}, user: { role: 'ditbinmas' } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { json, status };
+
+  await getClientProfile(req, res, () => {});
+
+  expect(mockFindClientById).toHaveBeenNthCalledWith(1, 'ORG1');
+  expect(mockFindClientById).toHaveBeenNthCalledWith(2, 'DITBINMAS');
+  expect(json).toHaveBeenCalledWith({
+    success: true,
+    client: expect.objectContaining({
+      client_id: 'ORG1',
+      client_type: 'org',
+      client_insta: 'ditinsta',
+      client_insta_status: true,
+      client_tiktok: 'dittiktok',
+      client_tiktok_status: true,
+      client_amplify_status: true,
+    }),
+  });
+});


### PR DESCRIPTION
## Summary
- overlay org client social media fields with role client data when logged in as non-operator
- test profile social media uses role client links for org users

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a352948b948327942fbc66e806864e