### PR TITLE
filter rekap user data by role

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -6,9 +6,14 @@ import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
 
-async function formatRekapUserData(clientId) {
+async function formatRekapUserData(clientId, roleFlag = null) {
+  const filterRole = ["ditbinmas", "ditlantas", "bidhumas"].includes(
+    roleFlag?.toLowerCase()
+  )
+    ? roleFlag
+    : null;
   const client = await findClientById(clientId);
-  const users = await getUsersSocialByClient(clientId);
+  const users = await getUsersSocialByClient(clientId, filterRole);
   const salam = getGreeting();
   const now = new Date();
   const hari = now.toLocaleDateString("id-ID", { weekday: "long" });
@@ -134,7 +139,7 @@ async function performAction(
   let msg = "";
   switch (action) {
     case "1": {
-      msg = await formatRekapUserData(userClientId || clientId);
+      msg = await formatRekapUserData(userClientId || clientId, roleFlag);
       break;
     }
     case "2":

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -5,9 +5,14 @@ import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
 
-async function formatRekapUserData(clientId) {
+async function formatRekapUserData(clientId, roleFlag = null) {
+  const filterRole = ["ditbinmas", "ditlantas", "bidhumas"].includes(
+    roleFlag?.toLowerCase()
+  )
+    ? roleFlag
+    : null;
   const client = await findClientById(clientId);
-  const users = await getUsersSocialByClient(clientId);
+  const users = await getUsersSocialByClient(clientId, filterRole);
   const salam = getGreeting();
   const now = new Date();
   const hari = now.toLocaleDateString("id-ID", { weekday: "long" });
@@ -128,7 +133,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
   const userType = userClient?.client_type?.toLowerCase();
   switch (action) {
     case "1": {
-      msg = await formatRekapUserData(userClientId || clientId);
+      msg = await formatRekapUserData(userClientId || clientId, roleFlag);
       break;
     }
     case "2":

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -111,7 +111,28 @@ test('choose_menu uses selected client id', async () => {
 
   await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
-  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1');
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1', null);
+});
+
+test('choose_menu forwards roleFlag to getUsersSocialByClient', async () => {
+  mockGetUsersSocialByClient.mockResolvedValue([]);
+  mockFindClientById.mockResolvedValue({});
+  const session = {
+    role: 'DITBINMAS',
+    selectedClientId: 'C1',
+    clientName: 'Client One',
+  };
+  const waClient = { sendMessage: jest.fn() };
+  const chatId = '123';
+  const mainSpy = jest
+    .spyOn(dashRequestHandlers, 'main')
+    .mockResolvedValue();
+
+  await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
+
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('C1', 'DITBINMAS');
+
+  mainSpy.mockRestore();
 });
 
 test.each([
@@ -304,7 +325,7 @@ test('choose_menu formats directorate report header', async () => {
   await dashRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
   const msg = waClient.sendMessage.mock.calls[0][1];
-  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('BINMAS');
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('BINMAS', null);
   expect(msg).toBe(
     'Selamat siang,\n\nMohon ijin Komandan, melaporkan absensi update data personil DIREKTORAT BINMAS pada hari Rabu, 20 Agustus 2025, pukul 14.28 WIB, sebagai berikut:'
   );


### PR DESCRIPTION
## Summary
- filter rekap user data by the requester role
- pass role flag into rekap user data helpers
- test dashboard rekap user data role flag

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa6796c7fc8327b06aaea972e648ef