### PR TITLE
Group dirrequest rekap per client

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -6,9 +6,8 @@ import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
 
 async function formatRekapUserData(clientId, roleFlag = null) {
-  const filterRole = ["ditbinmas", "ditlantas", "bidhumas"].includes(
-    roleFlag?.toLowerCase()
-  )
+  const directorateRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+  const filterRole = directorateRoles.includes(roleFlag?.toLowerCase())
     ? roleFlag
     : null;
   const client = await findClientById(clientId);
@@ -27,7 +26,11 @@ async function formatRekapUserData(clientId, roleFlag = null) {
   });
 
   const clientType = client?.client_type?.toLowerCase();
-  if (clientType === "direktorat") {
+  const isDirektoratView =
+    clientType === "direktorat" ||
+    directorateRoles.includes(clientId.toLowerCase()) ||
+    directorateRoles.includes(roleFlag?.toLowerCase());
+  if (isDirektoratView) {
     const groups = {};
     users.forEach((u) => {
       const cid = u.client_id;

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -53,7 +53,7 @@ test('choose_menu aggregates directorate data by client_id', async () => {
     'polres_sidoarjo',
   ]);
   mockFindClientById.mockImplementation(async (cid) => ({
-    ditbinmas: { nama: 'DIT BINMAS', client_type: 'direktorat' },
+    ditbinmas: { nama: 'DIT BINMAS', client_type: 'org' },
     polres_pasuruan_kota: { nama: 'POLRES PASURUAN KOTA', client_type: 'org' },
     polres_sidoarjo: { nama: 'POLRES SIDOARJO', client_type: 'org' },
   })[cid]);


### PR DESCRIPTION
## Summary
- ensure dirrequest user recap groups attendance by client_id and resolves client names even when the directorate client type is misclassified
- adjust dirRequestHandlers test to cover directorate grouping for non-directorate client types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3a5518e883279e5175ada6f2aaac