### PR TITLE
refine thisgroup access check

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -547,7 +547,11 @@ Ketik *angka* menu, atau *batal* untuk keluar.
 
 
   // ========== VALIDASI ADMIN COMMAND ==========
-  if (isAdminCommand && !isAdmin) {
+  if (
+    isAdminCommand &&
+    !isAdmin &&
+    !text.toLowerCase().startsWith("thisgroup#")
+  ) {
     await waClient.sendMessage(
       chatId,
       "❌ Anda tidak memiliki akses ke sistem ini."


### PR DESCRIPTION
## Summary
- avoid generic access denial for `thisgroup#` command so group-specific admin messaging can run

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b002e363808327bc180569e1ce93e5