### PR TITLE
Handle dashboard username lookup case-insensitively

### DIFF
--- a/src/model/dashboardUserModel.js
+++ b/src/model/dashboardUserModel.js
@@ -1,14 +1,16 @@
 import { query } from '../repository/db.js';
 
 async function findOneBy(field, value) {
+  const whereClause =
+    field === 'username' ? 'LOWER(du.username) = LOWER($1)' : `du.${field} = $1`;
   const res = await query(
     `SELECT du.*, r.role_name AS role, COALESCE(array_agg(duc.client_id) FILTER (WHERE duc.client_id IS NOT NULL), '{}') AS client_ids
      FROM dashboard_user du
      LEFT JOIN roles r ON du.role_id = r.role_id
      LEFT JOIN dashboard_user_clients duc ON du.dashboard_user_id = duc.dashboard_user_id
-     WHERE du.${field} = $1
+     WHERE ${whereClause}
      GROUP BY du.dashboard_user_id, r.role_name`,
-    [value]
+    [value],
   );
   return res.rows[0] || null;
 }
@@ -29,7 +31,7 @@ export async function findAllByWhatsApp(wa) {
      LEFT JOIN dashboard_user_clients duc ON du.dashboard_user_id = duc.dashboard_user_id
      WHERE du.whatsapp = $1
      GROUP BY du.dashboard_user_id, r.role_name`,
-    [wa]
+    [wa],
   );
   return res.rows;
 }
@@ -47,7 +49,7 @@ export async function createUser(data) {
       data.status,
       data.user_id ?? null,
       data.whatsapp,
-    ]
+    ],
   );
   return res.rows[0];
 }
@@ -59,7 +61,7 @@ export async function addClients(dashboardUserId, clientIds = []) {
   const placeholders = clientIds.map((_, i) => `($1, $${i + 2})`).join(', ');
   await query(
     `INSERT INTO dashboard_user_clients (dashboard_user_id, client_id) VALUES ${placeholders} ON CONFLICT DO NOTHING`,
-    [dashboardUserId, ...clientIds]
+    [dashboardUserId, ...clientIds],
   );
 }
 
@@ -70,7 +72,7 @@ export async function findById(id) {
 export async function updateStatus(id, status) {
   const res = await query(
     'UPDATE dashboard_user SET status=$2, updated_at=NOW() WHERE dashboard_user_id=$1 RETURNING *',
-    [id, status]
+    [id, status],
   );
   return res.rows[0];
 }


### PR DESCRIPTION
## Summary
- allow case-insensitive username lookup for dashboard approvals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea31cf0708327b3f3c7990ec8e845