### PR TITLE
Add insta_post_roles table for role-based post filtering

### DIFF
--- a/sql/migrations/20251018_createInstaPostRoles.sql
+++ b/sql/migrations/20251018_createInstaPostRoles.sql
@@ -1,0 +1,6 @@
+-- Create mapping table between Instagram posts and roles
+CREATE TABLE IF NOT EXISTS insta_post_roles (
+  shortcode VARCHAR REFERENCES insta_post(shortcode) ON DELETE CASCADE,
+  role_name VARCHAR NOT NULL,
+  PRIMARY KEY (shortcode, role_name)
+);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -82,6 +82,12 @@ CREATE TABLE insta_post (
   created_at TIMESTAMP
 );
 
+CREATE TABLE insta_post_roles (
+  shortcode VARCHAR REFERENCES insta_post(shortcode) ON DELETE CASCADE,
+  role_name VARCHAR NOT NULL,
+  PRIMARY KEY (shortcode, role_name)
+);
+
 CREATE TABLE insta_like (
   shortcode VARCHAR PRIMARY KEY REFERENCES insta_post(shortcode),
   likes JSONB,


### PR DESCRIPTION
## Summary
- introduce `insta_post_roles` table for mapping post shortcodes to roles
- add migration to create the table with cascading deletes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36631a5d48327ab621558e50309ba