### PR TITLE
Restrict WhatsApp group update command to admins

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -176,7 +176,8 @@ waClient.on("message", async (msg) => {
   const isAdminCommand = adminCommands.some((cmd) =>
     text.toLowerCase().startsWith(cmd)
   );
-  const isAdmin = isAdminWhatsApp(chatId);
+  const senderId = msg.author || chatId;
+  const isAdmin = isAdminWhatsApp(senderId);
 
   // =========== Menu User Interaktif ===========
   if (userMenuContext[chatId] && text.toLowerCase() === "batal") {
@@ -1355,6 +1356,13 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       await waClient.sendMessage(
         chatId,
         "❌ Perintah ini hanya bisa digunakan di dalam group WhatsApp!"
+      );
+      return;
+    }
+    if (!isAdmin) {
+      await waClient.sendMessage(
+        chatId,
+        "❌ Perintah ini hanya bisa digunakan oleh admin WhatsApp!"
       );
       return;
     }


### PR DESCRIPTION
## Summary
- Ensure admin detection uses the message sender so group messages identify WhatsApp admins correctly
- Limit `thisgroup#` command to WhatsApp admins before updating a client's group ID

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afed12e6d08327bedb668db2f6b646