### PR TITLE
feat: add dashrequest link recap

### DIFF
--- a/src/handler/fetchabsensi/link/rekapLink.js
+++ b/src/handler/fetchabsensi/link/rekapLink.js
@@ -1,0 +1,60 @@
+import { query } from "../../../db/index.js";
+import { getShortcodesTodayByClient } from "../../../model/instaPostModel.js";
+import { getReportsTodayByClient } from "../../../model/linkReportModel.js";
+import { hariIndo } from "../../../utils/constants.js";
+import { getGreeting } from "../../../utils/utilsHelper.js";
+
+async function getClientName(clientId) {
+  const { rows } = await query(
+    "SELECT nama FROM clients WHERE client_id=$1 LIMIT 1",
+    [clientId]
+  );
+  return rows[0]?.nama || clientId;
+}
+
+export async function rekapLink(clientId) {
+  const reports = await getReportsTodayByClient(clientId);
+  if (!reports || reports.length === 0) {
+    return `Tidak ada laporan link hari ini untuk client *${clientId}*.`;
+  }
+  const shortcodes = await getShortcodesTodayByClient(clientId);
+  const list = { facebook: [], instagram: [], twitter: [], tiktok: [], youtube: [] };
+  const users = new Set();
+  reports.forEach((r) => {
+    users.add(r.user_id);
+    if (r.facebook_link) list.facebook.push(r.facebook_link);
+    if (r.instagram_link) list.instagram.push(r.instagram_link);
+    if (r.twitter_link) list.twitter.push(r.twitter_link);
+    if (r.tiktok_link) list.tiktok.push(r.tiktok_link);
+    if (r.youtube_link) list.youtube.push(r.youtube_link);
+  });
+  const totalLinks =
+    list.facebook.length +
+    list.instagram.length +
+    list.twitter.length +
+    list.tiktok.length +
+    list.youtube.length;
+  const now = new Date();
+  const hari = hariIndo[now.getDay()];
+  const tanggal = now.toLocaleDateString("id-ID");
+  const jam = now.toLocaleTimeString("id-ID", { hour12: false });
+  const salam = getGreeting();
+  const clientName = await getClientName(clientId);
+  const kontenLinks = shortcodes.map((sc) => `https://www.instagram.com/p/${sc}`);
+  let msg = `${salam}\n\n`;
+  msg += `Mohon Ijin Melaporkan Pelaksanaan Tugas Amplifikasi *${clientName}* pada hari :\n`;
+  msg += `Hari : ${hari}\n`;
+  msg += `Tanggal : ${tanggal}\n`;
+  msg += `Pukul : ${jam}\n\n`;
+  msg += `Jumlah Konten Resmi Hari ini : ${shortcodes.length}\n`;
+  msg += kontenLinks.length ? `${kontenLinks.join("\n")}\n\n` : "-\n\n";
+  msg += `Jumlah Personil yang melaksnakan : ${users.size}\n`;
+  msg += `Jumlah Total Link dari 5 Platform Sosial Media : ${totalLinks}\n\n`;
+  msg += `Link Sebagai Berikut :\n`;
+  msg += `Facebook (${list.facebook.length}):\n${list.facebook.join("\n") || "-"}`;
+  msg += `\n\nInstagram (${list.instagram.length}):\n${list.instagram.join("\n") || "-"}`;
+  msg += `\n\nTwitter (${list.twitter.length}):\n${list.twitter.join("\n") || "-"}`;
+  msg += `\n\nTikTok (${list.tiktok.length}):\n${list.tiktok.join("\n") || "-"}`;
+  msg += `\n\nYoutube (${list.youtube.length}):\n${list.youtube.join("\n") || "-"}`;
+  return msg.trim();
+}

--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -1,5 +1,5 @@
 import { getUsersSocialByClient } from "../../model/userModel.js";
-import { absensiLink } from "../fetchabsensi/link/absensiLinkAmplifikasi.js";
+import { rekapLink } from "../fetchabsensi/link/rekapLink.js";
 import { absensiLikes } from "../fetchabsensi/insta/absensiLikesInsta.js";
 import { absensiKomentarInstagram } from "../fetchabsensi/insta/absensiKomentarInstagram.js";
 import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
@@ -131,11 +131,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag) {
       break;
     }
     case "2":
-      msg = await absensiLink(clientId, {
-        clientFilter: clientId,
-        mode: "all",
-        roleFlag,
-      });
+      msg = await rekapLink(clientId);
       break;
     case "3":
       msg = await absensiLikes(clientId, {

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -370,11 +370,20 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
     }
     if (validUsers.length === 1) {
       const du = validUsers[0];
+      let clientIds = du.client_ids;
+      try {
+        const roleClient = await clientService.findClientById(du.role);
+        if (roleClient?.client_type?.toLowerCase() === "direktorat") {
+          clientIds = [du.role];
+        }
+      } catch (e) {
+        // ignore lookup errors and fallback to dashboard user client_ids
+      }
       setSession(chatId, {
         menu: "dashrequest",
         step: "main",
         role: du.role,
-        client_ids: du.client_ids,
+        client_ids: clientIds,
       });
       await dashRequestHandlers.main(getSession(chatId), chatId, "", waClient);
       return;


### PR DESCRIPTION
## Summary
- map directorate roles to their own client IDs when entering dashrequest
- implement link recap handler grouping links by platform and counting unique personnel
- wire dashrequest option to new recap handler and update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6fb9626988327814b84f0785690b2