### PR TITLE
Forward role flag to dashboard rekap handlers

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -123,7 +123,7 @@ async function formatRekapUserData(clientId) {
   ).trim();
 }
 
-async function performAction(action, clientId, waClient, chatId) {
+async function performAction(action, clientId, waClient, chatId, role) {
   let msg = "";
   switch (action) {
     case "1": {
@@ -134,24 +134,28 @@ async function performAction(action, clientId, waClient, chatId) {
       msg = await absensiLink(clientId, {
         clientFilter: clientId,
         mode: "all",
+        roleFlag: role,
       });
       break;
     case "3":
       msg = await absensiLikes(clientId, {
         clientFilter: clientId,
         mode: "all",
+        roleFlag: role,
       });
       break;
     case "4":
       msg = await absensiKomentarInstagram(clientId, {
         clientFilter: clientId,
         mode: "all",
+        roleFlag: role,
       });
       break;
     case "5":
       msg = await absensiKomentar(clientId, {
         clientFilter: clientId,
         mode: "all",
+        roleFlag: role,
       });
       break;
     default:
@@ -294,7 +298,7 @@ export const dashRequestHandlers = {
       await dashRequestHandlers.main(session, chatId, "", waClient);
       return;
     }
-    await performAction(choice, clientId, waClient, chatId);
+    await performAction(choice, clientId, waClient, chatId, session.role);
     session.step = "main";
     await dashRequestHandlers.main(session, chatId, "", waClient);
   },
@@ -302,7 +306,7 @@ export const dashRequestHandlers = {
   async ask_client(session, chatId, text, waClient) {
     const clientId = text.trim().toUpperCase();
     const action = session.pendingAction;
-    await performAction(action, clientId, waClient, chatId);
+    await performAction(action, clientId, waClient, chatId, session.role);
     delete session.pendingAction;
     session.step = "main";
     await dashRequestHandlers.main(session, chatId, "", waClient);

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -114,6 +114,35 @@ test('choose_menu uses selected client id', async () => {
   expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1');
 });
 
+test.each([
+  ['2', mockAbsensiLink],
+  ['3', mockAbsensiLikes],
+  ['4', mockAbsensiKomentarInstagram],
+  ['5', mockAbsensiKomentar],
+])('choose_menu forwards roleFlag to rekap functions', async (choice, handlerMock) => {
+  handlerMock.mockResolvedValue('ok');
+  const session = {
+    role: 'DITBINMAS',
+    selectedClientId: 'C1',
+    clientName: 'Client One',
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+  const mainSpy = jest
+    .spyOn(dashRequestHandlers, 'main')
+    .mockResolvedValue();
+
+  await dashRequestHandlers.choose_menu(session, chatId, choice, waClient);
+
+  expect(handlerMock).toHaveBeenCalledWith('C1', {
+    clientFilter: 'C1',
+    mode: 'all',
+    roleFlag: 'DITBINMAS',
+  });
+
+  mainSpy.mockRestore();
+});
+
 test('choose_dash_user lists and selects dashboard user', async () => {
   mockFindClientById
     .mockResolvedValueOnce({ nama: 'Client One' })


### PR DESCRIPTION
## Summary
- include `role` param in `performAction` and propagate as `roleFlag`
- pass `session.role` when invoking dashboard actions
- test that dashboard rekap functions receive `roleFlag`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ecd96a80832783c57530b53463d6