### PR TITLE
Use role-based client ID for dashrequest recaps

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -124,6 +124,7 @@ async function formatRekapUserData(clientId) {
 }
 
 async function performAction(action, clientId, waClient, chatId, roleFlag) {
+  const directorateRoles = ["ditbinmas", "ditlantas", "bidhumas"];
   let msg = "";
   switch (action) {
     case "1": {
@@ -133,27 +134,39 @@ async function performAction(action, clientId, waClient, chatId, roleFlag) {
     case "2":
       msg = await rekapLink(clientId);
       break;
-    case "3":
-      msg = await absensiLikes(clientId, {
-        clientFilter: clientId,
+    case "3": {
+      const targetId = directorateRoles.includes((roleFlag || "").toLowerCase())
+        ? roleFlag
+        : clientId;
+      msg = await absensiLikes(targetId, {
+        clientFilter: targetId,
         mode: "all",
         roleFlag,
       });
       break;
-    case "4":
-      msg = await absensiKomentarInstagram(clientId, {
-        clientFilter: clientId,
+    }
+    case "4": {
+      const targetId = directorateRoles.includes((roleFlag || "").toLowerCase())
+        ? roleFlag
+        : clientId;
+      msg = await absensiKomentarInstagram(targetId, {
+        clientFilter: targetId,
         mode: "all",
         roleFlag,
       });
       break;
-    case "5":
-      msg = await absensiKomentar(clientId, {
-        clientFilter: clientId,
+    }
+    case "5": {
+      const targetId = directorateRoles.includes((roleFlag || "").toLowerCase())
+        ? roleFlag
+        : clientId;
+      msg = await absensiKomentar(targetId, {
+        clientFilter: targetId,
         mode: "all",
         roleFlag,
       });
       break;
+    }
     default:
       msg = "Menu tidak dikenal.";
   }
@@ -166,9 +179,15 @@ export const dashRequestHandlers = {
     if (!text) {
       const list = await Promise.all(
         dashUsers.map(async (u, idx) => {
+          const directorateRoles = ["ditbinmas", "ditlantas", "bidhumas"];
           let cid = u.client_ids[0];
           let c = cid ? await findClientById(cid) : null;
-          if (!cid || c?.client_type?.toLowerCase() === "direktorat") {
+          if (
+            !cid ||
+            !c ||
+            c?.client_type?.toLowerCase() === "direktorat" ||
+            directorateRoles.includes(u.role.toLowerCase())
+          ) {
             cid = u.role;
             c = await findClientById(cid);
           }
@@ -192,8 +211,12 @@ export const dashRequestHandlers = {
     }
     const chosen = dashUsers[idx];
     session.role = chosen.role;
-    const dir = await findClientById(chosen.role);
-    if (dir?.client_type?.toLowerCase() === "direktorat") {
+    const directorateRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+    const dir = await findClientById(chosen.role.toUpperCase());
+    if (
+      dir?.client_type?.toLowerCase() === "direktorat" ||
+      directorateRoles.includes(chosen.role.toLowerCase())
+    ) {
       session.client_ids = [chosen.role];
     } else {
       session.client_ids = chosen.client_ids;

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -133,8 +133,8 @@ test.each([
 
   await dashRequestHandlers.choose_menu(session, chatId, choice, waClient);
 
-  expect(handlerMock).toHaveBeenCalledWith('C1', {
-    clientFilter: 'C1',
+  expect(handlerMock).toHaveBeenCalledWith('DITBINMAS', {
+    clientFilter: 'DITBINMAS',
     mode: 'all',
     roleFlag: 'DITBINMAS',
   });
@@ -195,8 +195,8 @@ test('ask_client forwards session role to handlers needing role', async () => {
 
   await dashRequestHandlers.ask_client(session, chatId, 'C1', waClient);
 
-  expect(mockAbsensiLikes).toHaveBeenCalledWith('C1', {
-    clientFilter: 'C1',
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
+    clientFilter: 'DITBINMAS',
     mode: 'all',
     roleFlag: 'DITBINMAS',
   });
@@ -218,8 +218,8 @@ test('ask_client uses nested user role when session.role missing', async () => {
 
   await dashRequestHandlers.ask_client(session, chatId, 'C1', waClient);
 
-  expect(mockAbsensiLikes).toHaveBeenCalledWith('C1', {
-    clientFilter: 'C1',
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
+    clientFilter: 'DITBINMAS',
     mode: 'all',
     roleFlag: 'DITBINMAS',
   });
@@ -304,6 +304,21 @@ test('choose_dash_user uses role as client when directorate', async () => {
     .mockResolvedValue();
   await dashRequestHandlers.choose_dash_user(session, chatId, '1', waClient);
   expect(session.client_ids).toEqual(['DITA']);
+  mainSpy.mockRestore();
+});
+
+test('choose_dash_user falls back to role when client not found', async () => {
+  mockFindClientById.mockResolvedValueOnce(null);
+  const session = {
+    dash_users: [{ role: 'DITBINMAS', client_ids: ['C1'] }],
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+  const mainSpy = jest
+    .spyOn(dashRequestHandlers, 'main')
+    .mockResolvedValue();
+  await dashRequestHandlers.choose_dash_user(session, chatId, '1', waClient);
+  expect(session.client_ids).toEqual(['DITBINMAS']);
   mainSpy.mockRestore();
 });
 


### PR DESCRIPTION
## Summary
- ensure dashrequest recaps for likes, comments, and TikTok use directorate client IDs when the user role matches a directorate
- fall back to role-based client IDs when selecting dashboard users lacking a client record
- update tests for directorate handling and add coverage for missing client scenario

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70b789e748327a833b1383d4d610a