### PR TITLE
Restrict Ditbinmas rekap to Ditbinmas users grouped by satfung

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -165,7 +165,9 @@ async function formatRekapUserData(clientId, roleFlag = null) {
 
 async function rekapUserDataDitbinmas() {
   const clientId = "ditbinmas";
-  const users = await getUsersSocialByClient(clientId);
+  const users = (await getUsersSocialByClient(clientId, clientId)).filter(
+    (u) => (u.client_id || "").toLowerCase() === clientId
+  );
   const salam = getGreeting();
   const now = new Date();
   const hari = now.toLocaleDateString("id-ID", { weekday: "long" });

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -91,9 +91,10 @@ test('choose_menu option 2 rekap user data ditbinmas', async () => {
   jest.setSystemTime(new Date('2025-08-27T16:06:00Z'));
 
   mockGetUsersSocialByClient.mockResolvedValue([
-    { divisi: 'Sat A', title: 'AKP', nama: 'Budi' },
-    { divisi: 'Sat A', title: 'Bripka', nama: 'Agus' },
-    { divisi: 'Sat B', title: 'Kompol', nama: 'Charlie' },
+    { client_id: 'ditbinmas', divisi: 'Sat A', title: 'AKP', nama: 'Budi' },
+    { client_id: 'ditbinmas', divisi: 'Sat A', title: 'Bripka', nama: 'Agus' },
+    { client_id: 'ditbinmas', divisi: 'Sat B', title: 'Kompol', nama: 'Charlie' },
+    { client_id: 'other', divisi: 'Sat C', title: 'Aiptu', nama: 'Dodi' },
   ]);
   mockFindClientById.mockImplementation(async (cid) => ({
     ditbinmas: { nama: 'DIT BINMAS' },
@@ -105,12 +106,13 @@ test('choose_menu option 2 rekap user data ditbinmas', async () => {
 
   await dirRequestHandlers.choose_menu(session, chatId, '2', waClient);
 
-  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('ditbinmas');
+  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
   const msg = waClient.sendMessage.mock.calls[0][1];
   expect(msg).toContain('SAT A (2)');
   expect(msg).toContain('AKP Budi');
   expect(msg).toContain('Bripka Agus');
   expect(msg).toContain('SAT B (1)');
   expect(msg).toContain('Kompol Charlie');
+  expect(msg).not.toMatch(/Aiptu Dodi/);
   jest.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- filter Rekap User Data Ditbinmas to only users with client and role `ditbinmas`
- test that rekap excludes other clients and lists rank and name grouped by satfung

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afe0c6eefc83279623e94d3de69333