### PR TITLE
Ensure operator-only absensi for org clients

### DIFF
--- a/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
+++ b/src/handler/fetchabsensi/link/absensiLinkAmplifikasi.js
@@ -19,7 +19,7 @@ async function getClientInfo(client_id) {
   );
   return {
     nama: res.rows[0]?.nama || client_id,
-    clientType: res.rows[0]?.client_type || null,
+    clientType: res.rows[0]?.client_type?.toLowerCase() || null,
   };
 }
 

--- a/src/handler/fetchabsensi/link/absensiLinkKhusus.js
+++ b/src/handler/fetchabsensi/link/absensiLinkKhusus.js
@@ -17,7 +17,7 @@ async function getClientInfo(client_id) {
   );
   return {
     nama: res.rows[0]?.nama || client_id,
-    clientType: res.rows[0]?.client_type || null,
+    clientType: res.rows[0]?.client_type?.toLowerCase() || null,
   };
 }
 

--- a/src/handler/fetchabsensi/wa/absensiRegistrasiWa.js
+++ b/src/handler/fetchabsensi/wa/absensiRegistrasiWa.js
@@ -13,7 +13,7 @@ async function getClientInfo(client_id) {
   );
   return {
     nama: res.rows[0]?.nama || client_id,
-    clientType: res.rows[0]?.client_type || null,
+    clientType: res.rows[0]?.client_type?.toLowerCase() || null,
   };
 }
 

--- a/tests/absensiLinkKhususOrgOperator.test.js
+++ b/tests/absensiLinkKhususOrgOperator.test.js
@@ -31,7 +31,7 @@ beforeEach(() => {
 });
 
 test('uses operator role for org clients', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'org' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'ORG' }] });
   mockGetOperatorsByClient.mockResolvedValueOnce([]);
   mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
 

--- a/tests/absensiLinkOrgOperator.test.js
+++ b/tests/absensiLinkOrgOperator.test.js
@@ -33,7 +33,7 @@ beforeEach(() => {
 });
 
 test('uses operator role for org clients', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'org' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'ORG' }] });
   mockGetOperatorsByClient.mockResolvedValueOnce([]);
   mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
 

--- a/tests/absensiRegistrasiOrgOperator.test.js
+++ b/tests/absensiRegistrasiOrgOperator.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
 });
 
 test('uses operator role for org clients', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'org' }] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'ORG A', client_type: 'ORG' }] });
   mockGetOperatorsByClient.mockResolvedValueOnce([]);
 
   await absensiRegistrasiWa('ORG1');


### PR DESCRIPTION
## Summary
- Normalize client type to lowercase in absensi handlers so org clients only include operator roles
- Add tests for uppercase client type to verify operator filtering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03f1800988327baa0cd116eed6844