### PR TITLE
Optimize link report creation queries

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -1,33 +1,15 @@
 import { query } from '../repository/db.js';
-import { findPostByShortcode } from './instaPostModel.js';
 
 export async function createLinkReport(data) {
-  const exists = await findPostByShortcode(data.shortcode);
-  if (!exists) {
-    const err = new Error('shortcode not found');
-    err.statusCode = 400;
-    throw err;
-  }
-
-  const postDate = new Date(exists.created_at).toLocaleDateString('en-CA', {
-    timeZone: 'Asia/Jakarta'
-  });
-  const today = new Date().toLocaleDateString('en-CA', {
-    timeZone: 'Asia/Jakarta'
-  });
-  if (postDate !== today) {
-    const err = new Error('reports can only be created for today\'s posts');
-    err.statusCode = 400;
-    throw err;
-  }
-
-  data.created_at = exists.created_at;
-
   const res = await query(
     `INSERT INTO link_report (
         shortcode, user_id, instagram_link, facebook_link,
         twitter_link, tiktok_link, youtube_link, created_at
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7, COALESCE($8, NOW()))
+     )
+     SELECT p.shortcode, $2, $3, $4, $5, $6, $7, p.created_at
+     FROM insta_post p
+     WHERE p.shortcode = $1
+       AND p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
      ON CONFLICT (shortcode, user_id) DO UPDATE
      SET instagram_link = EXCLUDED.instagram_link,
          facebook_link = EXCLUDED.facebook_link,
@@ -43,10 +25,16 @@ export async function createLinkReport(data) {
       data.facebook_link || null,
       data.twitter_link || null,
       data.tiktok_link || null,
-      data.youtube_link || null,
-      data.created_at || null
+      data.youtube_link || null
     ]
   );
+
+  if (res.rows.length === 0) {
+    const err = new Error('shortcode not found or not from today');
+    err.statusCode = 400;
+    throw err;
+  }
+
   return res.rows[0];
 }
 

--- a/tests/linkReportKhususModel.test.js
+++ b/tests/linkReportKhususModel.test.js
@@ -1,13 +1,9 @@
 import { jest } from '@jest/globals';
 
 const mockQuery = jest.fn();
-const mockFindPost = jest.fn();
 
 jest.unstable_mockModule('../src/repository/db.js', () => ({
   query: mockQuery
-}));
-jest.unstable_mockModule('../src/model/instaPostKhususModel.js', () => ({
-  findPostByShortcode: mockFindPost
 }));
 
 let createLinkReport;
@@ -27,27 +23,25 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockQuery.mockReset();
-  mockFindPost.mockReset();
 });
 
 test('createLinkReport inserts row', async () => {
-  mockFindPost.mockResolvedValueOnce({ shortcode: 'abc' });
   mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc' }] });
   const data = { shortcode: 'abc', user_id: '1', instagram_link: 'a' };
   const res = await createLinkReport(data);
   expect(res).toEqual({ shortcode: 'abc' });
-  expect(mockFindPost).toHaveBeenCalledWith('abc');
   expect(mockQuery).toHaveBeenCalledWith(
-    expect.stringContaining('ON CONFLICT (shortcode, user_id)'),
-    ['abc', '1', 'a', null, null, null, null, null]
+    expect.stringContaining('FROM insta_post_khusus p'),
+    ['abc', '1', 'a', null, null, null, null]
   );
 });
 
-test('createLinkReport throws if post missing', async () => {
-  mockFindPost.mockResolvedValueOnce(null);
-  await expect(createLinkReport({ shortcode: 'xyz' })).rejects.toThrow('shortcode not found');
-  expect(mockFindPost).toHaveBeenCalledWith('xyz');
-  expect(mockQuery).not.toHaveBeenCalled();
+test('createLinkReport throws when shortcode missing or not today', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await expect(createLinkReport({ shortcode: 'xyz' })).rejects.toThrow(
+    'shortcode not found or not from today'
+  );
+  expect(mockQuery).toHaveBeenCalled();
 });
 
 test('getLinkReports joins with insta_post_khusus', async () => {


### PR DESCRIPTION
## Summary
- streamline link report creation by inserting with SELECT and ON CONFLICT, eliminating pre-checks
- apply same approach for khusus reports
- adjust tests for consolidated insert logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a913f09bb08327a99a13910f26e0ef