### PR TITLE
Prevent duplicate link reports within two days

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -1,6 +1,39 @@
 import { query } from '../repository/db.js';
 
+export async function hasRecentTask(shortcode, user_id) {
+  const res = await query(
+    `SELECT 1 FROM tasks
+     WHERE shortcode = $1
+       AND user_id IS NOT DISTINCT FROM $2
+       AND created_at >= NOW() - INTERVAL '2 days'
+     LIMIT 1`,
+    [shortcode, user_id]
+  );
+  return res.rows.length > 0;
+}
+
+export async function hasRecentLinkReport(shortcode, user_id) {
+  const res = await query(
+    `SELECT 1 FROM link_report
+     WHERE shortcode = $1
+       AND user_id IS NOT DISTINCT FROM $2
+       AND created_at >= NOW() - INTERVAL '2 days'
+     LIMIT 1`,
+    [shortcode, user_id]
+  );
+  return res.rows.length > 0;
+}
+
 export async function createLinkReport(data) {
+  if (
+    (await hasRecentTask(data.shortcode, data.user_id || null)) ||
+    (await hasRecentLinkReport(data.shortcode, data.user_id || null))
+  ) {
+    const err = new Error('duplicate report/task in last two days');
+    err.statusCode = 400;
+    throw err;
+  }
+
   const res = await query(
     `INSERT INTO link_report (
         shortcode, user_id, instagram_link, facebook_link,

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -34,22 +34,69 @@ function mockClientType(type = 'instansi') {
 }
 
 test('createLinkReport inserts row', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc' }] });
+  mockQuery
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ shortcode: 'abc' }] });
   const data = { shortcode: 'abc', user_id: '1', instagram_link: 'a' };
   const res = await createLinkReport(data);
   expect(res).toEqual({ shortcode: 'abc' });
-  expect(mockQuery).toHaveBeenCalledWith(
-    expect.stringContaining('FROM insta_post p'),
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('FROM tasks'),
+    ['abc', '1']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining('FROM link_report'),
+    ['abc', '1']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    3,
+    expect.stringContaining('INSERT INTO link_report'),
     ['abc', '1', 'a', null, null, null, null]
   );
 });
 
 test('createLinkReport throws when shortcode missing or not today', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [] });
-  await expect(createLinkReport({ shortcode: 'xyz' })).rejects.toThrow(
-    'shortcode not found or not from today'
+  mockQuery
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] });
+  await expect(
+    createLinkReport({ shortcode: 'xyz', user_id: '1' })
+  ).rejects.toThrow('shortcode not found or not from today');
+  expect(mockQuery).toHaveBeenCalledTimes(3);
+});
+
+test('createLinkReport throws when recent task exists', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+  await expect(
+    createLinkReport({ shortcode: 'abc', user_id: '1' })
+  ).rejects.toThrow('duplicate report/task in last two days');
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('FROM tasks'),
+    ['abc', '1']
   );
-  expect(mockQuery).toHaveBeenCalled();
+});
+
+test('createLinkReport throws when recent link report exists', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+  await expect(
+    createLinkReport({ shortcode: 'abc', user_id: '1' })
+  ).rejects.toThrow('duplicate report/task in last two days');
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('FROM tasks'),
+    ['abc', '1']
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining('FROM link_report'),
+    ['abc', '1']
+  );
 });
 
 test('getLinkReports joins with insta_post', async () => {


### PR DESCRIPTION
## Summary
- add helpers to detect recent tasks and link reports
- block creating link report if duplicate found within two days
- cover duplicate scenarios with new unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a917dbd2708327a8bd90ecb98c2a68