### PR TITLE
Avoid duplicate Google contacts

### DIFF
--- a/docs/google_contacts_integration.md
+++ b/docs/google_contacts_integration.md
@@ -29,7 +29,7 @@ async function addContact() {
 ```
 
 ### Avoiding Duplicates
-`saveContactIfNew(chatId)` checks a local table and Google Contacts before inserting:
+`saveGoogleContact` akan mengecek apakah nomor telepon sudah ada di Google Contacts sebelum menyimpan, sehingga tidak terjadi duplikasi. Untuk validasi tambahan terhadap tabel lokal, gunakan `saveContactIfNew(chatId)`:
 ```javascript
 import { saveContactIfNew } from './src/service/googleContactsService.js';
 

--- a/src/service/googleContactsService.js
+++ b/src/service/googleContactsService.js
@@ -93,6 +93,13 @@ export async function searchByNumbers(auth, numbers = []) {
 }
 
 export async function saveGoogleContact(auth, { name, phone }) {
+  // Hindari duplikasi dengan memeriksa kontak yang sudah ada
+  try {
+    const exists = await searchByNumbers(auth, [phone]);
+    if (exists.includes(phone)) return;
+  } catch (err) {
+    console.error('[GOOGLE CONTACT] duplicate check failed:', err.message);
+  }
   const service = google.people({ version: 'v1', auth });
   await service.people.createContact({
     requestBody: {

--- a/tests/googleContactsService.test.js
+++ b/tests/googleContactsService.test.js
@@ -127,7 +127,7 @@ describe('saveContactIfNew', () => {
 
     await saveContactIfNew('98765@c.us');
 
-    expect(mockSearchContacts).toHaveBeenCalledTimes(1);
+    expect(mockSearchContacts).toHaveBeenCalledTimes(2);
     expect(mockCreateContact).toHaveBeenCalledTimes(1);
     expect(mockQuery).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- prevent duplicate Google contact creation by checking existing numbers
- document and test duplicate-checking behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a05f92e48327b06f313ce10c8da7