### PR TITLE
feat: support directorate client filtering

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -370,11 +370,11 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
     }
     if (validUsers.length === 1) {
       const du = validUsers[0];
-      let clientIds = du.client_ids;
+      let dirClientId = null;
       try {
         const roleClient = await clientService.findClientById(du.role);
         if (roleClient?.client_type?.toLowerCase() === "direktorat") {
-          clientIds = [du.role];
+          dirClientId = du.role;
         }
       } catch (e) {
         // ignore lookup errors and fallback to dashboard user client_ids
@@ -383,7 +383,8 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
         menu: "dashrequest",
         step: "main",
         role: du.role,
-        client_ids: clientIds,
+        client_ids: du.client_ids,
+        dir_client_id: dirClientId,
       });
       await dashRequestHandlers.main(getSession(chatId), chatId, "", waClient);
       return;

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -142,6 +142,28 @@ test.each([
   mainSpy.mockRestore();
 });
 
+test('choose_menu uses directorate id for task and client id for filter', async () => {
+  mockAbsensiLikes.mockResolvedValue('ok');
+  const session = {
+    role: 'DITBINMAS',
+    selectedClientId: 'C1',
+    clientName: 'Client One',
+    dir_client_id: 'DITBINMAS',
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+  const mainSpy = jest
+    .spyOn(dashRequestHandlers, 'main')
+    .mockResolvedValue();
+  await dashRequestHandlers.choose_menu(session, chatId, '3', waClient);
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
+    clientFilter: 'C1',
+    mode: 'all',
+    roleFlag: 'DITBINMAS',
+  });
+  mainSpy.mockRestore();
+});
+
 test('choose_menu calls rekapLink with clientId only', async () => {
   mockRekapLink.mockResolvedValue('ok');
   const session = {
@@ -254,6 +276,7 @@ test('choose_dash_user lists and selects dashboard user', async () => {
   await dashRequestHandlers.choose_dash_user(session, chatId, '2', waClient);
   expect(session.role).toBe('user');
   expect(session.client_ids).toEqual(['C2']);
+  expect(session.dir_client_id).toBeNull();
   expect(mainSpy).toHaveBeenCalled();
   mainSpy.mockRestore();
 });
@@ -303,7 +326,8 @@ test('choose_dash_user uses role as client when directorate', async () => {
     .spyOn(dashRequestHandlers, 'main')
     .mockResolvedValue();
   await dashRequestHandlers.choose_dash_user(session, chatId, '1', waClient);
-  expect(session.client_ids).toEqual(['DITA']);
+  expect(session.client_ids).toEqual(['C1', 'C2']);
+  expect(session.dir_client_id).toBe('DITA');
   mainSpy.mockRestore();
 });
 


### PR DESCRIPTION
## Summary
- keep dashboard user's client list while tracking directorate client id
- route dash request actions with separate task and attendance client ids
- cover directorate filtering in dash request handler tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f8750fe08327ad1b76210ebe9377