### PR TITLE
refactor dirrequest rekap sorting

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -54,13 +54,21 @@ async function formatRekapUserData(clientId, roleFlag = null) {
       })
     );
 
-    entries.sort((a, b) => {
-      if (a.cid === clientId) return -1;
-      if (b.cid === clientId) return 1;
+    const filteredEntries = entries.filter((e) => e.cid !== clientId);
+
+    filteredEntries.sort((a, b) => {
+      const aHasUsers = a.stat.total > 0;
+      const bHasUsers = b.stat.total > 0;
+      if (aHasUsers && bHasUsers) {
+        if (a.updated !== b.updated) return b.updated - a.updated;
+        return a.name.localeCompare(b.name);
+      }
+      if (aHasUsers && !bHasUsers) return -1;
+      if (!aHasUsers && bHasUsers) return 1;
       return a.name.localeCompare(b.name);
     });
 
-    const lines = entries.map((e, idx) =>
+    const lines = filteredEntries.map((e, idx) =>
       e.stat.total === 0
         ? `${idx + 1}. ${e.name}`
         : `${idx + 1}. ${e.name}\n\n` +

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -68,10 +68,13 @@ test('choose_menu aggregates directorate data by client_id', async () => {
   expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
   expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas');
   const msg = waClient.sendMessage.mock.calls[0][1];
-  expect(msg).toContain('DIT BINMAS');
+  expect(msg).not.toMatch(/1\. DIT BINMAS/);
   expect(msg).toContain('POLRES PASURUAN KOTA');
   expect(msg).toContain('POLRES SIDOARJO');
   expect(msg).not.toMatch(/POLRES SIDOARJO\n\nJumlah User/);
+  const idxPasuruan = msg.indexOf('POLRES PASURUAN KOTA');
+  const idxSidoarjo = msg.indexOf('POLRES SIDOARJO');
+  expect(idxPasuruan).toBeLessThan(idxSidoarjo);
   jest.useRealTimers();
 });
 


### PR DESCRIPTION
## Summary
- order dirrequest rekap by filled user count and move empty clients last
- drop top-level DITBINMAS entry in rekap list
- update tests for new dirrequest behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd26db45c83278b97a858e28cd58d