### PR TITLE
feat: include operator counts in dashboard registration report

### DIFF
--- a/src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js
+++ b/src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js
@@ -1,5 +1,4 @@
 import { query } from "../../../db/index.js";
-import { getClientsByRole } from "../../../model/userModel.js";
 import { hariIndo } from "../../../utils/constants.js";
 import { getGreeting } from "../../../utils/utilsHelper.js";
 
@@ -10,38 +9,46 @@ export async function absensiRegistrasiDashboardDitbinmas() {
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
   const salam = getGreeting();
 
-  const polresIds = (await getClientsByRole("ditbinmas")).map((id) => id.toUpperCase());
-  const { rows: polresRows } = await query(
-    "SELECT client_id, nama FROM clients WHERE client_id = ANY($1::varchar[]) ORDER BY nama",
-    [polresIds]
+  const { rows: clients } = await query(
+    `SELECT client_id, nama FROM clients
+     WHERE LOWER(client_type) = 'org'
+     ORDER BY nama`
   );
 
   const { rows: registeredRows } = await query(
-    `SELECT DISTINCT duc.client_id FROM dashboard_user du
+    `SELECT duc.client_id, COUNT(*) AS operator
+     FROM dashboard_user du
      JOIN roles r ON du.role_id = r.role_id
      JOIN dashboard_user_clients duc ON du.dashboard_user_id = duc.dashboard_user_id
-     WHERE LOWER(r.role_name) = 'ditbinmas' AND du.status = true`
+     WHERE LOWER(r.role_name) = 'ditbinmas' AND du.status = true
+     GROUP BY duc.client_id`
   );
-  const registeredSet = new Set(registeredRows.map((r) => r.client_id.toUpperCase()));
+
+  const countMap = new Map(
+    registeredRows.map((r) => [r.client_id.toUpperCase(), Number(r.operator)])
+  );
 
   const sudah = [];
   const belum = [];
-  for (const pr of polresRows) {
-    if (registeredSet.has(pr.client_id.toUpperCase())) {
-      sudah.push(pr.nama);
+  for (const client of clients) {
+    const id = client.client_id.toUpperCase();
+    const count = countMap.get(id) || 0;
+    if (count > 0) {
+      sudah.push(`${client.nama.toUpperCase()} : ${count} Operator`);
     } else {
-      belum.push(pr.nama);
+      belum.push(client.nama.toUpperCase());
     }
   }
 
   let msg = `${salam}\n\n`;
+  msg += `Mohon Ijin Komandan,\n\n`;
   msg += `\uD83D\uDCCB Rekap Registrasi User dashboard Cicero DIT BINMAS :\n`;
   msg += `${hari}, ${tanggal}\n`;
   msg += `Jam: ${jam}\n\n`;
   msg += `Absensi Registrasi User Direktorat dan Polres :\n\n`;
-  msg += `*Sudah :*\n`;
+  msg += `Sudah :\n`;
   msg += sudah.length ? sudah.map((n) => `- ${n}`).join("\n") : "-";
-  msg += `\n*Belum :*\n`;
+  msg += `\nBelum :\n`;
   msg += belum.length ? belum.map((n) => `- ${n}`).join("\n") : "-";
   return msg.trim();
 }

--- a/tests/absensiRegistrasiDashboardDitbinmas.test.js
+++ b/tests/absensiRegistrasiDashboardDitbinmas.test.js
@@ -1,28 +1,28 @@
 import { jest } from '@jest/globals';
 
 const mockQuery = jest.fn();
-const mockGetClientsByRole = jest.fn();
 
 jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
-jest.unstable_mockModule('../src/model/userModel.js', () => ({ getClientsByRole: mockGetClientsByRole }));
 
 const { absensiRegistrasiDashboardDitbinmas } = await import('../src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js');
 
-test('generates report with registered and unregistered polres', async () => {
-  mockGetClientsByRole.mockResolvedValue(['polresa', 'polresb']);
-  mockQuery.mockImplementation((sql, params) => {
-    if (sql.includes('SELECT client_id, nama FROM clients')) {
-      return { rows: [
-        { client_id: 'POLRESA', nama: 'Polres A' },
-        { client_id: 'POLRESB', nama: 'Polres B' },
-      ] };
+test('generates report with operator counts and unregistered clients', async () => {
+  mockQuery.mockImplementation((sql) => {
+    if (sql.includes('FROM clients')) {
+      return {
+        rows: [
+          { client_id: 'POLRESA', nama: 'Polres A' },
+          { client_id: 'POLRESB', nama: 'Polres B' },
+        ],
+      };
     }
-    if (sql.includes('SELECT DISTINCT duc.client_id')) {
-      return { rows: [{ client_id: 'POLRESA' }] };
+    if (sql.includes('GROUP BY duc.client_id')) {
+      return { rows: [{ client_id: 'POLRESA', operator: 2 }] };
     }
     return { rows: [] };
   });
+
   const msg = await absensiRegistrasiDashboardDitbinmas();
-  expect(msg).toContain('*Sudah :*\n- Polres A');
-  expect(msg).toContain('*Belum :*\n- Polres B');
+  expect(msg).toContain('Sudah :\n- POLRES A : 2 Operator');
+  expect(msg).toContain('Belum :\n- POLRES B');
 });


### PR DESCRIPTION
## Summary
- count registered dashboard operators per ORG client
- show all unregistered ORG clients in report
- adjust test for registration dashboard report

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae995663408327bda86116aa733ac7