### PR TITLE
Sort dirrequest recap by update and user counts

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -61,6 +61,7 @@ async function formatRekapUserData(clientId, roleFlag = null) {
 
     withData.sort((a, b) => {
       if (a.updated !== b.updated) return b.updated - a.updated;
+      if (a.stat.total !== b.stat.total) return b.stat.total - a.stat.total;
       return a.name.localeCompare(b.name);
     });
     noData.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- order dirrequest recap by updated users then total user count
- add regression test for recap ordering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03683163c83279f9ae2997d0d45de