### PR TITLE
Filter org attendance to operator role

### DIFF
--- a/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
+++ b/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
@@ -1,5 +1,9 @@
 import { query } from "../../../db/index.js";
-import { getUsersByClient, getUsersByDirektorat } from "../../../model/userModel.js";
+import {
+  getUsersByClient,
+  getUsersByDirektorat,
+  getOperatorsByClient,
+} from "../../../model/userModel.js";
 import { getShortcodesTodayByClient } from "../../../model/instaPostModel.js";
 import {
   getReportsTodayByClient,
@@ -38,6 +42,9 @@ export async function absensiLink(client_id, opts = {}) {
     users = (
       await getUsersByDirektorat(flag, clientFilter || null)
     ).filter((u) => u.status === true);
+  } else if (clientType === "org") {
+    shortcodes = await getShortcodesTodayByClient(client_id);
+    users = await getOperatorsByClient(clientFilter || client_id);
   } else {
     shortcodes = await getShortcodesTodayByClient(client_id);
     users = await getUsersByClient(clientFilter || client_id, roleFlag);

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -112,6 +112,19 @@ export async function getUsersByClient(client_id, roleFilter = null) {
   return res.rows;
 }
 
+export async function getOperatorsByClient(client_id) {
+  const { clause, params } = await buildClientFilter(client_id, 'u', 1);
+  const res = await query(
+    `SELECT u.user_id, u.nama, u.tiktok, u.insta, u.divisi, u.title, u.status, u.exception
+     FROM "user" u
+     JOIN user_roles ur_opr ON ur_opr.user_id = u.user_id
+     JOIN roles r_opr ON ur_opr.role_id = r_opr.role_id
+     WHERE ${clause} AND u.status = true AND LOWER(r_opr.role_name) = 'operator'`,
+    params
+  );
+  return res.rows;
+}
+
 // Ambil semua user aktif (status = true/NULL), khusus absensi TikTok
 export async function getUsersByClientFull(client_id, roleFilter = null) {
   const { clause, params } = await buildClientFilter(client_id, 'u', 1, roleFilter);

--- a/tests/absensiLinkDirektorat.test.js
+++ b/tests/absensiLinkDirektorat.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 const mockQuery = jest.fn();
 const mockGetUsersByDirektorat = jest.fn();
+const mockGetOperatorsByClient = jest.fn();
 const mockGetShortcodesTodayByClient = jest.fn();
 const mockGetReportsTodayByClient = jest.fn();
 
@@ -9,6 +10,7 @@ jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
   getUsersByClient: jest.fn(),
   getUsersByDirektorat: mockGetUsersByDirektorat,
+  getOperatorsByClient: mockGetOperatorsByClient,
 }));
 jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
   getShortcodesTodayByClient: mockGetShortcodesTodayByClient,

--- a/tests/absensiLinkOrgOperator.test.js
+++ b/tests/absensiLinkOrgOperator.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByClient = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetOperatorsByClient = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+const mockGetReportsTodayByClient = jest.fn();
+const mockGetReportsTodayByShortcode = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: mockGetUsersByClient,
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+  getOperatorsByClient: mockGetOperatorsByClient,
+}));
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+jest.unstable_mockModule('../src/model/linkReportModel.js', () => ({
+  getReportsTodayByClient: mockGetReportsTodayByClient,
+  getReportsTodayByShortcode: mockGetReportsTodayByShortcode,
+}));
+
+let absensiLink;
+
+beforeAll(async () => {
+  ({ absensiLink } = await import('../src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('uses operator role for org clients', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'org' }] });
+  mockGetOperatorsByClient.mockResolvedValueOnce([]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
+
+  await absensiLink('ORG1');
+
+  expect(mockGetOperatorsByClient).toHaveBeenCalledWith('ORG1');
+  expect(mockGetUsersByClient).not.toHaveBeenCalled();
+  expect(mockGetUsersByDirektorat).not.toHaveBeenCalled();
+});

--- a/tests/absensiLinkRoleFlag.test.js
+++ b/tests/absensiLinkRoleFlag.test.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 const mockQuery = jest.fn();
 const mockGetUsersByClient = jest.fn();
 const mockGetUsersByDirektorat = jest.fn();
+const mockGetOperatorsByClient = jest.fn();
 const mockGetShortcodesTodayByClient = jest.fn();
 const mockGetReportsTodayByClient = jest.fn();
 const mockGetReportsTodayByShortcode = jest.fn();
@@ -11,6 +12,7 @@ jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
   getUsersByClient: mockGetUsersByClient,
   getUsersByDirektorat: mockGetUsersByDirektorat,
+  getOperatorsByClient: mockGetOperatorsByClient,
 }));
 jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
   getShortcodesTodayByClient: mockGetShortcodesTodayByClient,


### PR DESCRIPTION
## Summary
- add getOperatorsByClient helper for fetching operator-role users
- restrict Absensi Amplifikasi User to operator role when client_type is org
- test operator-only attendance for org clients

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03a37c48c83278195fb3c131c35d6