### PR TITLE
Fix dir request rekap aggregation

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -133,7 +133,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
   const userType = userClient?.client_type?.toLowerCase();
   switch (action) {
     case "1": {
-      msg = await formatRekapUserData(userClientId || clientId, roleFlag);
+      msg = await formatRekapUserData(clientId, roleFlag);
       break;
     }
     case "2":

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -1,0 +1,70 @@
+import { jest } from '@jest/globals';
+
+process.env.TZ = 'Asia/Jakarta';
+
+const mockGetUsersSocialByClient = jest.fn();
+const mockAbsensiLink = jest.fn();
+const mockAbsensiLikes = jest.fn();
+const mockAbsensiKomentar = jest.fn();
+const mockFindClientById = jest.fn();
+
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersSocialByClient: mockGetUsersSocialByClient,
+}));
+jest.unstable_mockModule('../src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js', () => ({
+  absensiLink: mockAbsensiLink,
+}));
+jest.unstable_mockModule('../src/handler/fetchabsensi/insta/absensiLikesInsta.js', () => ({
+  absensiLikes: mockAbsensiLikes,
+}));
+jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js', () => ({
+  absensiKomentar: mockAbsensiKomentar,
+}));
+jest.unstable_mockModule('../src/service/clientService.js', () => ({
+  findClientById: mockFindClientById,
+}));
+jest.unstable_mockModule('../src/utils/utilsHelper.js', () => ({
+  getGreeting: () => 'Selamat malam',
+  sortDivisionKeys: (arr) => arr.sort(),
+  formatNama: (u) => `${u.title || ''} ${u.nama || ''}`.trim(),
+}));
+
+let dirRequestHandlers;
+beforeAll(async () => {
+  ({ dirRequestHandlers } = await import('../src/handler/menu/dirRequestHandlers.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('choose_menu aggregates directorate data by client_id', async () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2025-08-27T16:06:00Z'));
+
+  mockGetUsersSocialByClient.mockResolvedValue([
+    { client_id: 'ditbinmas', insta: null, tiktok: null },
+    { client_id: 'polres_pasuruan_kota', insta: null, tiktok: null },
+  ]);
+  mockFindClientById.mockImplementation(async (cid) => ({
+    ditbinmas: { nama: 'DIT BINMAS', client_type: 'direktorat' },
+    polres_pasuruan_kota: { nama: 'POLRES PASURUAN KOTA' },
+  })[cid]);
+
+  const session = {
+    role: 'ditbinmas',
+    selectedClientId: 'polres_pasuruan_kota',
+    clientName: 'POLRES PASURUAN KOTA',
+    dir_client_id: 'ditbinmas',
+  };
+  const chatId = '123';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '1', waClient);
+
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
+  const msg = waClient.sendMessage.mock.calls[0][1];
+  expect(msg).toContain('DIT BINMAS');
+  expect(msg).toContain('POLRES PASURUAN KOTA');
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- ensure dirRequest rekap uses the directorate client id for ditbinmas grouping
- add test covering ditbinmas rekap aggregation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af31e697a0832787ed35840ee582f3