### PR TITLE
Filter dash rekap users by role

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -6,9 +6,9 @@ import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
 
-async function formatRekapUserData(clientId) {
+async function formatRekapUserData(clientId, role) {
   const client = await findClientById(clientId);
-  const users = await getUsersSocialByClient(clientId);
+  const users = await getUsersSocialByClient(clientId, role);
   const salam = getGreeting();
   const now = new Date();
   const hari = now.toLocaleDateString("id-ID", { weekday: "long" });
@@ -101,7 +101,7 @@ async function performAction(action, clientId, role, waClient, chatId) {
   let msg = "";
   switch (action) {
     case "1": {
-      msg = await formatRekapUserData(clientId);
+      msg = await formatRekapUserData(clientId, role);
       break;
     }
     case "2":

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -111,7 +111,7 @@ test('choose_menu uses selected client id', async () => {
 
   await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
-  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1');
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1', 'user');
 });
 
 test('choose_dash_user lists and selects dashboard user', async () => {
@@ -169,6 +169,7 @@ test('choose_menu formats directorate report header', async () => {
   await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
   const msg = waClient.sendMessage.mock.calls[0][1];
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('BINMAS', 'user');
   expect(msg).toBe(
     'Selamat siang,\n\nMohon ijin Komandan, Melaporkan absensi update data personil DIREKTORAT BINMAS, pada Hari Rabu, Tanggal 20 Agustus 2025, jam 14.28 Wib, sebagai berikut :'
   );


### PR DESCRIPTION
## Summary
- limit dash rekap to users matching the dashboard user's role
- adjust tests for new role-aware rekap

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a69a123c3c8327932f26511c246cd8