### PR TITLE
Ensure dashboard role forwarding and roleFlag filtering tests

### DIFF
--- a/docs/roleToClientMapping.md
+++ b/docs/roleToClientMapping.md
@@ -1,0 +1,18 @@
+# Role to Client Behavior
+
+This guide outlines how session roles map to client data and how the `roleFlag` option scopes dashboard reports.
+
+## Roles
+
+- **admin** – unrestricted; can request data for any client. Rekap handlers receive `roleFlag: 'admin'` and treat it as unfiltered access.
+- **Directorate roles** (e.g. `DITBINMAS`, `DITLANTAS`, `BIDHUMAS`) – `session.role` equals the directorate ID. Rekap handlers aggregate across subordinate clients and use `roleFlag` to query with `getUsersByDirektorat`.
+- **Client roles** – regular users tied to specific clients. Their `session.role` is forwarded as `roleFlag` so rekap handlers call `getUsersByClient(clientId, roleFlag)` and limit results to that role.
+
+## Dashboard flow
+
+1. `dashRequestHandlers` stores the current role on `session.role`.
+2. `performAction` passes this value as `roleFlag` to the selected rekap handler.
+3. Rekap handlers use `roleFlag` to filter users: either by client (`getUsersByClient`) or directorate (`getUsersByDirektorat`).
+4. If `session.role` is missing, the handlers fall back to `session.user.role` ensuring accurate filtering.
+
+Maintaining this mapping guarantees that each dashboard user sees only the content permitted for their role.

--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -123,7 +123,7 @@ async function formatRekapUserData(clientId) {
   ).trim();
 }
 
