### PR TITLE
Include empty polres in directorate recap

### DIFF
--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 process.env.TZ = 'Asia/Jakarta';
 
 const mockGetUsersSocialByClient = jest.fn();
+const mockGetClientsByRole = jest.fn();
 const mockAbsensiLink = jest.fn();
 const mockAbsensiLikes = jest.fn();
 const mockAbsensiKomentar = jest.fn();
@@ -10,6 +11,7 @@ const mockFindClientById = jest.fn();
 
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
   getUsersSocialByClient: mockGetUsersSocialByClient,
+  getClientsByRole: mockGetClientsByRole,
 }));
 jest.unstable_mockModule('../src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js', () => ({
   absensiLink: mockAbsensiLink,
@@ -46,9 +48,14 @@ test('choose_menu aggregates directorate data by client_id', async () => {
     { client_id: 'ditbinmas', insta: null, tiktok: null },
     { client_id: 'polres_pasuruan_kota', insta: null, tiktok: null },
   ]);
+  mockGetClientsByRole.mockResolvedValue([
+    'polres_pasuruan_kota',
+    'polres_sidoarjo',
+  ]);
   mockFindClientById.mockImplementation(async (cid) => ({
     ditbinmas: { nama: 'DIT BINMAS', client_type: 'direktorat' },
-    polres_pasuruan_kota: { nama: 'POLRES PASURUAN KOTA' },
+    polres_pasuruan_kota: { nama: 'POLRES PASURUAN KOTA', client_type: 'org' },
+    polres_sidoarjo: { nama: 'POLRES SIDOARJO', client_type: 'org' },
   })[cid]);
 
   const session = {
@@ -63,8 +70,11 @@ test('choose_menu aggregates directorate data by client_id', async () => {
   await dirRequestHandlers.choose_menu(session, chatId, '1', waClient);
 
   expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
+  expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas');
   const msg = waClient.sendMessage.mock.calls[0][1];
   expect(msg).toContain('DIT BINMAS');
   expect(msg).toContain('POLRES PASURUAN KOTA');
+  expect(msg).toContain('POLRES SIDOARJO');
+  expect(msg).not.toMatch(/POLRES SIDOARJO\n\nJumlah User/);
   jest.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- List all `org` clients in directorate user recap, even if a polres has no users
- Test dirrequest report to ensure empty polres names appear without user counts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af34792b888327893531d34faa6e10