### PR TITLE
feat: add daily DB backup cron job

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ This allows operators to scope responses to the correct client.
     GOOGLE_CONTACT_SCOPE=https://www.googleapis.com/auth/contacts
     GOOGLE_SERVICE_ACCOUNT=/path/to/service-account.json
     GOOGLE_IMPERSONATE_EMAIL=admin@example.com
+    BACKUP_DIR=./backups
+    GOOGLE_DRIVE_FOLDER_ID=your-drive-folder-id
     ```
    `GOOGLE_SERVICE_ACCOUNT` may be set to a JSON string or a path to a JSON file. If the value starts with `/` or ends with `.json`, the application reads the file; otherwise it parses the variable directly as JSON. `GOOGLE_IMPERSONATE_EMAIL` should be set to the Workspace user to impersonate when performing contact operations.
 
@@ -127,6 +129,8 @@ The application can synchronize Google Workspace contacts using the People API. 
    - `GOOGLE_SERVICE_ACCOUNT` – JSON key or file path for the service account.
    - `GOOGLE_CONTACT_SCOPE` – OAuth scope for contacts, e.g. `https://www.googleapis.com/auth/contacts`.
    - `GOOGLE_IMPERSONATE_EMAIL` – Workspace user email to impersonate when accessing contacts.
+   - `BACKUP_DIR` – temporary folder for local database dumps.
+   - `GOOGLE_DRIVE_FOLDER_ID` – Google Drive folder ID to receive backups.
 
 For detailed setup and usage examples, see [`docs/google_contacts_integration.md`](docs/google_contacts_integration.md).
 
@@ -140,6 +144,8 @@ Example commands for backing up and restoring the database:
 pg_dump -U <dbuser> -h <host> -d <dbname> > cicero_backup.sql
 psql -U <dbuser> -h <host> -d <dbname> < cicero_backup.sql
 ```
+
+A cron job (`src/cron/cronDbBackup.js`) runs daily at **02:00** (Asia/Jakarta), storing dumps in `BACKUP_DIR` and uploading them to the Drive folder defined by `GOOGLE_DRIVE_FOLDER_ID`.
 
 ---
 

--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ import './src/cron/cronAmplifyLinkMonthly.js';
 import './src/cron/cronPremiumRequest.js';
 import './src/cron/cronAbsensiUserData.js';
 import './src/cron/cronAbsensiOprDitbinmas.js';
+import './src/cron/cronDbBackup.js';
 
 const app = express();
 

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -21,6 +21,8 @@ export const env = cleanEnv(process.env, {
   APP_SESSION_NAME: str({ default: '' }),
   DEBUG_FETCH_INSTAGRAM: bool({ default: false }),
   AMQP_URL: str({ default: 'amqp://localhost' }),
+  BACKUP_DIR: str({ default: 'backups' }),
+  GOOGLE_DRIVE_FOLDER_ID: str({ default: '' }),
   GOOGLE_SERVICE_ACCOUNT: str({ default: '' }),
   GOOGLE_IMPERSONATE_EMAIL: str({ default: '' }),
   GOOGLE_CONTACT_SCOPE: str({

--- a/src/cron/cronDbBackup.js
+++ b/src/cron/cronDbBackup.js
@@ -1,0 +1,79 @@
+import cron from 'node-cron';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import { exec } from 'child_process';
+import { google } from 'googleapis';
+import { env } from '../config/env.js';
+
+dotenv.config();
+
+function parseServiceAccount(data) {
+  if (!data) throw new Error('GOOGLE_SERVICE_ACCOUNT not set');
+  if (data.trim().startsWith('{')) {
+    return JSON.parse(data);
+  }
+  const filePath = path.resolve(data);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function runCommand(cmd, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    exec(cmd, { env: { ...process.env, ...extraEnv } }, (err, stdout, stderr) => {
+      if (err) return reject(err);
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+async function uploadToDrive(filePath) {
+  const credentials = parseServiceAccount(env.GOOGLE_SERVICE_ACCOUNT);
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: ['https://www.googleapis.com/auth/drive.file']
+  });
+  const drive = google.drive({ version: 'v3', auth });
+  await drive.files.create({
+    requestBody: {
+      name: path.basename(filePath),
+      parents: env.GOOGLE_DRIVE_FOLDER_ID ? [env.GOOGLE_DRIVE_FOLDER_ID] : undefined
+    },
+    media: {
+      mimeType: 'application/octet-stream',
+      body: fs.createReadStream(filePath)
+    },
+    fields: 'id'
+  });
+}
+
+async function backupDatabase() {
+  const date = new Date().toISOString().replace(/[:.]/g, '-');
+  const dir = env.BACKUP_DIR;
+  await fsPromises.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `${env.DB_NAME}-${date}.sql`);
+  const driver = (env.DB_DRIVER || '').toLowerCase();
+  let cmd;
+  if (driver === 'mysql') {
+    cmd = `mysqldump -u ${env.DB_USER} -p${env.DB_PASS} -h ${env.DB_HOST} -P ${env.DB_PORT} ${env.DB_NAME} > ${filePath}`;
+  } else if (driver === 'sqlite') {
+    cmd = `sqlite3 ${env.DB_NAME} .dump > ${filePath}`;
+  } else {
+    cmd = `pg_dump -h ${env.DB_HOST} -p ${env.DB_PORT} -U ${env.DB_USER} ${env.DB_NAME} > ${filePath}`;
+  }
+  await runCommand(cmd, { PGPASSWORD: env.DB_PASS });
+  await uploadToDrive(filePath);
+  await fsPromises.unlink(filePath);
+}
+
+cron.schedule(
+  '0 2 * * *',
+  () => {
+    backupDatabase().catch((err) => {
+      console.error('[DB BACKUP] failed:', err.message);
+    });
+  },
+  { timezone: 'Asia/Jakarta' }
+);
+
+export default null;


### PR DESCRIPTION
## Summary
- add cron job to dump the database daily and upload to Google Drive
- document backup environment variables and schedule

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9af093588327a55d4593287e988a