### PR TITLE
feat: include Ditbinmas registration counts

### DIFF
--- a/src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js
+++ b/src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js
@@ -46,9 +46,9 @@ export async function absensiRegistrasiDashboardDitbinmas() {
   msg += `${hari}, ${tanggal}\n`;
   msg += `Jam: ${jam}\n\n`;
   msg += `Absensi Registrasi User Direktorat dan Polres :\n\n`;
-  msg += `Sudah :\n`;
+  msg += `Sudah : ${sudah.length} Polres\n`;
   msg += sudah.length ? sudah.map((n) => `- ${n}`).join("\n") : "-";
-  msg += `\nBelum :\n`;
+  msg += `\nBelum : ${belum.length} Polres\n`;
   msg += belum.length ? belum.map((n) => `- ${n}`).join("\n") : "-";
   return msg.trim();
 }

--- a/tests/absensiRegistrasiDashboardDitbinmas.test.js
+++ b/tests/absensiRegistrasiDashboardDitbinmas.test.js
@@ -23,6 +23,6 @@ test('generates report with operator counts and unregistered clients', async () 
   });
 
   const msg = await absensiRegistrasiDashboardDitbinmas();
-  expect(msg).toContain('Sudah :\n- POLRES A : 2 Operator');
-  expect(msg).toContain('Belum :\n- POLRES B');
+  expect(msg).toContain('Sudah : 1 Polres\n- POLRES A : 2 Operator');
+  expect(msg).toContain('Belum : 1 Polres\n- POLRES B');
 });


### PR DESCRIPTION
## Summary
- show the number of Polres that have registered versus not registered in the Ditbinmas dashboard recap
- update unit test to validate count headers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb87b0e088327b12aa661ccf5b72e