### PR TITLE
Fix directorate shortcode lookup

### DIFF
--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -40,31 +40,32 @@ export async function findPostByShortcode(shortcode) {
   return res.rows[0] || null;
 }
 
-export async function getShortcodesTodayByClient(client_id) {
+export async function getShortcodesTodayByClient(identifier) {
   const today = new Date().toLocaleDateString('en-CA', {
     timeZone: 'Asia/Jakarta'
   });
 
   const typeRes = await query(
     'SELECT client_type FROM clients WHERE LOWER(client_id) = LOWER($1)',
-    [client_id]
+    [identifier]
   );
   const clientType = typeRes.rows[0]?.client_type?.toLowerCase();
 
   let sql;
   let params;
-  if (clientType === 'direktorat') {
+
+  if (clientType === 'direktorat' || typeRes.rows.length === 0) {
     sql =
       `SELECT p.shortcode FROM insta_post p\n` +
       `JOIN insta_post_roles pr ON pr.shortcode = p.shortcode\n` +
       `WHERE LOWER(pr.role_name) = LOWER($1)\n` +
       `  AND (p.created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date`;
-    params = [client_id, today];
+    params = [identifier, today];
   } else {
     sql =
       `SELECT shortcode FROM insta_post\n` +
       `WHERE LOWER(client_id) = LOWER($1) AND (created_at AT TIME ZONE 'Asia/Jakarta')::date = $2::date`;
-    params = [client_id, today];
+    params = [identifier, today];
   }
 
   const res = await query(sql, params);

--- a/tests/instaPostModel.test.js
+++ b/tests/instaPostModel.test.js
@@ -43,3 +43,13 @@ test('getShortcodesTodayByClient uses role filter for directorate', async () => 
   expect(sql).toContain('insta_post_roles');
   expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
 });
+
+test('getShortcodesTodayByClient falls back to role when client not found', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] });
+  await getShortcodesTodayByClient('ditbinmas');
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain('insta_post_roles');
+  expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
+});


### PR DESCRIPTION
## Summary
- allow `getShortcodesTodayByClient` to fall back to role names when client id is unknown
- cover fallback behavior with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af0d79856883279ab7803e580adb7c