### PR TITLE
Use role role-based filter for directorate like recap

### DIFF
--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -93,7 +93,7 @@ test('filters users by client_id for non-directorate clients', async () => {
 test('filters users by role for directorate clients', async () => {
   mockClientType('direktorat');
   mockQuery.mockResolvedValueOnce({ rows: [] });
-  await getRekapLikesByClient('ditbinmas', 'harian');
+  await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
   expect(sql).toContain('user_roles ur');
@@ -153,7 +153,7 @@ test('aggregates likes across multiple client IDs for directorate role', async (
       },
     ],
   });
-  const rows = await getRekapLikesByClient('ditbinmas', 'harian');
+  const rows = await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
   expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');


### PR DESCRIPTION
## Summary
- remove client-specific user filtering for directorate Instagram like recap
- filter active users by role and allow optional explicit client id
- update tests for directorate role filtering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35510b9408327ad0eca658b1613a6