### PR TITLE
feat: add user totals to rekap messages

### DIFF
--- a/src/handler/menu/dashRequestHandlers.js
+++ b/src/handler/menu/dashRequestHandlers.js
@@ -37,36 +37,49 @@ async function formatRekapUserData(clientId, roleFlag = null) {
       if (!u.insta || !u.tiktok) groups[cid].miss++;
     });
 
-    const entries = await Promise.all(
-      Object.entries(groups).map(async ([cid, stat]) => {
-        const c = await findClientById(cid);
-        const name = (c?.nama || cid).toUpperCase();
-        const updated = stat.total - stat.miss;
-        return { cid, name, stat, updated };
-      })
-    );
+      const entries = await Promise.all(
+        Object.entries(groups).map(async ([cid, stat]) => {
+          const c = await findClientById(cid);
+          const name = (c?.nama || cid).toUpperCase();
+          const updated = stat.total - stat.miss;
+          return { cid, name, stat, updated };
+        })
+      );
 
-    entries.sort((a, b) => {
-      if (a.cid === clientId) return -1;
-      if (b.cid === clientId) return 1;
-      return a.name.localeCompare(b.name);
-    });
+      entries.sort((a, b) => {
+        if (a.cid === clientId) return -1;
+        if (b.cid === clientId) return 1;
+        return a.name.localeCompare(b.name);
+      });
 
-    const lines = entries.map(
-      (e, idx) =>
-        `${idx + 1}. ${e.name}\n\n` +
-        `Jumlah User: ${e.stat.total}\n` +
-        `Jumlah User Sudah Update: ${e.updated}\n` +
-        `Jumlah User Belum Update: ${e.stat.miss}`
-    );
+      const totals = entries.reduce(
+        (acc, e) => {
+          acc.total += e.stat.total;
+          acc.updated += e.updated;
+          acc.miss += e.stat.miss;
+          return acc;
+        },
+        { total: 0, updated: 0, miss: 0 }
+      );
 
-    const header =
-      `${salam},\n\n` +
-      `Mohon ijin Komandan, melaporkan absensi update data personil ${
-        (client?.nama || clientId).toUpperCase()
-      } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:`;
-    const body = lines.length ? `\n\n${lines.join("\n\n")}` : "";
-    return `${header}${body}`.trim();
+      const lines = entries.map(
+        (e, idx) =>
+          `${idx + 1}. ${e.name}\n\n` +
+          `Jumlah User: ${e.stat.total}\n` +
+          `Jumlah User Sudah Update: ${e.updated}\n` +
+          `Jumlah User Belum Update: ${e.stat.miss}`
+      );
+
+      const header =
+        `${salam},\n\n` +
+        `Mohon ijin Komandan, melaporkan absensi update data personil ${
+          (client?.nama || clientId).toUpperCase()
+        } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:\n\n` +
+        `Jumlah Total User : ${totals.total}\n` +
+        `Jumlah Total User Sudah Update Data : ${totals.updated}\n` +
+        `Jumlah Total User Belum Update Data : ${totals.miss}`;
+      const body = lines.length ? `\n\n${lines.join("\n\n")}` : "";
+      return `${header}${body}`.trim();
   }
 
   const complete = {};

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -65,33 +65,43 @@ async function formatRekapUserData(clientId, roleFlag = null) {
     });
     noData.sort((a, b) => a.name.localeCompare(b.name));
 
-    const withDataLines = withData.map(
-      (e, idx) =>
-        `${idx + 1}. ${e.name}\n\n` +
-        `Jumlah User: ${e.stat.total}\n` +
-        `Jumlah User Sudah Update: ${e.updated}\n` +
-        `Jumlah User Belum Update: ${e.stat.miss}`
-    );
-    const noDataLines = noData.map((e, idx) => `${idx + 1}. ${e.name}`);
-
-    const header =
-      `${salam},\n\n` +
-      `Mohon ijin Komandan, melaporkan absensi update data personil ${
-        (client?.nama || clientId).toUpperCase()
-      } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:`;
-
-    const sections = [];
-    if (withDataLines.length) {
-      const totalUpdated = withData.reduce((sum, e) => sum + e.updated, 0);
-      sections.push(
-        `Jumlah Total Personil Sudah Input: ${totalUpdated}\n\nSudah Input Data:\n\n${withDataLines.join("\n\n")}`
+      const withDataLines = withData.map(
+        (e, idx) =>
+          `${idx + 1}. ${e.name}\n\n` +
+          `Jumlah User: ${e.stat.total}\n` +
+          `Jumlah User Sudah Update: ${e.updated}\n` +
+          `Jumlah User Belum Update: ${e.stat.miss}`
       );
-    }
-    if (noDataLines.length)
-      sections.push(`Client Belum Input Data:\n${noDataLines.join("\n")}`);
-    const body = sections.length ? `\n\n${sections.join("\n\n")}` : "";
+      const noDataLines = noData.map((e, idx) => `${idx + 1}. ${e.name}`);
 
-    return `${header}${body}`.trim();
+      const totals = filteredEntries.reduce(
+        (acc, e) => {
+          acc.total += e.stat.total;
+          acc.updated += e.updated;
+          acc.miss += e.stat.miss;
+          return acc;
+        },
+        { total: 0, updated: 0, miss: 0 }
+      );
+
+      const header =
+        `${salam},\n\n` +
+        `Mohon ijin Komandan, melaporkan absensi update data personil ${
+          (client?.nama || clientId).toUpperCase()
+        } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:`;
+
+      const sections = [
+        `Jumlah Total User : ${totals.total}\n` +
+          `Jumlah Total User Sudah Update Data : ${totals.updated}\n` +
+          `Jumlah Total User Belum Update Data : ${totals.miss}`,
+      ];
+      if (withDataLines.length)
+        sections.push(`Sudah Input Data:\n\n${withDataLines.join("\n\n")}`);
+      if (noDataLines.length)
+        sections.push(`Client Belum Input Data:\n${noDataLines.join("\n")}`);
+      const body = `\n\n${sections.join("\n\n")}`;
+
+      return `${header}${body}`.trim();
   }
 
   const complete = {};
