### PR TITLE
Remove client_id filters for directorate likes recap

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -1,8 +1,6 @@
 # Insta Rekap Likes API
 
 The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
-An optional `clientId` query parameter can further restrict results to a
-specific client when requesting data for a directorate role.
 
 ## Response
 
@@ -27,8 +25,7 @@ specific client when requesting data for a directorate role.
 When `client_id` refers to a directorate client, the endpoint aggregates user data
 across **all** client IDs that have a user role matching the directorate name.
 For example, requesting rekap likes for `ditbinmas` will include users from every
-client who has the role `ditbinmas`. Passing `clientId=c1` will limit the
-results to users from client `c1` only.
+client who has the role `ditbinmas`.
 
 ### Organization Clients with Non-Operator Roles
 

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -17,7 +17,6 @@ import { sendConsoleDebug } from "../middleware/debugHandler.js";
 
 export async function getInstaRekapLikes(req, res) {
   const client_id = req.query.client_id;
-  const clientId = req.query.clientId;
   const periode = req.query.periode || "harian";
   const tanggal = req.query.tanggal;
   const startDate =
@@ -29,13 +28,7 @@ export async function getInstaRekapLikes(req, res) {
     }
     if (req.user?.client_ids) {
       const idsLower = req.user.client_ids.map((c) => c.toLowerCase());
-      if (clientId) {
-        if (!idsLower.includes(clientId.toLowerCase())) {
-          return res
-            .status(403)
-            .json({ success: false, message: "client_id tidak diizinkan" });
-        }
-      } else if (
+      if (
         !idsLower.includes(client_id.toLowerCase()) &&
         req.user.role?.toLowerCase() !== client_id.toLowerCase()
       ) {
@@ -44,32 +37,24 @@ export async function getInstaRekapLikes(req, res) {
           .json({ success: false, message: "client_id tidak diizinkan" });
       }
     }
-    if (req.user?.client_id) {
-      if (clientId) {
-        if (req.user.client_id !== clientId) {
-          return res
-            .status(403)
-            .json({ success: false, message: "client_id tidak diizinkan" });
-        }
-      } else if (
-        req.user.client_id !== client_id &&
-        req.user.role?.toLowerCase() !== client_id.toLowerCase()
-      ) {
-        return res
-          .status(403)
-          .json({ success: false, message: "client_id tidak diizinkan" });
-      }
+    if (
+      req.user?.client_id &&
+      req.user.client_id !== client_id &&
+      req.user.role?.toLowerCase() !== client_id.toLowerCase()
+    ) {
+      return res
+        .status(403)
+        .json({ success: false, message: "client_id tidak diizinkan" });
     }
   try {
-    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''} ${clientId || ''}` });
+    sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}` });
     const data = await getRekapLikesByClient(
       client_id,
       periode,
       tanggal,
       startDate,
       endDate,
-      role,
-      clientId
+      role
     );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -85,8 +85,7 @@ export async function getRekapLikesByClient(
   tanggal,
   start_date,
   end_date,
-  role,
-  clientId
+  role
 ) {
   const clientTypeRes = await query(
     'SELECT client_type FROM clients WHERE client_id = $1',
@@ -154,11 +153,6 @@ export async function getRekapLikesByClient(
       GROUP BY username
     `;
     likeJoin = "lower(replace(trim(u.insta), '@', '')) = lc.username";
-    if (clientId) {
-      const clientIdx = params.push(clientId);
-      postClientFilter = `LOWER(p.client_id) = LOWER($${clientIdx})`;
-      userWhere += ` AND LOWER(u.client_id) = LOWER($${clientIdx})`;
-    }
   } else if (roleLower && roleLower !== 'operator') {
     const roleIndex = params.push(roleLower);
     userWhere = `LOWER(u.client_id) = LOWER($1) AND EXISTS (

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -43,7 +43,7 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const json = jest.fn();
   const res = { json };
   await getInstaRekapLikes(req, res);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
@@ -70,7 +70,7 @@ test('allows authorized client_id', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getInstaRekapLikes(req, res);
   expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined);
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -163,15 +163,3 @@ test('aggregates likes across multiple client IDs for directorate role', async (
   expect(rows).toHaveLength(2);
   expect(rows.map(r => r.client_id)).toEqual(['c1', 'c2']);
 });
-
-test('applies explicit clientId filter for directorate clients', async () => {
-  mockClientType('direktorat');
-  mockQuery.mockResolvedValueOnce({ rows: [] });
-  await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, undefined, 'c1');
-  const sql = mockQuery.mock.calls[1][0];
-  const params = mockQuery.mock.calls[1][1];
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
-  expect(sql).toContain('LOWER(p.client_id) = LOWER($2)');
-  expect(sql).toContain('LOWER(u.client_id) = LOWER($2)');
-  expect(params).toEqual(['ditbinmas', 'c1']);
-});


### PR DESCRIPTION
## Summary
- Skip client_id filtering when summarizing likes for directorate clients
- Simplify Insta likes recap controller to drop optional clientId parameter
- Update documentation and tests for new behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35ccab3d88327ae1e69db7c9b95af