### PR TITLE
Use DITBINMAS Instagram for directorate like attendance

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -81,7 +81,7 @@ export async function absensiLikes(client_id, opts = {}) {
     const reports = [];
     for (const cid of polresIds) {
       const users = usersByClient[cid] || [];
-      const { nama: polresNama } = await getClientInfo(cid);
+      const { nama: clientName } = await getClientInfo(cid);
       const sudah = [];
       const belum = [];
       const noUsername = [];
@@ -103,7 +103,7 @@ export async function absensiLikes(client_id, opts = {}) {
         else belum.push(u);
       });
       reports.push(
-        `*Polres*: *${polresNama}*\n` +
+        `*Client*: *${clientName}*\n` +
           `*Jumlah user:* ${users.length}\n` +
           `✅ *Sudah melaksanakan* : *${sudah.length} user*\n` +
           `❌ *Belum melaksanakan* : *${belum.length} user*\n` +

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -217,11 +217,17 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = await rekapUserDataDitbinmas();
       break;
     case "3":
-      msg = await absensiLikes(clientId, {
-        ...(userType === "org" ? { clientFilter: userClientId } : {}),
-        mode: "all",
-        roleFlag,
-      });
+      {
+        const opts = { mode: "all", roleFlag };
+        const directorateRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+        if (
+          userType === "org" &&
+          !directorateRoles.includes((clientId || "").toLowerCase())
+        ) {
+          opts.clientFilter = userClientId;
+        }
+        msg = await absensiLikes(clientId, opts);
+      }
       break;
     case "4":
       msg = await absensiKomentar(clientId, {

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -133,7 +133,7 @@ test('directorate summarizes across clients', async () => {
     'POLRESA',
     'POLRESB',
   ]);
-  expect(msg).toMatch(/Polres\*: \*POLRES A\*[\s\S]*Sudah melaksanakan\* : \*1 user\*[\s\S]*Belum melaksanakan\* : \*0 user\*[\s\S]*Belum input username\* : \*1 user/);
-  expect(msg).toMatch(/Polres\*: \*POLRES B\*[\s\S]*Sudah melaksanakan\* : \*0 user\*[\s\S]*Belum melaksanakan\* : \*1 user\*[\s\S]*Belum input username\* : \*0 user/);
+  expect(msg).toMatch(/Client\*: \*POLRES A\*[\s\S]*Sudah melaksanakan\* : \*1 user\*[\s\S]*Belum melaksanakan\* : \*0 user\*[\s\S]*Belum input username\* : \*1 user/);
+  expect(msg).toMatch(/Client\*: \*POLRES B\*[\s\S]*Sudah melaksanakan\* : \*0 user\*[\s\S]*Belum melaksanakan\* : \*1 user\*[\s\S]*Belum input username\* : \*0 user/);
 });
 

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -151,3 +151,24 @@ test('choose_menu option 2 rekap user data ditbinmas', async () => {
   expect(msg).not.toMatch(/Aiptu Dodi/);
   jest.useRealTimers();
 });
+
+test('choose_menu option 3 absensi likes uses ditbinmas data for all users', async () => {
+  mockAbsensiLikes.mockResolvedValue('laporan');
+  mockFindClientById.mockResolvedValue({ client_type: 'org', nama: 'POLRES A' });
+
+  const session = {
+    role: 'ditbinmas',
+    selectedClientId: 'polres_a',
+    clientName: 'POLRES A',
+    dir_client_id: 'ditbinmas',
+  };
+  const chatId = '999';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '3', waClient);
+
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('ditbinmas', {
+    mode: 'all',
+    roleFlag: 'ditbinmas',
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid client-based filtering when running dirrequest absensi likes for directorates
- Group likes attendance by client name instead of Polres label
- Add coverage for dirrequest absensi likes and update existing tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0505c4a288327940de8c7212dc622