### PR TITLE
Normalize DITBINMAS client handling

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -20,7 +20,7 @@ function normalizeUsername(username) {
 
 async function getClientInfo(client_id) {
   const res = await query(
-    "SELECT nama, client_type FROM clients WHERE client_id = $1 LIMIT 1",
+    "SELECT nama, client_type FROM clients WHERE LOWER(client_id) = LOWER($1) LIMIT 1",
     [client_id]
   );
   return {

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -216,17 +216,16 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
     case "2":
       msg = await rekapUserDataDitbinmas();
       break;
-    case "3":
-      {
-        const normalizedId = (clientId || "").toLowerCase();
-        if (normalizedId !== "ditbinmas") {
-          msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
-          break;
-        }
-        const opts = { mode: "all", roleFlag: "ditbinmas" };
-        msg = await absensiLikes("ditbinmas", opts);
+    case "3": {
+      const normalizedId = (clientId || "").toUpperCase();
+      if (normalizedId !== "DITBINMAS") {
+        msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
+        break;
       }
+      const opts = { mode: "all", roleFlag: "ditbinmas" };
+      msg = await absensiLikes("DITBINMAS", opts);
       break;
+    }
     case "4":
       msg = await absensiKomentar(clientId, {
         ...(userType === "org" ? { clientFilter: userClientId } : {}),

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -167,7 +167,7 @@ test('choose_menu option 3 absensi likes uses ditbinmas data for all users', asy
 
   await dirRequestHandlers.choose_menu(session, chatId, '3', waClient);
 
-  expect(mockAbsensiLikes).toHaveBeenCalledWith('ditbinmas', {
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
     mode: 'all',
     roleFlag: 'ditbinmas',
   });


### PR DESCRIPTION
## Summary
- ensure menu logic uses uppercase DITBINMAS for Instagram like attendance
- query client info case-insensitively to avoid missing DITBINMAS
- update tests for new DITBINMAS handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05ddfc7688327b282ed7daec333ca