### PR TITLE
docs: clarify cron jobs and request dedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CICERO_V2
-*Last updated: 2025-07-16*
+*Last updated: 2025-08-19*
 
 ## Description
 
@@ -75,6 +75,7 @@ This allows operators to scope responses to the correct client.
     NEXT_PUBLIC_CLIENT_OPERATOR=628123456789
     RAPIDAPI_KEY=xxxx
     REDIS_URL=redis://localhost:6379
+    ALLOW_DUPLICATE_REQUESTS=false
     SECRET_KEY=your-secret
     JWT_SECRET=your-jwt-secret
     AMQP_URL=amqp://localhost
@@ -157,6 +158,10 @@ psql -U <dbuser> -h <host> -d <dbname> < cicero_backup.sql
 - All POST/PUT endpoints perform strict validation.
 - Only admins from the environment variables can trigger manual WhatsApp commands.
 - Back up the database regularly and test recovery procedures.
+
+## Request Deduplication
+
+The middleware in [`src/middleware/dedupRequestMiddleware.js`](src/middleware/dedupRequestMiddleware.js) hashes non-GET requests and caches them in Redis for five minutes. Identical requests sent again within that window receive an HTTP 429 response. Set `ALLOW_DUPLICATE_REQUESTS=true` to bypass this protection during development.
 
 ---
 

--- a/docs/activity_schedule.md
+++ b/docs/activity_schedule.md
@@ -1,5 +1,5 @@
 # System Activity Schedule
-*Last updated: 2025-07-25*
+*Last updated: 2025-08-19*
 
 This document summarizes the automated jobs ("activity") that run inside Cicero_V2. All jobs use `node-cron` and are started automatically when `app.js` boots. Times are in **Asia/Jakarta** timezone.
 
@@ -13,6 +13,10 @@ This document summarizes the automated jobs ("activity") that run inside Cicero_
 | `cronTiktokLaphar.js` | `03 15,18,21 * * *` | Daily at 15:03, 18:03 and 21:03. Fetches TikTok posts and comments then sends attendance reports to recipients. |
 | `cronInstaDataMining.js` | `40 23 * * *` | Daily at 23:40. Crawls Instagram accounts for new posts and stores extended metadata. |
 | `cronNotifikasiLikesDanKomentar.js` | `10 12,16,19 * * *` | Daily at 12:10, 16:10 and 19:10. Sends WhatsApp reminders to users who have not liked/commented on today's posts. |
+| `cronRekapLink.js` | `2 15,18,21 * * *` | Daily at 15:02, 18:02 and 21:02. Sends attendance link recaps to operators and admins. |
+| `cronPremiumSubscription.js` | `0 0 * * *` | Daily at 00:00. Revokes `premium_status` for users whose `premium_end_date` has passed. |
+| `cronPremiumRequest.js` | `*/30 * * * *` | Every 30 minutes. Expires premium subscription requests older than three hours. |
+| `cronAbsensiUserData.js` | `0 13 * * *` | Daily at 13:00. Notifies users and operators about incomplete registration data. |
 | `cronAmplifyLinkMonthly.js` | `0 23 28-31 * *` | At 23:00 on the last day of each month. Generates monthly amplification link reports and sends an Excel file to each operator. |
 
 Each job collects data from the database, interacts with RapidAPI or WhatsApp, and updates the system accordingly. The cron files are imported in `app.js` so no additional setup is required.

--- a/docs/premium_subscription.md
+++ b/docs/premium_subscription.md
@@ -21,3 +21,8 @@ administrators via WhatsApp.
 Each request will automatically expire after three hours if no confirmation is
 received. Administrators approve by replying `grantsub#<id>` or reject with
 `denysub#<id>`. Approval sets `premium_status` to `true` for the user.
+
+## Scheduled Maintenance
+
+- `cronPremiumRequest.js` runs every 30 minutes to clean up premium requests that have not been confirmed within three hours.
+- `cronPremiumSubscription.js` runs daily at midnight (00:00) to disable `premium_status` for users whose `premium_end_date` has passed.


### PR DESCRIPTION
## Summary
- document request deduplication middleware and its ALLOW_DUPLICATE_REQUESTS flag in README
- note premium request expiration and subscription cleanup cron jobs
- extend activity schedule with link recap, premium, and user data cron entries

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bee234e08327950086ac072ba741