### PR TITLE
feat: enhance ditbinmas instagram like attendance

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -77,21 +77,21 @@ export async function absensiLikes(client_id, opts = {}) {
     });
 
     const totalKonten = shortcodes.length;
-    const threshold = Math.ceil(totalKonten * 0.5);
     const reports = [];
     for (const cid of polresIds) {
       const users = usersByClient[cid] || [];
       const { nama: clientName } = await getClientInfo(cid);
       const sudah = [];
+      const kurang = [];
       const belum = [];
-      const noUsername = [];
+      const tanpaUsername = [];
       users.forEach((u) => {
         if (u.exception === true) {
           sudah.push(u);
           return;
         }
         if (!u.insta || u.insta.trim() === "") {
-          noUsername.push(u);
+          tanpaUsername.push(u);
           return;
         }
         const uname = normalizeUsername(u.insta);
@@ -99,15 +99,18 @@ export async function absensiLikes(client_id, opts = {}) {
         likesSets.forEach((set) => {
           if (set.has(uname)) count += 1;
         });
-        if (count >= threshold) sudah.push(u);
+        const percentage = totalKonten ? (count / totalKonten) * 100 : 0;
+        if (percentage >= 50) sudah.push(u);
+        else if (percentage > 0) kurang.push(u);
         else belum.push(u);
       });
       reports.push(
         `*Client*: *${clientName}*\n` +
           `*Jumlah user:* ${users.length}\n` +
           `✅ *Sudah melaksanakan* : *${sudah.length} user*\n` +
+          `⚠️ *Kurang melaksanakan* : *${kurang.length} user*\n` +
           `❌ *Belum melaksanakan* : *${belum.length} user*\n` +
-          `⚠️ *Belum input username* : *${noUsername.length} user*`
+          `❓ *Tanpa username* : *${tanpaUsername.length} user*`
       );
     }
 

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -218,15 +218,13 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     case "3":
       {
-        const opts = { mode: "all", roleFlag };
-        const directorateRoles = ["ditbinmas", "ditlantas", "bidhumas"];
-        if (
-          userType === "org" &&
-          !directorateRoles.includes((clientId || "").toLowerCase())
-        ) {
-          opts.clientFilter = userClientId;
+        const normalizedId = (clientId || "").toLowerCase();
+        if (normalizedId !== "ditbinmas") {
+          msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
+          break;
         }
-        msg = await absensiLikes(clientId, opts);
+        const opts = { mode: "all", roleFlag: "ditbinmas" };
+        msg = await absensiLikes("ditbinmas", opts);
       }
       break;
     case "4":

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -94,9 +94,10 @@ test('directorate summarizes across clients', async () => {
     .mockResolvedValueOnce({ rows: [{ nama: 'POLRES A' }] })
     .mockResolvedValueOnce({ rows: [{ nama: 'POLRES B' }] });
   mockGetClientsByRole.mockResolvedValueOnce(['polresa', 'polresb']);
-  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1', 'sc2']);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1', 'sc2', 'sc3']);
   mockGetLikesByShortcode
-    .mockResolvedValueOnce(['user1'])
+    .mockResolvedValueOnce(['user1', 'user3'])
+    .mockResolvedValueOnce(['user3'])
     .mockResolvedValueOnce([]);
   mockGetUsersByDirektorat.mockResolvedValueOnce([
     {
@@ -123,6 +124,14 @@ test('directorate summarizes across clients', async () => {
       exception: false,
       status: true,
     },
+    {
+      user_id: 'u4',
+      nama: 'User4',
+      insta: '@user4',
+      client_id: 'POLRESB',
+      exception: false,
+      status: true,
+    },
   ]);
 
   const msg = await absensiLikes('DITBINMAS');
@@ -133,7 +142,7 @@ test('directorate summarizes across clients', async () => {
     'POLRESA',
     'POLRESB',
   ]);
-  expect(msg).toMatch(/Client\*: \*POLRES A\*[\s\S]*Sudah melaksanakan\* : \*1 user\*[\s\S]*Belum melaksanakan\* : \*0 user\*[\s\S]*Belum input username\* : \*1 user/);
-  expect(msg).toMatch(/Client\*: \*POLRES B\*[\s\S]*Sudah melaksanakan\* : \*0 user\*[\s\S]*Belum melaksanakan\* : \*1 user\*[\s\S]*Belum input username\* : \*0 user/);
+  expect(msg).toMatch(/Client\*: \*POLRES A\*[\s\S]*Sudah melaksanakan\* : \*0 user\*[\s\S]*Kurang melaksanakan\* : \*1 user\*[\s\S]*Belum melaksanakan\* : \*0 user\*[\s\S]*Tanpa username\* : \*1 user/);
+  expect(msg).toMatch(/Client\*: \*POLRES B\*[\s\S]*Sudah melaksanakan\* : \*1 user\*[\s\S]*Kurang melaksanakan\* : \*0 user\*[\s\S]*Belum melaksanakan\* : \*1 user\*[\s\S]*Tanpa username\* : \*0 user/);
 });
 

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -172,3 +172,23 @@ test('choose_menu option 3 absensi likes uses ditbinmas data for all users', asy
     roleFlag: 'ditbinmas',
   });
 });
+
+test('choose_menu option 3 skips when client is not ditbinmas', async () => {
+  mockAbsensiLikes.mockResolvedValue('laporan');
+
+  const session = {
+    role: 'polres',
+    selectedClientId: 'polres_a',
+    clientName: 'POLRES A',
+  };
+  const chatId = '555';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '3', waClient);
+
+  expect(mockAbsensiLikes).not.toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('DITBINMAS')
+  );
+});


### PR DESCRIPTION
## Summary
- restrict dirrequest Instagram like attendance to Ditbinmas only
- track kurang and tanpa username categories in Ditbinmas likes recap
- cover edge cases with new unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05a8a39208327a8bcf13e3381f1b1