### PR TITLE
feat(sql): add tasks table with migration

### DIFF
--- a/sql/migrations/20251016_create_tasks.sql
+++ b/sql/migrations/20251016_create_tasks.sql
@@ -1,0 +1,9 @@
+-- Create tasks table for tracking user tasks per post
+CREATE TABLE IF NOT EXISTS tasks (
+    shortcode VARCHAR REFERENCES insta_post(shortcode) ON DELETE CASCADE,
+    user_id VARCHAR REFERENCES "user"(user_id),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS tasks_shortcode_user_idx
+    ON tasks (shortcode, user_id, created_at);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -282,6 +282,15 @@ CREATE TABLE visitor_logs (
     visited_at TIMESTAMP DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS tasks (
+    shortcode VARCHAR REFERENCES insta_post(shortcode) ON DELETE CASCADE,
+    user_id VARCHAR REFERENCES "user"(user_id),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS tasks_shortcode_user_idx
+    ON tasks (shortcode, user_id, created_at);
+
 CREATE TABLE IF NOT EXISTS link_report (
     shortcode VARCHAR REFERENCES insta_post(shortcode) ON DELETE CASCADE,
     user_id VARCHAR REFERENCES "user"(user_id),


### PR DESCRIPTION
## Summary
- add `tasks` table with FK to `insta_post` and `user`
- index tasks by shortcode, user, and created_at
- provide SQL migration for new table

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a960b4d8bc8327a31385f323086da4