-async function performAction(action, clientId, waClient, chatId, role) {
+async function performAction(action, clientId, waClient, chatId, roleFlag) {
   let msg = "";
   switch (action) {
     case "1": {
@@ -134,28 +134,28 @@ async function performAction(action, clientId, waClient, chatId, role) {
       msg = await absensiLink(clientId, {
         clientFilter: clientId,
         mode: "all",
-        roleFlag: role,
+        roleFlag,
       });
       break;
     case "3":
       msg = await absensiLikes(clientId, {
         clientFilter: clientId,
         mode: "all",
-        roleFlag: role,
+        roleFlag,
       });
       break;
     case "4":
       msg = await absensiKomentarInstagram(clientId, {
         clientFilter: clientId,
         mode: "all",
-        roleFlag: role,
+        roleFlag,
       });
       break;
     case "5":
       msg = await absensiKomentar(clientId, {
         clientFilter: clientId,
         mode: "all",
-        roleFlag: role,
+        roleFlag,
       });
       break;
     default:
@@ -298,7 +298,13 @@ export const dashRequestHandlers = {
       await dashRequestHandlers.main(session, chatId, "", waClient);
       return;
     }
-    await performAction(choice, clientId, waClient, chatId, session.role);
+    await performAction(
+      choice,
+      clientId,
+      waClient,
+      chatId,
+      session.role || session.user?.role
+    );
     session.step = "main";
     await dashRequestHandlers.main(session, chatId, "", waClient);
   },
@@ -306,7 +312,13 @@ export const dashRequestHandlers = {
   async ask_client(session, chatId, text, waClient) {
     const clientId = text.trim().toUpperCase();
     const action = session.pendingAction;
-    await performAction(action, clientId, waClient, chatId, session.role);
+    await performAction(
+      action,
+      clientId,
+      waClient,
+      chatId,
+      session.role || session.user?.role
+    );
     delete session.pendingAction;
     session.step = "main";
     await dashRequestHandlers.main(session, chatId, "", waClient);

--- a/tests/absensiKomentarInstagramRoleFlag.test.js
+++ b/tests/absensiKomentarInstagramRoleFlag.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByClient = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: mockGetUsersByClient,
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+}));
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+
+let absensiKomentarInstagram;
+
+beforeAll(async () => {
+  ({ absensiKomentarInstagram } = await import('../src/handler/fetchabsensi/insta/absensiKomentarInstagram.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('filters users by roleFlag when provided', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC' }] });
+  mockGetUsersByClient.mockResolvedValueOnce([]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
+
+  await absensiKomentarInstagram('POLRES', { roleFlag: 'ditbinmas' });
+
+  expect(mockGetUsersByClient).toHaveBeenCalledWith('POLRES', 'ditbinmas');
+  expect(mockGetUsersByDirektorat).not.toHaveBeenCalled();
+});

--- a/tests/absensiKomentarTiktokRoleFlag.test.js
+++ b/tests/absensiKomentarTiktokRoleFlag.test.js
@@ -1,0 +1,44 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByClient = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetPostsTodayByClient = jest.fn();
+const mockGetCommentsByVideoId = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: mockGetUsersByClient,
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+}));
+jest.unstable_mockModule('../src/model/tiktokPostModel.js', () => ({
+  getPostsTodayByClient: mockGetPostsTodayByClient,
+}));
+jest.unstable_mockModule('../src/model/tiktokCommentModel.js', () => ({
+  getCommentsByVideoId: mockGetCommentsByVideoId,
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let absensiKomentar;
+
+beforeAll(async () => {
+  ({ absensiKomentar } = await import('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('filters users by roleFlag when provided', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_tiktok: '@abc' }] });
+  mockGetUsersByClient.mockResolvedValueOnce([]);
+  mockGetPostsTodayByClient.mockResolvedValueOnce([]);
+
+  await absensiKomentar('POLRES', { roleFlag: 'ditbinmas' });
+
+  expect(mockGetUsersByClient).toHaveBeenCalledWith('POLRES', 'ditbinmas');
+  expect(mockGetUsersByDirektorat).not.toHaveBeenCalled();
+});

--- a/tests/absensiLinkRoleFlag.test.js
+++ b/tests/absensiLinkRoleFlag.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByClient = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+const mockGetReportsTodayByClient = jest.fn();
+const mockGetReportsTodayByShortcode = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: mockGetUsersByClient,
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+}));
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+jest.unstable_mockModule('../src/model/linkReportModel.js', () => ({
+  getReportsTodayByClient: mockGetReportsTodayByClient,
+  getReportsTodayByShortcode: mockGetReportsTodayByShortcode,
+}));
+
+let absensiLink;
+
+beforeAll(async () => {
+  ({ absensiLink } = await import('../src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('filters users by roleFlag when provided', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_type: 'instansi' }] });
+  mockGetUsersByClient.mockResolvedValueOnce([]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
+
+  await absensiLink('POLRES', { roleFlag: 'ditbinmas' });
+
+  expect(mockGetUsersByClient).toHaveBeenCalledWith('POLRES', 'ditbinmas');
+  expect(mockGetUsersByDirektorat).not.toHaveBeenCalled();
+});

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -143,6 +143,52 @@ test.each([
   mainSpy.mockRestore();
 });
 
+test('ask_client forwards session role to rekap functions', async () => {
+  mockAbsensiLink.mockResolvedValue('ok');
+  const session = {
+    role: 'DITBINMAS',
+    pendingAction: '2',
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+  const mainSpy = jest
+    .spyOn(dashRequestHandlers, 'main')
+    .mockResolvedValue();
+
+  await dashRequestHandlers.ask_client(session, chatId, 'C1', waClient);
+
+  expect(mockAbsensiLink).toHaveBeenCalledWith('C1', {
+    clientFilter: 'C1',
+    mode: 'all',
+    roleFlag: 'DITBINMAS',
+  });
+
+  mainSpy.mockRestore();
+});
+
+test('ask_client uses nested user role when session.role missing', async () => {
+  mockAbsensiLink.mockResolvedValue('ok');
+  const session = {
+    user: { role: 'DITBINMAS' },
+    pendingAction: '2',
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+  const mainSpy = jest
+    .spyOn(dashRequestHandlers, 'main')
+    .mockResolvedValue();
+
+  await dashRequestHandlers.ask_client(session, chatId, 'C1', waClient);
+
+  expect(mockAbsensiLink).toHaveBeenCalledWith('C1', {
+    clientFilter: 'C1',
+    mode: 'all',
+    roleFlag: 'DITBINMAS',
+  });
+
+  mainSpy.mockRestore();
+});
+
 test('choose_dash_user lists and selects dashboard user', async () => {
   mockFindClientById
     .mockResolvedValueOnce({ nama: 'Client One' })


### PR DESCRIPTION
## Summary
- forward `session.role` (or nested `session.user.role`) to `performAction` so rekap handlers receive correct role
- add unit tests verifying absensiLink, absensiKomentarInstagram, and absensiKomentar honor the passed `roleFlag`
- document role-to-client behavior for maintainers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f5dd066c83278fe7ac3a0b27869a