### PR TITLE
feat: add user count stats to recap endpoints

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -12,13 +12,15 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
   "usersWithLikes": ["alice", "charlie"],
   "usersWithoutLikes": ["bob"],
   "usersWithLikesCount": 2,
-  "usersWithoutLikesCount": 1
+  "usersWithoutLikesCount": 1,
+  "usersCount": 3
 }
 ```
 
 - **usersWithLikes** – usernames with `jumlah_like > 0`.
 - **usersWithoutLikes** – usernames with `jumlah_like = 0`.
 - Count fields provide totals for each category.
+- **usersCount** – total number of users returned in `data`.
 
 ### Directorate Clients
 

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -72,6 +72,7 @@ export async function getInstaRekapLikes(req, res) {
       usersWithoutLikes,
       usersWithLikesCount: usersWithLikes.length,
       usersWithoutLikesCount: usersWithoutLikes.length,
+      usersCount: length,
     });
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaRekapLikes: ${err.message}` });

--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -87,7 +87,22 @@ export async function getTiktokRekapKomentar(req, res) {
     );
     const length = Array.isArray(data) ? data.length : 0;
     const chartHeight = Math.max(length * 30, 300);
-    res.json({ success: true, data, chartHeight });
+    const usersWithComments = data
+      .filter((u) => u.jumlah_komentar > 0)
+      .map((u) => u.username);
+    const usersWithoutComments = data
+      .filter((u) => u.jumlah_komentar === 0)
+      .map((u) => u.username);
+    res.json({
+      success: true,
+      data,
+      chartHeight,
+      usersWithComments,
+      usersWithoutComments,
+      usersWithCommentsCount: usersWithComments.length,
+      usersWithoutCommentsCount: usersWithoutComments.length,
+      usersCount: length,
+    });
   } catch (err) {
     const code = err.statusCode || err.response?.status || 500;
     res.status(code).json({ success: false, message: err.message });

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -93,7 +93,8 @@ test('returns user like summaries', async () => {
       usersWithLikes: ['alice', 'charlie'],
       usersWithoutLikes: ['bob'],
       usersWithLikesCount: 2,
-      usersWithoutLikesCount: 1
+      usersWithoutLikesCount: 1,
+      usersCount: 3
     })
   );
 });

--- a/tests/tiktokControllerDateRange.test.js
+++ b/tests/tiktokControllerDateRange.test.js
@@ -83,3 +83,25 @@ test('allows authorized client_id', async () => {
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 
+test('returns user comment summaries with counts', async () => {
+  const rows = [
+    { username: 'alice', jumlah_komentar: 2 },
+    { username: 'bob', jumlah_komentar: 0 },
+    { username: 'charlie', jumlah_komentar: 1 }
+  ];
+  mockGetRekap.mockResolvedValue(rows);
+  const req = { query: { client_id: 'c1' } };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getTiktokRekapKomentar(req, res);
+  expect(json).toHaveBeenCalledWith(
+    expect.objectContaining({
+      usersWithComments: ['alice', 'charlie'],
+      usersWithoutComments: ['bob'],
+      usersWithCommentsCount: 2,
+      usersWithoutCommentsCount: 1,
+      usersCount: 3
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- expose total user counts in Instagram like recap
- include user count breakdowns in TikTok comment recap
- document new `usersCount` field

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40be1152083278b85924ae8c78899