### PR TITLE
refactor: update dash request absensi report format

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -14,7 +14,7 @@ async function formatRekapUserData(clientId) {
   const hari = now.toLocaleDateString("id-ID", { weekday: "long" });
   const tanggal = now.toLocaleDateString("id-ID", {
     day: "2-digit",
-    month: "2-digit",
+    month: "long",
     year: "numeric",
   });
   const jam = now.toLocaleTimeString("id-ID", {
@@ -44,10 +44,10 @@ async function formatRekapUserData(clientId) {
       })
     );
     return (
-      `${salam}\n\n` +
+      `${salam},\n\n` +
       `Mohon ijin Komandan, Melaporkan absensi update data personil ${
         client?.nama || clientId
-      }, pada Hari(${hari}), Tanggal (${tanggal}), jam (${jam}) Wib, sebagai berikut :\n\n` +
+      }, pada Hari ${hari}, Tanggal ${tanggal}, jam ${jam} Wib, sebagai berikut :\n\n` +
       lines.join("\n").trim()
     );
   }
@@ -89,10 +89,10 @@ async function formatRekapUserData(clientId) {
     .join("\n");
 
   return (
-    `${salam}\n\n` +
+    `${salam},\n\n` +
     `Mohon ijin Komandan, Melaporkan absensi update data personil ${
       client?.nama || clientId
-    }, pada Hari(${hari}), Tanggal (${tanggal}), jam (${jam}) Wib, sebagai berikut :\n\n` +
+    }, pada Hari ${hari}, Tanggal ${tanggal}, jam ${jam} Wib, sebagai berikut :\n\n` +
     body
   ).trim();
 }

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -1,5 +1,7 @@
 import { jest } from '@jest/globals';
 
+process.env.TZ = 'Asia/Jakarta';
+
 const mockGetUsersSocialByClient = jest.fn();
 const mockAbsensiLink = jest.fn();
 const mockAbsensiLikes = jest.fn();
@@ -141,5 +143,36 @@ test('choose_dash_user lists and selects dashboard user', async () => {
   expect(session.client_ids).toEqual(['C2']);
   expect(mainSpy).toHaveBeenCalled();
   mainSpy.mockRestore();
+});
+
+test('choose_menu formats directorate report header', async () => {
+  mockGetUsersSocialByClient.mockReset();
+  mockFindClientById.mockReset();
+
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2025-08-20T14:28:00Z'));
+
+  mockGetUsersSocialByClient.mockResolvedValue([]);
+  mockFindClientById.mockResolvedValue({
+    nama: 'DIREKTORAT BINMAS',
+    client_type: 'direktorat',
+  });
+
+  const session = {
+    role: 'user',
+    selectedClientId: 'BINMAS',
+    clientName: 'DIREKTORAT BINMAS',
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+
+  await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
+
+  const msg = waClient.sendMessage.mock.calls[0][1];
+  expect(msg).toBe(
+    'Selamat siang,\n\nMohon ijin Komandan, Melaporkan absensi update data personil DIREKTORAT BINMAS, pada Hari Rabu, Tanggal 20 Agustus 2025, jam 14.28 Wib, sebagai berikut :'
+  );
+
+  jest.useRealTimers();
 });
 


### PR DESCRIPTION
## Summary
- format dash request absensi message with spelled-out month and new wording
- test directorate report header formatting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57cb128408327b80d2d42a56c4881