### PR TITLE
fix: remove client filter for directorate likes

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -91,7 +91,7 @@ export async function getRekapLikesByClient(
     'SELECT client_type FROM clients WHERE client_id = $1',
     [client_id]
   );
-  const clientType = clientTypeRes.rows[0]?.client_type;
+  const clientType = clientTypeRes.rows[0]?.client_type?.toLowerCase();
 
   const roleLower = role ? role.toLowerCase() : null;
 

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -107,6 +107,19 @@ test('filters users by role for directorate clients', async () => {
   expect(params).toEqual(['ditbinmas']);
 });
 
+test('handles mixed-case client_type for directorate', async () => {
+  mockClientType('Direktorat');
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  const sql = mockQuery.mock.calls[1][0];
+  const params = mockQuery.mock.calls[1][1];
+  expect(sql).toContain('user_roles ur');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
+  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
+  expect(params).toEqual(['ditbinmas']);
+});
+
 test('filters users by role for non-directorate clients', async () => {
   mockClientType('regular');
   mockQuery.mockResolvedValueOnce({ rows: [] });


### PR DESCRIPTION
## Summary
- detect directorate client types case-insensitively so users aren't filtered by client_id
- add regression test ensuring directorate recap likes skip client_id filter

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a364b0e01c832782b35f71dbd6463a