### PR TITLE
feat: add ditbinmas operator attendance menu

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -234,7 +234,7 @@ waClient.on("message", async (msg) => {
       setSession(chatId, { menu: "clientrequest", step: "main" });
       await waClient.sendMessage(
         chatId,
-        `┏━━━ *MENU CLIENT CICERO* ━━━\n1️⃣ Tambah client baru\n2️⃣ Kelola client (update/hapus/info)\n3️⃣ Kelola user (update/exception/status)\n4️⃣ Proses Instagram\n5️⃣ Proses TikTok\n6️⃣ Absensi Username Instagram\n7️⃣ Absensi Username TikTok\n8️⃣ Transfer User\n9️⃣ Exception Info\n🔟 Hapus WA Admin\n1️⃣1️⃣ Hapus WA User\n1️⃣2️⃣ Transfer User Sheet\n1️⃣3️⃣ Download Sheet Amplifikasi\n┗━━━━━━━━━━━━━━━━━━━━━━━━━━━\nKetik *angka* menu, atau *batal* untuk keluar.`
+        `┏━━━ *MENU CLIENT CICERO* ━━━\n1️⃣ Tambah client baru\n2️⃣ Kelola client (update/hapus/info)\n3️⃣ Kelola user (update/exception/status)\n4️⃣ Proses Instagram\n5️⃣ Proses TikTok\n6️⃣ Absensi Username Instagram\n7️⃣ Absensi Username TikTok\n8️⃣ Transfer User\n9️⃣ Exception Info\n🔟 Hapus WA Admin\n1️⃣1️⃣ Hapus WA User\n1️⃣2️⃣ Transfer User Sheet\n1️⃣3️⃣ Download Sheet Amplifikasi\n1️⃣4️⃣ Download Docs\n1️⃣5️⃣ Absensi Operator Ditbinmas\n┗━━━━━━━━━━━━━━━━━━━━━━━━━━━\nKetik *angka* menu, atau *batal* untuk keluar.`
       );
       return;
     }
@@ -562,6 +562,7 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
 1️⃣2️⃣ Transfer User Sheet
 1️⃣3️⃣ Download Sheet Amplifikasi
 1️⃣4️⃣ Download Docs
+1️⃣5️⃣ Absensi Operator Ditbinmas
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Ketik *angka* menu, atau *batal* untuk keluar.
 `.trim()

--- a/tests/clientRequestHandlersAbsensiOprDitbinmas.test.js
+++ b/tests/clientRequestHandlersAbsensiOprDitbinmas.test.js
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+
+const mockAbsensiRegistrasiDashboardDitbinmas = jest.fn();
+
+jest.unstable_mockModule('../src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js', () => ({
+  absensiRegistrasiDashboardDitbinmas: mockAbsensiRegistrasiDashboardDitbinmas,
+}));
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: jest.fn() }));
+jest.unstable_mockModule('../src/service/linkReportExcelService.js', () => ({
+  saveLinkReportExcel: jest.fn(),
+}));
+jest.unstable_mockModule('../src/service/googleContactsService.js', () => ({
+  saveContactIfNew: jest.fn(),
+}));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  getAdminWANumbers: jest.fn(),
+  getAdminWAIds: jest.fn(),
+  sendWAFile: jest.fn(),
+  formatToWhatsAppId: jest.fn(),
+}));
+jest.unstable_mockModule('../src/model/linkReportModel.js', () => ({}));
+jest.unstable_mockModule('../src/handler/fetchengagement/fetchLikesInstagram.js', () => ({
+  handleFetchLikesInstagram: jest.fn(),
+}));
+jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js', () => ({
+  absensiKomentar: jest.fn(),
+  absensiKomentarTiktokPerKonten: jest.fn(),
+}));
+
+process.env.JWT_SECRET = 'test';
+
+let clientRequestHandlers;
+beforeAll(async () => {
+  ({ clientRequestHandlers } = await import('../src/handler/menu/clientRequestHandlers.js'));
+});
+
+test('absensiOprDitbinmas sends report and resets step', async () => {
+  mockAbsensiRegistrasiDashboardDitbinmas.mockResolvedValue('msg');
+  const session = {};
+  const chatId = '123';
+  const waClient = { sendMessage: jest.fn() };
+
+  await clientRequestHandlers.absensiOprDitbinmas(session, chatId, '', waClient);
+
+  expect(mockAbsensiRegistrasiDashboardDitbinmas).toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'msg');
+  expect(session.step).toBe('main');
+});


### PR DESCRIPTION
## Summary
- expand clientrequest menu with "Absensi Operator Ditbinmas"
- cover Ditbinmas attendance handler with unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae9543f19483279ce9bd51ce094cca