### PR TITLE
Restrict org absensi menus to operator users

### DIFF
--- a/src/handler/fetchabsensi/link/absensiLinkKhusus.js
+++ b/src/handler/fetchabsensi/link/absensiLinkKhusus.js
@@ -1,5 +1,5 @@
 import { query } from "../../../db/index.js";
-import { getUsersByClient } from "../../../model/userModel.js";
+import { getUsersByClient, getOperatorsByClient } from "../../../model/userModel.js";
 import {
   getShortcodesTodayByClient,
 } from "../../../model/instaPostKhususModel.js";
@@ -10,12 +10,15 @@ import {
 import { hariIndo } from "../../../utils/constants.js";
 import { groupByDivision, sortDivisionKeys, getGreeting } from "../../../utils/utilsHelper.js";
 
-async function getClientNama(client_id) {
+async function getClientInfo(client_id) {
   const res = await query(
-    "SELECT nama FROM clients WHERE client_id = $1 LIMIT 1",
+    "SELECT nama, client_type FROM clients WHERE client_id = $1 LIMIT 1",
     [client_id]
   );
-  return res.rows[0]?.nama || client_id;
+  return {
+    nama: res.rows[0]?.nama || client_id,
+    clientType: res.rows[0]?.client_type || null,
+  };
 }
 
 export async function absensiLinkKhusus(client_id) {
@@ -24,8 +27,11 @@ export async function absensiLinkKhusus(client_id) {
   const tanggal = now.toLocaleDateString("id-ID");
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
-  const clientNama = await getClientNama(client_id);
-  const users = await getUsersByClient(client_id);
+  const { nama: clientNama, clientType } = await getClientInfo(client_id);
+  const users =
+    clientType === "org"
+      ? await getOperatorsByClient(client_id)
+      : await getUsersByClient(client_id);
   const shortcodes = await getShortcodesTodayByClient(client_id);
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;
@@ -128,8 +134,11 @@ export async function absensiLinkKhususPerPost(client_id, opts = {}) {
   const tanggal = now.toLocaleDateString("id-ID");
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
-  const clientNama = await getClientNama(client_id);
-  const users = await getUsersByClient(client_id);
+  const { nama: clientNama, clientType } = await getClientInfo(client_id);
+  const users =
+    clientType === "org"
+      ? await getOperatorsByClient(client_id)
+      : await getUsersByClient(client_id);
   const shortcodes = await getShortcodesTodayByClient(client_id);
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -115,7 +115,7 @@ export async function getUsersByClient(client_id, roleFilter = null) {
 export async function getOperatorsByClient(client_id) {
   const { clause, params } = await buildClientFilter(client_id, 'u', 1);
   const res = await query(
-    `SELECT u.user_id, u.nama, u.tiktok, u.insta, u.divisi, u.title, u.status, u.exception
+    `SELECT u.user_id, u.nama, u.tiktok, u.insta, u.divisi, u.title, u.status, u.exception, u.whatsapp
      FROM "user" u
      JOIN user_roles ur_opr ON ur_opr.user_id = u.user_id
      JOIN roles r_opr ON ur_opr.role_id = r_opr.role_id

--- a/tests/absensiLinkKhususOrgOperator.test.js
+++ b/tests/absensiLinkKhususOrgOperator.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByClient = jest.fn();
+const mockGetOperatorsByClient = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+const mockGetReportsTodayByClient = jest.fn();
+const mockGetReportsTodayByShortcode = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: mockGetUsersByClient,
+  getOperatorsByClient: mockGetOperatorsByClient,
+}));
+jest.unstable_mockModule('../src/model/instaPostKhususModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+jest.unstable_mockModule('../src/model/linkReportKhususModel.js', () => ({
+  getReportsTodayByClient: mockGetReportsTodayByClient,
+  getReportsTodayByShortcode: mockGetReportsTodayByShortcode,
+}));
+
+let absensiLinkKhusus;
+
+beforeAll(async () => {
+  ({ absensiLinkKhusus } = await import('../src/handler/fetchabsensi/link/absensiLinkKhusus.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('uses operator role for org clients', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'org' }] });
+  mockGetOperatorsByClient.mockResolvedValueOnce([]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
+
+  await absensiLinkKhusus('ORG1');
+
+  expect(mockGetOperatorsByClient).toHaveBeenCalledWith('ORG1');
+  expect(mockGetUsersByClient).not.toHaveBeenCalled();
+});
+

--- a/tests/absensiRegistrasiOrgOperator.test.js
+++ b/tests/absensiRegistrasiOrgOperator.test.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersWithWaByClient = jest.fn();
+const mockGetOperatorsByClient = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersWithWaByClient: mockGetUsersWithWaByClient,
+  getOperatorsByClient: mockGetOperatorsByClient,
+}));
+
+let absensiRegistrasiWa;
+
+beforeAll(async () => {
+  ({ absensiRegistrasiWa } = await import('../src/handler/fetchabsensi/wa/absensiRegistrasiWa.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('uses operator role for org clients', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'org' }] });
+  mockGetOperatorsByClient.mockResolvedValueOnce([]);
+
+  await absensiRegistrasiWa('ORG1');
+
+  expect(mockGetOperatorsByClient).toHaveBeenCalledWith('ORG1');
+  expect(mockGetUsersWithWaByClient).not.toHaveBeenCalled();
+});
+


### PR DESCRIPTION
## Summary
- When client type is org, use operator-only queries for Absensi Amplifikasi Khusus and Absensi Registrasi
- Include WhatsApp field in operator fetch
- Add tests covering operator filtering for org clients

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03cac4cf0832784905cb343078faa