### PR TITLE
feat: apply directorate logic to tiktok comments and link recaps

### DIFF
--- a/src/controller/amplifyController.js
+++ b/src/controller/amplifyController.js
@@ -22,7 +22,15 @@ export async function getAmplifyRekap(req, res) {
       tag: 'AMPLIFY',
       msg: `getAmplifyRekap ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}`
     });
-    const data = await getRekapLinkByClient(client_id, periode, tanggal, startDate, endDate);
+    const role = req.user?.role;
+    const data = await getRekapLinkByClient(
+      client_id,
+      periode,
+      tanggal,
+      startDate,
+      endDate,
+      role
+    );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);
     res.json({ success: true, data, chartHeight });

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -76,12 +76,14 @@ export async function getTiktokRekapKomentar(req, res) {
       .json({ success: false, message: 'client_id tidak diizinkan' });
   }
   try {
+    const role = req.user?.role;
     const data = await getRekapKomentarByClient(
       client_id,
       periode,
       tanggal,
       startDate,
-      endDate
+      endDate,
+      role
     );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);

--- a/tests/amplifyControllerDateRange.test.js
+++ b/tests/amplifyControllerDateRange.test.js
@@ -30,7 +30,14 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const json = jest.fn();
   const res = { json, status: jest.fn().mockReturnThis() };
   await getAmplifyRekap(req, res);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+  expect(mockGetRekap).toHaveBeenCalledWith(
+    'c1',
+    'harian',
+    undefined,
+    '2024-01-01',
+    '2024-01-31',
+    undefined
+  );
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
@@ -57,7 +64,14 @@ test('allows authorized client_id', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getAmplifyRekap(req, res);
   expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith(
+    'c1',
+    'harian',
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 

--- a/tests/tiktokCommentModel.test.js
+++ b/tests/tiktokCommentModel.test.js
@@ -16,26 +16,33 @@ beforeEach(() => {
   mockQuery.mockReset();
 });
 
+function mockClientType(type = 'instansi') {
+  mockQuery.mockResolvedValueOnce({ rows: [{ client_type: type }] });
+}
+
 test('getRekapKomentarByClient uses updated_at BETWEEN for date range', async () => {
+  mockClientType();
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '2' }] })
     .mockResolvedValueOnce({ rows: [] });
   await getRekapKomentarByClient('POLRES', 'harian', null, '2024-01-01', '2024-01-31');
-  expect(mockQuery).toHaveBeenCalledTimes(2);
-  expect(mockQuery.mock.calls[0][0]).toContain('c.updated_at');
-  expect(mockQuery.mock.calls[0][0]).toContain('BETWEEN $2::date AND $3::date');
-  expect(mockQuery.mock.calls[0][1]).toEqual(['POLRES', '2024-01-01', '2024-01-31']);
+  expect(mockQuery).toHaveBeenCalledTimes(3);
   expect(mockQuery.mock.calls[1][0]).toContain('c.updated_at');
   expect(mockQuery.mock.calls[1][0]).toContain('BETWEEN $2::date AND $3::date');
   expect(mockQuery.mock.calls[1][1]).toEqual(['POLRES', '2024-01-01', '2024-01-31']);
+  expect(mockQuery.mock.calls[2][0]).toContain('c.updated_at');
+  expect(mockQuery.mock.calls[2][0]).toContain('BETWEEN $2::date AND $3::date');
+  expect(mockQuery.mock.calls[2][1]).toEqual(['POLRES', '2024-01-01', '2024-01-31']);
 });
 
 test('getRekapKomentarByClient includes directorate role filter for ditbinmas', async () => {
+  mockClientType('direktorat');
   mockQuery
     .mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] })
     .mockResolvedValueOnce({ rows: [] });
-  await getRekapKomentarByClient('ditbinmas');
-  const sql = mockQuery.mock.calls[1][0];
-  expect(sql).toContain('clients WHERE client_id = $1');
+  await getRekapKomentarByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  expect(mockQuery.mock.calls[0][0]).toContain('SELECT client_type FROM clients');
+  const sql = mockQuery.mock.calls[2][0];
+  expect(sql).toContain('tiktok_post_roles');
   expect(sql).toContain('user_roles');
 });

--- a/tests/tiktokControllerDateRange.test.js
+++ b/tests/tiktokControllerDateRange.test.js
@@ -38,7 +38,14 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const json = jest.fn();
   const res = { json, status: jest.fn().mockReturnThis() };
   await getTiktokRekapKomentar(req, res);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31');
+  expect(mockGetRekap).toHaveBeenCalledWith(
+    'c1',
+    'harian',
+    undefined,
+    '2024-01-01',
+    '2024-01-31',
+    undefined
+  );
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
@@ -65,7 +72,14 @@ test('allows authorized client_id', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getTiktokRekapKomentar(req, res);
   expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined);
+  expect(mockGetRekap).toHaveBeenCalledWith(
+    'c1',
+    'harian',
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 


### PR DESCRIPTION
## Summary
- honor directorate roles when recapping TikTok comments
- scope amplify link recap by post roles and user roles like Instagram likes
- pass user roles from controllers to recap queries

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a368eedbe88327bfb7fd354835cc2c