### PR TITLE
Group dirrequest absensi recap by client

### DIFF
--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -1,0 +1,50 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetPostsTodayByClient = jest.fn();
+const mockGetCommentsByVideoId = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: jest.fn(),
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+}));
+jest.unstable_mockModule('../src/model/tiktokPostModel.js', () => ({
+  getPostsTodayByClient: mockGetPostsTodayByClient,
+}));
+jest.unstable_mockModule('../src/model/tiktokCommentModel.js', () => ({
+  getCommentsByVideoId: mockGetCommentsByVideoId,
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({ sendDebug: mockSendDebug }));
+
+let absensiKomentar;
+beforeAll(async () => {
+  ({ absensiKomentar } = await import('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('aggregates directorate data per client', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ nama: 'DIT A', client_tiktok: '@dita', client_type: 'direktorat' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES A', client_tiktok: '@a', client_type: 'org' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES B', client_tiktok: '@b', client_type: 'org' }] });
+  mockGetUsersByDirektorat.mockResolvedValueOnce([
+    { user_id: 1, client_id: 'polres_a', tiktok: 'usera', status: true, exception: false },
+    { user_id: 2, client_id: 'polres_b', tiktok: 'userb', status: true, exception: false },
+  ]);
+  mockGetPostsTodayByClient.mockResolvedValueOnce([{ video_id: 'v1' }]);
+  mockGetCommentsByVideoId.mockResolvedValueOnce({ comments: [{ username: 'usera' }] });
+
+  const msg = await absensiKomentar('ditbinmas', { roleFlag: 'ditbinmas' });
+
+  expect(msg).toContain('POLRES A');
+  expect(msg).toContain('✅ *Sudah melaksanakan* : *1 user*');
+  expect(msg).toContain('POLRES B');
+  expect(msg).toContain('❌ *Belum melaksanakan* : *1 user*');
+  expect(msg).not.toMatch(/usera/i);
+});

--- a/tests/absensiKomentarTiktokRoleFlag.test.js
+++ b/tests/absensiKomentarTiktokRoleFlag.test.js
@@ -33,7 +33,7 @@ beforeEach(() => {
 });
 
 test('filters users by roleFlag when provided', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_tiktok: '@abc' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_tiktok: '@abc', client_type: 'org' }] });
   mockGetUsersByClient.mockResolvedValueOnce([]);
   mockGetPostsTodayByClient.mockResolvedValueOnce([]);
 

--- a/tests/absensiLinkDirektorat.test.js
+++ b/tests/absensiLinkDirektorat.test.js
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+const mockGetReportsTodayByClient = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: jest.fn(),
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+}));
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+jest.unstable_mockModule('../src/model/linkReportModel.js', () => ({
+  getReportsTodayByClient: mockGetReportsTodayByClient,
+  getReportsTodayByShortcode: jest.fn(),
+}));
+jest.unstable_mockModule('../src/utils/utilsHelper.js', () => ({
+  getGreeting: () => 'Selamat pagi',
+  groupByDivision: jest.fn(),
+  sortDivisionKeys: jest.fn(),
+}));
+
+let absensiLink;
+beforeAll(async () => {
+  ({ absensiLink } = await import('../src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('aggregates directorate data per client', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ nama: 'DIT A', client_type: 'direktorat' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES A', client_type: 'org' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES B', client_type: 'org' }] });
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
+  mockGetUsersByDirektorat.mockResolvedValueOnce([
+    { user_id: 1, client_id: 'polres_a', status: true, exception: false },
+    { user_id: 2, client_id: 'polres_b', status: true, exception: false },
+  ]);
+  mockGetReportsTodayByClient.mockResolvedValueOnce([
+    { user_id: 1, client_id: 'polres_a', facebook_link: 'f' },
+  ]);
+
+  const msg = await absensiLink('ditA');
+
+  expect(msg).toContain('POLRES A');
+  expect(msg).toContain('✅ *Sudah melaksanakan* : *1 user*');
+  expect(msg).toContain('POLRES B');
+  expect(msg).toContain('❌ *Belum melaksanakan* : *1 user*');
+  expect(msg).not.toMatch(/\bAIPTU\b/i);
+});


### PR DESCRIPTION
## Summary
- Aggregate Instagram amplification absensi per client for directorates
- Aggregate TikTok comment absensi per client for directorates
- Add tests covering directorate-level absensi aggregation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3731c1bc832794837449daa5d8ab