### PR TITLE
Allow group ID command for all members

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1353,33 +1353,13 @@ Ketik *angka* menu, atau *batal* untuk keluar.
   }
 
   // =========================
-  // === UPDATE client_group dari WhatsApp GROUP (ADMIN)
+  // === UPDATE client_group dari WhatsApp GROUP
   // =========================
   if (text.toLowerCase().startsWith("thisgroup#")) {
     if (!msg.from.endsWith("@g.us")) {
       await waClient.sendMessage(
         chatId,
         "❌ Perintah ini hanya bisa digunakan di dalam group WhatsApp!"
-      );
-      return;
-    }
-    let isGroupAdmin = false;
-    try {
-      const chat = await msg.getChat();
-      const participant = chat.participants?.find(
-        (p) => p.id?._serialized === senderId
-      );
-      isGroupAdmin = participant?.isAdmin || participant?.isSuperAdmin || false;
-    } catch (e) {
-      console.error(
-        "[WA] Gagal memeriksa status admin grup:",
-        e.message
-      );
-    }
-    if (!isAdmin && !isGroupAdmin) {
-      await waClient.sendMessage(
-        chatId,
-        "❌ Perintah ini hanya bisa digunakan oleh admin WhatsApp!"
       );
       return;
     }


### PR DESCRIPTION
## Summary
- drop WhatsApp admin check for `thisgroup#` command so any group member can link a group

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b015348d4083279cf98a53c13f3950