### PR TITLE
Allow group admins to link group

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1363,7 +1363,20 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       );
       return;
     }
-    if (!isAdmin) {
+    let isGroupAdmin = false;
+    try {
+      const chat = await msg.getChat();
+      const participant = chat.participants?.find(
+        (p) => p.id?._serialized === senderId
+      );
+      isGroupAdmin = participant?.isAdmin || participant?.isSuperAdmin || false;
+    } catch (e) {
+      console.error(
+        "[WA] Gagal memeriksa status admin grup:",
+        e.message
+      );
+    }
+    if (!isAdmin && !isGroupAdmin) {
       await waClient.sendMessage(
         chatId,
         "❌ Perintah ini hanya bisa digunakan oleh admin WhatsApp!"


### PR DESCRIPTION
## Summary
- allow WhatsApp group admins to use `thisgroup#` command by checking group admin status

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00857b7d08327ac5b6926d2e3ba81