### PR TITLE
Filter user data recap for Ditbinmas clients

### DIFF
--- a/tests/cronAbsensiUserData.test.js
+++ b/tests/cronAbsensiUserData.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 const mockQuery = jest.fn();
 const mockGetUsersMissing = jest.fn();
+const mockGetClientsByRole = jest.fn();
 const mockSendWAReport = jest.fn();
 const mockFormatToWhatsAppId = jest.fn((no) => no);
 const mockSafeSendMessage = jest.fn();
@@ -10,6 +11,7 @@ const mockGetAdminWAIds = jest.fn(() => ['ADMIN']);
 jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
   getUsersMissingDataByClient: mockGetUsersMissing,
+  getClientsByRole: mockGetClientsByRole,
 }));
 jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
 jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
@@ -30,11 +32,13 @@ describe('cronAbsensiUserData', () => {
     jest.clearAllMocks();
   });
 
-  test('orders clients by type and includes username with numbering', async () => {
+  test('orders clients with DITBINMAS first and includes username with numbering', async () => {
+    mockGetClientsByRole.mockResolvedValue(['org1', 'dir1']);
     mockQuery.mockResolvedValueOnce({
       rows: [
         { client_id: 'ORG1', nama: 'Org 1', client_operator: null, client_type: 'org' },
         { client_id: 'DIR1', nama: 'Dir 1', client_operator: null, client_type: 'direktorat' },
+        { client_id: 'DITBINMAS', nama: 'DITBINMAS', client_operator: null, client_type: 'direktorat' },
       ],
     });
     mockGetUsersMissing.mockImplementation(async (cid) => {
@@ -44,6 +48,9 @@ describe('cronAbsensiUserData', () => {
       if (cid === 'ORG1') {
         return [{ nama: 'User O', user_id: 'UO1', insta: '', tiktok: '', whatsapp: '' }];
       }
+      if (cid === 'DITBINMAS') {
+        return [{ nama: 'User B', user_id: 'UB1', insta: '', tiktok: '', whatsapp: '' }];
+      }
       return [];
     });
 
@@ -51,10 +58,13 @@ describe('cronAbsensiUserData', () => {
 
     expect(mockSendWAReport).toHaveBeenCalledTimes(1);
     const message = mockSendWAReport.mock.calls[0][1];
-    const dirIndex = message.indexOf('1. Dir 1');
-    const orgIndex = message.indexOf('2. Org 1');
-    expect(dirIndex).toBeGreaterThanOrEqual(0);
+    const ditIndex = message.indexOf('1. DITBINMAS');
+    const dirIndex = message.indexOf('2. Dir 1');
+    const orgIndex = message.indexOf('3. Org 1');
+    expect(ditIndex).toBeGreaterThanOrEqual(0);
+    expect(dirIndex).toBeGreaterThan(ditIndex);
     expect(orgIndex).toBeGreaterThan(dirIndex);
+    expect(message).toContain('- User B (UB1): Belum Registrasi Whatsapp, Instagram Kosong, Tiktok Kosong');
     expect(message).toContain('- User D (UD1): Belum Registrasi Whatsapp, Instagram Kosong, Tiktok Kosong');
     expect(message).toContain('- User O (UO1): Belum Registrasi Whatsapp, Instagram Kosong, Tiktok Kosong');
   });


### PR DESCRIPTION
## Summary
- target only Ditbinmas-role clients for missing data notifications
- ensure DITBINMAS appears first when generating the recap
- extend tests to cover Ditbinmas ordering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afcb672f808327801a4f0046e2d1e9