### PR TITLE
Fix dashboard user client lookup

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -90,7 +90,11 @@ async function buildClientFilter(
 // Ambil daftar client_id berdasarkan role_name
 export async function getClientsByRole(roleName) {
   const { rows } = await query(
-    'SELECT DISTINCT LOWER(client_id) AS client_id FROM users WHERE LOWER(role_name) = LOWER($1)',
+    `SELECT DISTINCT LOWER(duc.client_id) AS client_id
+     FROM dashboard_user du
+     JOIN roles r ON du.role_id = r.role_id
+     JOIN dashboard_user_clients duc ON du.dashboard_user_id = duc.dashboard_user_id
+     WHERE LOWER(r.role_name) = LOWER($1)`,
     [roleName]
   );
   return rows.map((r) => r.client_id);

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -239,7 +239,11 @@ test('getClientsByRole returns lowercase client ids', async () => {
   const clients = await getClientsByRole('operator');
   expect(clients).toEqual(['c1', 'c2']);
   expect(mockQuery).toHaveBeenCalledWith(
-    'SELECT DISTINCT LOWER(client_id) AS client_id FROM users WHERE LOWER(role_name) = LOWER($1)',
+    `SELECT DISTINCT LOWER(duc.client_id) AS client_id
+     FROM dashboard_user du
+     JOIN roles r ON du.role_id = r.role_id
+     JOIN dashboard_user_clients duc ON du.dashboard_user_id = duc.dashboard_user_id
+     WHERE LOWER(r.role_name) = LOWER($1)`,
     ['operator']
   );
 });


### PR DESCRIPTION
## Summary
- query dashboard_user tables for client lookup by role
- update user model tests for new dashboard query

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9777f4d083279dcffd6fed193e60