@@ -189,6 +199,16 @@ async function rekapUserDataDitbinmas() {
 
   entries.sort((a, b) => a.name.localeCompare(b.name));
 
+  const totals = entries.reduce(
+    (acc, e) => {
+      acc.total += e.stat.total;
+      acc.updated += e.updated;
+      acc.miss += e.stat.miss;
+      return acc;
+    },
+    { total: 0, updated: 0, miss: 0 }
+  );
+
   const lines = entries.map(
     (e, idx) =>
       `${idx + 1}. ${e.name}\n\n` +
@@ -202,7 +222,10 @@ async function rekapUserDataDitbinmas() {
     `${salam},\n\n` +
     `Mohon ijin Komandan, melaporkan absensi update data personil ${
       (client?.nama || clientId).toUpperCase()
-    } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:`;
+    } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:\n\n` +
+    `Jumlah Total User : ${totals.total}\n` +
+    `Jumlah Total User Sudah Update Data : ${totals.updated}\n` +
+    `Jumlah Total User Belum Update Data : ${totals.miss}`;
   const body = lines.length ? `\n\n${lines.join("\n\n")}` : "";
   return `${header}${body}`.trim();
 }

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -327,7 +327,7 @@ test('choose_menu formats directorate report header', async () => {
   const msg = waClient.sendMessage.mock.calls[0][1];
   expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('BINMAS', null);
   expect(msg).toBe(
-    'Selamat siang,\n\nMohon ijin Komandan, melaporkan absensi update data personil DIREKTORAT BINMAS pada hari Rabu, 20 Agustus 2025, pukul 14.28 WIB, sebagai berikut:'
+    'Selamat siang,\n\nMohon ijin Komandan, melaporkan absensi update data personil DIREKTORAT BINMAS pada hari Rabu, 20 Agustus 2025, pukul 14.28 WIB, sebagai berikut:\n\nJumlah Total User : 0\nJumlah Total User Sudah Update Data : 0\nJumlah Total User Belum Update Data : 0'
   );
 
   jest.useRealTimers();

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -72,7 +72,9 @@ test('choose_menu aggregates directorate data by client_id', async () => {
   expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas');
   const msg = waClient.sendMessage.mock.calls[0][1];
   expect(msg).not.toMatch(/1\. DIT BINMAS/);
-  expect(msg).toContain('Jumlah Total Personil Sudah Input: 1');
+  expect(msg).toContain('Jumlah Total User : 1');
+  expect(msg).toContain('Jumlah Total User Sudah Update Data : 1');
+  expect(msg).toContain('Jumlah Total User Belum Update Data : 0');
   expect(msg).toContain('POLRES PASURUAN KOTA');
   expect(msg.match(/POLRES PASURUAN KOTA/g).length).toBe(1);
   expect(msg).toMatch(/Client Belum Input Data:\n1\. POLRES SIDOARJO/);
@@ -107,6 +109,9 @@ test('choose_menu option 2 rekap user data ditbinmas', async () => {
 
   expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('ditbinmas');
   const msg = waClient.sendMessage.mock.calls[0][1];
+  expect(msg).toContain('Jumlah Total User : 3');
+  expect(msg).toContain('Jumlah Total User Sudah Update Data : 1');
+  expect(msg).toContain('Jumlah Total User Belum Update Data : 2');
   expect(msg).toContain('POLRES A');
   expect(msg).toContain('Jumlah User: 2');
   expect(msg).toContain('Jumlah User Sudah Update: 1');


### PR DESCRIPTION
## Summary
- show total, updated, and pending user counts in rekap reports
- update directorate and Ditbinmas rekap logic
- adjust tests for new totals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afdd7d4718832789291fe55018ca79