### PR TITLE
feat: add dashboard recap for user data

### DIFF
--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-const mockGetUsersMissingDataByClient = jest.fn();
+const mockGetUsersSocialByClient = jest.fn();
 const mockAbsensiLink = jest.fn();
 const mockAbsensiLikes = jest.fn();
 const mockAbsensiKomentarInstagram = jest.fn();
@@ -8,7 +8,7 @@ const mockAbsensiKomentar = jest.fn();
 const mockFindClientById = jest.fn();
 
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
-  getUsersMissingDataByClient: mockGetUsersMissingDataByClient,
+  getUsersSocialByClient: mockGetUsersSocialByClient,
 }));
 
 jest.unstable_mockModule(
@@ -97,7 +97,8 @@ test('choose_client selects client and shows menu', async () => {
 });
 
 test('choose_menu uses selected client id', async () => {
-  mockGetUsersMissingDataByClient.mockResolvedValue([]);
+  mockGetUsersSocialByClient.mockResolvedValue([]);
+  mockFindClientById.mockResolvedValue({});
   const session = {
     role: 'user',
     selectedClientId: 'C1',
@@ -108,7 +109,7 @@ test('choose_menu uses selected client id', async () => {
 
   await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
-  expect(mockGetUsersMissingDataByClient).toHaveBeenCalledWith('C1');
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1');
 });
 
 test('choose_dash_user lists and selects dashboard user', async () => {


### PR DESCRIPTION
## Summary
- add query to fetch non-operator users with social usernames
- enhance dashboard menu to report missing Instagram/TikTok usernames per client type
- update dashRequestHandlers tests for new recap flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5722fe3488327b361be15b03edcba