### PR TITLE
feat: add ditbinmas attendance to absensi report

### DIFF
--- a/src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js
+++ b/src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js
@@ -11,7 +11,7 @@ export async function absensiRegistrasiDashboardDitbinmas() {
 
   const { rows: clients } = await query(
     `SELECT client_id, nama FROM clients
-     WHERE LOWER(client_type) = 'org'
+     WHERE LOWER(client_type) = 'org' AND UPPER(client_id) <> 'DITBINMAS'
      ORDER BY nama`
   );
 
@@ -20,13 +20,17 @@ export async function absensiRegistrasiDashboardDitbinmas() {
      FROM dashboard_user du
      JOIN roles r ON du.role_id = r.role_id
      JOIN dashboard_user_clients duc ON du.dashboard_user_id = duc.dashboard_user_id
+     JOIN clients c ON c.client_id = duc.client_id
      WHERE LOWER(r.role_name) = 'ditbinmas' AND du.status = true
+       AND (LOWER(c.client_type) = 'org' OR UPPER(c.client_id) = 'DITBINMAS')
      GROUP BY duc.client_id`
   );
 
   const countMap = new Map(
     registeredRows.map((r) => [r.client_id.toUpperCase(), Number(r.operator)])
   );
+
+  const ditbinmasCount = countMap.get("DITBINMAS") || 0;
 
   const sudah = [];
   const belum = [];
@@ -46,6 +50,7 @@ export async function absensiRegistrasiDashboardDitbinmas() {
   msg += `${hari}, ${tanggal}\n`;
   msg += `Jam: ${jam}\n\n`;
   msg += `Absensi Registrasi User Direktorat dan Polres :\n\n`;
+  msg += `DITBINMAS : ${ditbinmasCount} Operator\n\n`;
   msg += `Sudah : ${sudah.length} Polres\n`;
   msg += sudah.length ? sudah.map((n) => `- ${n}`).join("\n") : "-";
   msg += `\nBelum : ${belum.length} Polres\n`;

--- a/tests/absensiRegistrasiDashboardDitbinmas.test.js
+++ b/tests/absensiRegistrasiDashboardDitbinmas.test.js
@@ -17,12 +17,18 @@ test('generates report with operator counts and unregistered clients', async () 
       };
     }
     if (sql.includes('GROUP BY duc.client_id')) {
-      return { rows: [{ client_id: 'POLRESA', operator: 2 }] };
+      return {
+        rows: [
+          { client_id: 'DITBINMAS', operator: 5 },
+          { client_id: 'POLRESA', operator: 2 },
+        ],
+      };
     }
     return { rows: [] };
   });
 
   const msg = await absensiRegistrasiDashboardDitbinmas();
-  expect(msg).toContain('Sudah : 1 Polres\n- POLRES A : 2 Operator');
+  expect(mockQuery.mock.calls[1][0]).toMatch(/OR UPPER\(c\.client_id\) = 'DITBINMAS'/);
+  expect(msg).toMatch(/DITBINMAS : 5 Operator\n\nSudah : 1 Polres\n- POLRES A : 2 Operator/);
   expect(msg).toContain('Belum : 1 Polres\n- POLRES B');
 });


### PR DESCRIPTION
## Summary
- include DITBINMAS attendance in operator registry report before Polres list
- test that report shows DITBINMAS first and excludes it from Polres counts
- ensure DITBINMAS attendance works without requiring client type ORG

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeda19d0e083279951806e935dbe95