### PR TITLE
feat: group ORG dashboard report

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -22,7 +22,8 @@ async function formatRekapUserData(clientId, role) {
     minute: "2-digit",
   });
 
-  if (client?.client_type?.toLowerCase() === "direktorat") {
+  const clientType = client?.client_type?.toLowerCase();
+  if (clientType === "direktorat") {
     const groups = {};
     users.forEach((u) => {
       const cid = u.client_id;
@@ -79,6 +80,28 @@ async function formatRekapUserData(clientId, role) {
       incomplete[div].push(`${nama}, ${missing.join(", ")}`);
     }
   });
+
+  if (clientType === "org") {
+    const completeLines = sortDivisionKeys(Object.keys(complete)).map((d) => {
+      const list = complete[d].join("\n\n");
+      return `SAT ${d.toUpperCase()} (${complete[d].length})\n\n${list}`;
+    });
+    const incompleteLines = sortDivisionKeys(Object.keys(incomplete)).map((d) => {
+      const list = incomplete[d].join("\n\n");
+      return `SAT ${d.toUpperCase()} (${incomplete[d].length})\n\n${list}`;
+    });
+    const sections = [];
+    if (completeLines.length) sections.push(`Sudah Lengkap :\n\n${completeLines.join("\n\n")}`);
+    if (incompleteLines.length) sections.push(`Belum Lengkap:\n\n${incompleteLines.join("\n\n")}`);
+    const body = sections.join("\n\n");
+    return (
+      `${salam},\n\n` +
+      `Mohon ijin Komandan, melaporkan absensi update data personil ${
+        (client?.nama || clientId).toUpperCase()
+      } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:\n\n` +
+      body
+    ).trim();
+  }
 
   const completeLines = sortDivisionKeys(Object.keys(complete)).map((d) => {
     const list = complete[d].join("\n\n");

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -269,3 +269,36 @@ test('directorate report orders directorate first with numbering', async () => {
   jest.useRealTimers();
 });
 
+test('choose_menu formats org report with separate sections', async () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2025-08-21T05:38:00Z'));
+
+  mockGetUsersSocialByClient.mockResolvedValue([
+    { divisi: 'BINMAS', title: 'BRIPKA', nama: 'RIZQA FP', insta: 'a', tiktok: 'b' },
+    { divisi: 'BINMAS', title: 'BRIPKA', nama: 'RIZQI ALFA', insta: null, tiktok: null },
+  ]);
+  mockFindClientById.mockResolvedValue({
+    nama: 'POLRES BOJONEGORO',
+    client_type: 'org',
+  });
+
+  const session = {
+    role: 'user',
+    selectedClientId: 'POLRES',
+    clientName: 'POLRES BOJONEGORO',
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+
+  await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
+
+  const msg = waClient.sendMessage.mock.calls[0][1];
+  expect(msg).toContain('Sudah Lengkap :');
+  expect(msg).toContain('Belum Lengkap:');
+  expect(msg).toContain('SAT BINMAS (1)');
+  expect(msg).toContain('BRIPKA RIZQA FP');
+  expect(msg).toContain('BRIPKA RIZQI ALFA, Instagram kosong, TikTok kosong');
+
+  jest.useRealTimers();
+});
+


### PR DESCRIPTION
## Summary
- format dashboard user report for ORG clients into "Sudah Lengkap" and "Belum Lengkap" sections
- test ORG dashboard formatting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6b24083a08327888939ead80f3814