### PR TITLE
Use dashboard user client IDs for dash request sessions

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -362,16 +362,11 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
     }
     if (validUsers.length === 1) {
       const du = validUsers[0];
-      const dir = await clientService.findClientById(du.role);
-      const clientIds =
-        dir?.client_type?.toLowerCase() === "direktorat"
-          ? [du.role]
-          : du.client_ids;
       setSession(chatId, {
         menu: "dashrequest",
         step: "main",
         role: du.role,
-        client_ids: clientIds,
+        client_ids: du.client_ids,
       });
       await dashRequestHandlers.main(getSession(chatId), chatId, "", waClient);
       return;


### PR DESCRIPTION
## Summary
- remove `clientService.findClientById` from dashrequest handling
- use dashboard user's stored role and `client_ids` when initializing dashrequest session

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f31339008327bd1aaecd27b29ae5