### PR TITLE
Handle duplicate dashboard users by WhatsApp

### DIFF
--- a/src/model/dashboardUserModel.js
+++ b/src/model/dashboardUserModel.js
@@ -21,6 +21,19 @@ export async function findByWhatsApp(wa) {
   return findOneBy('whatsapp', wa);
 }
 
+export async function findAllByWhatsApp(wa) {
+  const res = await query(
+    `SELECT du.*, r.role_name AS role, COALESCE(array_agg(duc.client_id) FILTER (WHERE duc.client_id IS NOT NULL), '{}') AS client_ids
+     FROM dashboard_user du
+     LEFT JOIN roles r ON du.role_id = r.role_id
+     LEFT JOIN dashboard_user_clients duc ON du.dashboard_user_id = duc.dashboard_user_id
+     WHERE du.whatsapp = $1
+     GROUP BY du.dashboard_user_id, r.role_name`,
+    [wa]
+  );
+  return res.rows;
+}
+
 export async function createUser(data) {
   const res = await query(
     `INSERT INTO dashboard_user (dashboard_user_id, username, password_hash, role_id, status, user_id, whatsapp)

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -111,3 +111,34 @@ test('choose_menu uses selected client id', async () => {
   expect(mockGetUsersMissingDataByClient).toHaveBeenCalledWith('C1');
 });
 
+test('choose_dash_user lists and selects dashboard user', async () => {
+  mockFindClientById
+    .mockResolvedValueOnce({ nama: 'Client One' })
+    .mockResolvedValueOnce({ nama: 'Client Two' })
+    .mockResolvedValueOnce({ nama: 'Client Two' });
+  const session = {
+    dash_users: [
+      { role: 'user', client_ids: ['C1'] },
+      { role: 'user', client_ids: ['C2'] },
+    ],
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+
+  await dashRequestHandlers.choose_dash_user(session, chatId, '', waClient);
+  expect(waClient.sendMessage).toHaveBeenCalled();
+  const listMsg = waClient.sendMessage.mock.calls[0][1];
+  expect(listMsg).toContain('1. Client One');
+  expect(listMsg).toContain('2. Client Two');
+
+  waClient.sendMessage.mockClear();
+  const mainSpy = jest
+    .spyOn(dashRequestHandlers, 'main')
+    .mockResolvedValue();
+  await dashRequestHandlers.choose_dash_user(session, chatId, '2', waClient);
+  expect(session.role).toBe('user');
+  expect(session.client_ids).toEqual(['C2']);
+  expect(mainSpy).toHaveBeenCalled();
+  mainSpy.mockRestore();
+});
+


### PR DESCRIPTION
## Summary
- allow dashboard users with duplicate WhatsApp numbers to select their client
- restrict dashrequest access to non-operator roles
- add tests for dashboard user selection

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5538bf58c8327b872544b9e30782f