### PR TITLE
Allow link reports from last two days

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -27,7 +27,7 @@ export async function createLinkReport(data) {
      SELECT p.shortcode, $2, $3, $4, $5, $6, $7, p.created_at
      FROM insta_post p
      WHERE p.shortcode = $1
-       AND p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date
+       AND p.created_at >= (NOW() AT TIME ZONE 'Asia/Jakarta') - INTERVAL '2 days'
      ON CONFLICT (shortcode, user_id) DO UPDATE
      SET instagram_link = EXCLUDED.instagram_link,
          facebook_link = EXCLUDED.facebook_link,
@@ -48,7 +48,7 @@ export async function createLinkReport(data) {
   );
 
   if (res.rows.length === 0) {
-    const err = new Error('shortcode not found or not from today');
+    const err = new Error('shortcode not found or older than 2 days');
     err.statusCode = 400;
     throw err;
   }

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -45,20 +45,22 @@ test('createLinkReport inserts row', async () => {
     expect.stringContaining('FROM link_report'),
     ['abc', '1']
   );
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain("p.created_at >= (NOW() AT TIME ZONE 'Asia/Jakarta') - INTERVAL '2 days'");
   expect(mockQuery).toHaveBeenNthCalledWith(
     2,
-    expect.stringContaining('INSERT INTO link_report'),
+    expect.any(String),
     ['abc', '1', 'a', null, null, null, null]
   );
 });
 
-test('createLinkReport throws when shortcode missing or not today', async () => {
+test('createLinkReport throws when shortcode missing or older than 2 days', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [] })
     .mockResolvedValueOnce({ rows: [] });
   await expect(
     createLinkReport({ shortcode: 'xyz', user_id: '1' })
-  ).rejects.toThrow('shortcode not found or not from today');
+  ).rejects.toThrow('shortcode not found or older than 2 days');
   expect(mockQuery).toHaveBeenCalledTimes(2);
 });
 


### PR DESCRIPTION
## Summary
- allow link report creation when source post is up to two days old
- cover new two-day window logic in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9bead0bc8327b5683fecfa207c32