### PR TITLE
Add cron job for Ditbinmas operator attendance

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ import './src/cron/cronRekapLink.js';
 import './src/cron/cronAmplifyLinkMonthly.js';
 import './src/cron/cronPremiumRequest.js';
 import './src/cron/cronAbsensiUserData.js';
+import './src/cron/cronAbsensiOprDitbinmas.js';
 
 const app = express();
 

--- a/src/cron/cronAbsensiOprDitbinmas.js
+++ b/src/cron/cronAbsensiOprDitbinmas.js
@@ -1,0 +1,17 @@
+import cron from 'node-cron';
+import waClient from '../service/waService.js';
+import { absensiRegistrasiDashboardDitbinmas } from '../handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js';
+import { sendWAReport, getAdminWAIds } from '../utils/waHelper.js';
+
+export async function runCron() {
+  try {
+    const msg = await absensiRegistrasiDashboardDitbinmas();
+    await sendWAReport(waClient, msg, getAdminWAIds());
+  } catch (err) {
+    console.error('[CRON ABSENSI OPR DITBINMAS]', err.message);
+  }
+}
+
+cron.schedule('0 8-21 * * *', runCron, { timezone: 'Asia/Jakarta' });
+
+export default null;

--- a/tests/cronAbsensiOprDitbinmas.test.js
+++ b/tests/cronAbsensiOprDitbinmas.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+
+const mockAbsensi = jest.fn().mockResolvedValue('msg');
+const mockSendWAReport = jest.fn();
+const mockGetAdminWAIds = jest.fn(() => ['ADMIN']);
+
+jest.unstable_mockModule('../src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js', () => ({
+  absensiRegistrasiDashboardDitbinmas: mockAbsensi,
+}));
+jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  sendWAReport: mockSendWAReport,
+  getAdminWAIds: mockGetAdminWAIds,
+}));
+
+let runCron;
+
+beforeAll(async () => {
+  ({ runCron } = await import('../src/cron/cronAbsensiOprDitbinmas.js'));
+});
+
+test('runCron sends report to admin', async () => {
+  await runCron();
+  expect(mockAbsensi).toHaveBeenCalled();
+  expect(mockSendWAReport).toHaveBeenCalledWith({}, 'msg', ['ADMIN']);
+});


### PR DESCRIPTION
## Summary
- schedule hourly cron to send Ditbinmas operator attendance report to admins via WA
- import new cron scheduler into application startup
- add unit test for the new cron

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aedd0d26ac832790a070f4e59307c2