### PR TITLE
Fix thisgroup command group assignment

### DIFF
--- a/src/model/clientModel.js
+++ b/src/model/clientModel.js
@@ -97,7 +97,7 @@ export const update = async (client_id, clientData) => {
     RETURNING *
   `;
   const values = [
-    client_id,
+    old.client_id,
     merged.nama,
     merged.client_type,
     merged.client_status,

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1366,7 +1366,8 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       );
       return;
     }
-    const [, client_id] = text.split("#");
+    const [, rawClientId] = text.split("#");
+    const client_id = (rawClientId || "").trim();
     if (!client_id) {
       await waClient.sendMessage(
         chatId,


### PR DESCRIPTION
## Summary
- ensure client update uses canonical ID to save group ids regardless of casing
- trim client id from thisgroup command input before updating

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff72898e48327bfc679853420e714