### PR TITLE
Add hourly dirrequest recap cron job

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ import './src/cron/cronAmplifyLinkMonthly.js';
 import './src/cron/cronPremiumRequest.js';
 import './src/cron/cronAbsensiUserData.js';
 import './src/cron/cronAbsensiOprDitbinmas.js';
+import './src/cron/cronDirRequest.js';
 import './src/cron/cronDbBackup.js';
 
 const app = express();

--- a/src/cron/cronDirRequest.js
+++ b/src/cron/cronDirRequest.js
@@ -1,0 +1,82 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import waClient from "../service/waService.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+import { formatRekapUserData, rekapUserDataDitbinmas } from "../handler/menu/dirRequestHandlers.js";
+
+async function getActiveClients() {
+  const { query } = await import("../db/index.js");
+  const rows = await query(
+    `SELECT client_id
+     FROM clients
+     WHERE client_status=true
+     ORDER BY client_id`
+  );
+  return rows.rows;
+}
+
+function toWAid(number) {
+  if (!number || typeof number !== "string") return null;
+  const no = number.trim();
+  if (!no) return null;
+  if (no.endsWith("@c.us")) return no;
+  return no.replace(/\D/g, "") + "@c.us";
+}
+
+function getAdminWAIds() {
+  return (process.env.ADMIN_WHATSAPP || "")
+    .split(",")
+    .map((n) => n.trim())
+    .filter(Boolean)
+    .map(toWAid)
+    .filter(Boolean);
+}
+
+const cronTag = "CRON DIRREQUEST";
+
+cron.schedule(
+  "0 7-20 * * *",
+  async () => {
+    sendDebug({ tag: cronTag, msg: "Mulai rekap dirrequest" });
+    try {
+      const admins = getAdminWAIds();
+      const clients = await getActiveClients();
+      for (const client of clients) {
+        try {
+          const msg1 = await formatRekapUserData(client.client_id);
+          for (const wa of admins) {
+            await waClient.sendMessage(wa, msg1).catch(() => {});
+          }
+          sendDebug({
+            tag: cronTag,
+            msg: `[${client.client_id}] Rekap menu 1 dikirim ke ${admins.length} admin`,
+          });
+        } catch (err) {
+          sendDebug({
+            tag: cronTag,
+            msg: `[${client.client_id}] ERROR menu 1: ${err.message}`,
+          });
+        }
+      }
+      try {
+        const msg2 = await rekapUserDataDitbinmas();
+        for (const wa of admins) {
+          await waClient.sendMessage(wa, msg2).catch(() => {});
+        }
+        sendDebug({
+          tag: cronTag,
+          msg: `Rekap menu 2 dikirim ke ${admins.length} admin`,
+        });
+      } catch (err) {
+        sendDebug({ tag: cronTag, msg: `[ERROR menu 2] ${err.message}` });
+      }
+    } catch (err) {
+      sendDebug({ tag: cronTag, msg: `[ERROR GLOBAL] ${err.message || err}` });
+    }
+  },
+  { timezone: "Asia/Jakarta" }
+);
+
+export default null;

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -360,5 +360,7 @@ export const dirRequestHandlers = {
   },
 };
 
+export { formatRekapUserData, rekapUserDataDitbinmas };
+
 export default dirRequestHandlers;
 


### PR DESCRIPTION
## Summary
- expose user data recap helpers for reuse
- schedule hourly dirrequest recap cron to send menus 1 and 2 to admins
- load the new cron in application startup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afe3a656f083279d7739eea1695f45