### PR TITLE
Add per-user link recap stats

### DIFF
--- a/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
+++ b/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
@@ -47,19 +47,33 @@ export async function absensiLink(client_id, opts = {}) {
   const reports = await getReportsTodayByClient(targetClient);
   const userStats = {};
   users.forEach((u) => {
-    userStats[u.user_id] = { ...u, count: 0 };
+    userStats[u.user_id] = { ...u, tasksDone: 0, linkCount: 0 };
   });
   reports.forEach((r) => {
-    if (userStats[r.user_id]) userStats[r.user_id].count += 1;
+    const stat = userStats[r.user_id];
+    if (stat) {
+      stat.tasksDone += 1;
+      stat.linkCount +=
+        (r.facebook_link ? 1 : 0) +
+        (r.instagram_link ? 1 : 0) +
+        (r.twitter_link ? 1 : 0) +
+        (r.tiktok_link ? 1 : 0) +
+        (r.youtube_link ? 1 : 0);
+    }
   });
 
+  const totalLinks = Object.values(userStats).reduce(
+    (acc, u) => acc + u.linkCount,
+    0
+  );
   const totalKonten = shortcodes.length;
   let sudah = [];
   let belum = [];
   Object.values(userStats).forEach((u) => {
+    u.tasksPending = Math.max(totalKonten - u.tasksDone, 0);
     if (u.exception === true) {
       sudah.push(u);
-    } else if (u.count >= Math.ceil(totalKonten / 2)) {
+    } else if (u.tasksDone >= Math.ceil(totalKonten / 2)) {
       sudah.push(u);
     } else {
       belum.push(u);
@@ -70,16 +84,6 @@ export async function absensiLink(client_id, opts = {}) {
   const kontenLinks = shortcodes.map(
     (sc) => `https://www.instagram.com/p/${sc}`
   );
-  const totalLinks = reports.reduce((acc, r) => {
-    return (
-      acc +
-      (r.facebook_link ? 1 : 0) +
-      (r.instagram_link ? 1 : 0) +
-      (r.twitter_link ? 1 : 0) +
-      (r.tiktok_link ? 1 : 0) +
-      (r.youtube_link ? 1 : 0)
-    );
-  }, 0);
 
   const mode = opts && opts.mode ? String(opts.mode).toLowerCase() : "all";
   const salam = getGreeting();
@@ -101,7 +105,10 @@ export async function absensiLink(client_id, opts = {}) {
       msg += `*${div}* (${list.length} user):\n`;
       msg +=
         list
-          .map((u) => `- ${u.title ? u.title + " " : ""}${u.nama}`)
+          .map(
+            (u) =>
+              `- ${u.title ? u.title + " " : ""}${u.nama} (Sudah Melaksanakan : ${u.tasksDone} / Belum melaksanakan : ${u.tasksPending} / Total Link : ${u.linkCount})`
+          )
           .join("\n") +
         "\n";
       if (idx < arrKeys.length - 1) msg += "\n";

--- a/tests/absensiLinkRoleFlag.test.js
+++ b/tests/absensiLinkRoleFlag.test.js
@@ -40,3 +40,27 @@ test('filters users by roleFlag when provided', async () => {
   expect(mockGetUsersByClient).toHaveBeenCalledWith('POLRES', 'ditbinmas');
   expect(mockGetUsersByDirektorat).not.toHaveBeenCalled();
 });
+
+test('reports per-user task and link counts', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_type: 'instansi' }] });
+  mockGetUsersByClient.mockResolvedValueOnce([
+    { user_id: 1, title: 'AIPTU', nama: 'HARIS ANTON A.', divisi: 'SI KEU', status: true, exception: false },
+    { user_id: 2, title: 'BRIPTU', nama: 'BUDI', divisi: 'SI KEU', status: true, exception: false },
+  ]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1', 'sc2']);
+  mockGetReportsTodayByClient.mockResolvedValueOnce([
+    {
+      user_id: 1,
+      facebook_link: 'f',
+      instagram_link: 'i',
+      twitter_link: 't',
+      tiktok_link: 'tt',
+      youtube_link: 'y',
+    },
+  ]);
+
+  const msg = await absensiLink('POLRES');
+
+  expect(msg).toContain('AIPTU HARIS ANTON A. (Sudah Melaksanakan : 1 / Belum melaksanakan : 1 / Total Link : 5)');
+  expect(msg).toContain('BRIPTU BUDI (Sudah Melaksanakan : 0 / Belum melaksanakan : 2 / Total Link : 0)');
+});


### PR DESCRIPTION
## Summary
- include per-user task and link counts in link recap
- cover new user stats in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a91b7caa988327bece42546d05d97b