### PR TITLE
Ensure client lookups use case-insensitive IDs

### DIFF
--- a/src/model/clientModel.js
+++ b/src/model/clientModel.js
@@ -8,9 +8,12 @@ export const findAll = async () => {
   return res.rows;
 };
 
-// Ambil client by client_id
+// Ambil client by client_id (case-insensitive)
 export const findById = async (client_id) => {
-  const res = await query('SELECT * FROM clients WHERE client_id = $1', [client_id]);
+  const res = await query(
+    'SELECT * FROM clients WHERE LOWER(client_id) = LOWER($1)',
+    [client_id]
+  );
   return res.rows[0] || null;
 };
 


### PR DESCRIPTION
## Summary
- Make `findById` case-insensitive so absentee reports can reference client names instead of raw IDs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd4f3511c8327a8fdf5af7c84b562