### PR TITLE
Fix dash request recaps to filter by client ID

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -6,9 +6,9 @@ import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
 
-async function formatRekapUserData(clientId, role) {
+async function formatRekapUserData(clientId) {
   const client = await findClientById(clientId);
-  const users = await getUsersSocialByClient(clientId, role);
+  const users = await getUsersSocialByClient(clientId);
   const salam = getGreeting();
   const now = new Date();
   const hari = now.toLocaleDateString("id-ID", { weekday: "long" });
@@ -123,37 +123,33 @@ async function formatRekapUserData(clientId, role) {
   ).trim();
 }
 
-async function performAction(action, clientId, role, waClient, chatId) {
+async function performAction(action, clientId, waClient, chatId) {
   let msg = "";
   switch (action) {
     case "1": {
-      msg = await formatRekapUserData(clientId, role);
+      msg = await formatRekapUserData(clientId);
       break;
     }
     case "2":
       msg = await absensiLink(clientId, {
-        roleFlag: role,
         clientFilter: clientId,
         mode: "all",
       });
       break;
     case "3":
       msg = await absensiLikes(clientId, {
-        roleFlag: role,
         clientFilter: clientId,
         mode: "all",
       });
       break;
     case "4":
       msg = await absensiKomentarInstagram(clientId, {
-        roleFlag: role,
         clientFilter: clientId,
         mode: "all",
       });
       break;
     case "5":
       msg = await absensiKomentar(clientId, {
-        roleFlag: role,
         clientFilter: clientId,
         mode: "all",
       });
@@ -298,7 +294,7 @@ export const dashRequestHandlers = {
       await dashRequestHandlers.main(session, chatId, "", waClient);
       return;
     }
-    await performAction(choice, clientId, session.role, waClient, chatId);
+    await performAction(choice, clientId, waClient, chatId);
     session.step = "main";
     await dashRequestHandlers.main(session, chatId, "", waClient);
   },
@@ -306,7 +302,7 @@ export const dashRequestHandlers = {
   async ask_client(session, chatId, text, waClient) {
     const clientId = text.trim().toUpperCase();
     const action = session.pendingAction;
-    await performAction(action, clientId, session.role, waClient, chatId);
+    await performAction(action, clientId, waClient, chatId);
     delete session.pendingAction;
     session.step = "main";
     await dashRequestHandlers.main(session, chatId, "", waClient);

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -111,7 +111,7 @@ test('choose_menu uses selected client id', async () => {
 
   await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
-  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1', 'user');
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1');
 });
 
 test('choose_dash_user lists and selects dashboard user', async () => {
@@ -169,7 +169,7 @@ test('choose_menu formats directorate report header', async () => {
   await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
   const msg = waClient.sendMessage.mock.calls[0][1];
-  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('BINMAS', 'user');
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('BINMAS');
   expect(msg).toBe(
     'Selamat siang,\n\nMohon ijin Komandan, melaporkan absensi update data personil DIREKTORAT BINMAS pada hari Rabu, 20 Agustus 2025, pukul 14.28 WIB, sebagai berikut:'
   );


### PR DESCRIPTION
## Summary
- Ensure dash request recaps fetch users by client ID instead of role
- Remove role-based filtering from dash request actions
- Align tests with client-based filtering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c105cf88832792dc034105dc7f93