### PR TITLE
feat: aggregate directorate user updates

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -362,11 +362,16 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
     }
     if (validUsers.length === 1) {
       const du = validUsers[0];
+      const dir = await clientService.findClientById(du.role);
+      const clientIds =
+        dir?.client_type?.toLowerCase() === "direktorat"
+          ? [du.role]
+          : du.client_ids;
       setSession(chatId, {
         menu: "dashrequest",
         step: "main",
         role: du.role,
-        client_ids: du.client_ids,
+        client_ids: clientIds,
       });
       await dashRequestHandlers.main(getSession(chatId), chatId, "", waClient);
       return;


### PR DESCRIPTION
## Summary
- group dashrequest user update reports by client for directorate roles
- support directorate dashboard users by binding role as client and initializing sessions accordingly
- cover directorate aggregations with new tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a58cc3df4c8327a127cd5888b10f6e