### PR TITLE
Normalize admin WhatsApp env numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This allows operators to scope responses to the correct client.
     DB_PASS=secret
     DB_PORT=5432
     DB_DRIVER=postgres
-    ADMIN_WHATSAPP=628xxxxxx@c.us,628yyyyyy@c.us
+    ADMIN_WHATSAPP=628xxxxxx,628yyyyyy
     CLIENT_OPERATOR=628123456789
     NEXT_PUBLIC_API_URL=http://localhost:3000/api
     NEXT_PUBLIC_ADMIN_WHATSAPP=628xxxxxx@c.us
@@ -85,6 +85,7 @@ This allows operators to scope responses to the correct client.
     BACKUP_DIR=./backups
     GOOGLE_DRIVE_FOLDER_ID=your-drive-folder-id
     ```
+   `ADMIN_WHATSAPP` accepts numbers with or without the `@c.us` suffix. When the suffix is omitted, the application automatically appends it.
    `GOOGLE_SERVICE_ACCOUNT` may be set to a JSON string or a path to a JSON file. If the value starts with `/` or ends with `.json`, the application reads the file; otherwise it parses the variable directly as JSON. `GOOGLE_IMPERSONATE_EMAIL` should be set to the Workspace user to impersonate when performing contact operations.
 
 3. **Set up Redis**

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -11,7 +11,9 @@ export function getAdminWhatsAppList() {
   return (process.env.ADMIN_WHATSAPP || '')
     .split(',')
     .map(s => s.trim())
-    .filter(wid => wid.endsWith('@c.us') && wid.length > 10);
+    .filter(Boolean)
+    .map(wid => (wid.endsWith('@c.us') ? wid : wid.replace(/\D/g, '') + '@c.us'))
+    .filter(wid => wid.length > 10);
 }
 
 export async function sendWAReport(waClient, message, chatIds = null) {


### PR DESCRIPTION
## Summary
- allow ADMIN_WHATSAPP numbers without '@c.us'
- document optional '@c.us' suffix for ADMIN_WHATSAPP

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0005198bc8327a9bb2d1682b8066b