### PR TITLE
feat: allow Ditbinmas to query Instagram posts by client

### DIFF
--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -49,12 +49,17 @@ export async function getShortcodesTodayByClient(identifier) {
     'SELECT client_type FROM clients WHERE LOWER(client_id) = LOWER($1)',
     [identifier]
   );
+
+  const isDitbinmas = identifier.toLowerCase() === 'ditbinmas';
   const clientType = typeRes.rows[0]?.client_type?.toLowerCase();
 
   let sql;
   let params;
 
-  if (clientType === 'direktorat' || typeRes.rows.length === 0) {
+  if (
+    typeRes.rows.length === 0 ||
+    (clientType === 'direktorat' && !isDitbinmas)
+  ) {
     sql =
       `SELECT p.shortcode FROM insta_post p\n` +
       `JOIN insta_post_roles pr ON pr.shortcode = p.shortcode\n` +

--- a/tests/instaPostModel.test.js
+++ b/tests/instaPostModel.test.js
@@ -44,11 +44,21 @@ test('getShortcodesTodayByClient uses role filter for directorate', async () => 
   expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
 });
 
+test('getShortcodesTodayByClient uses client filter for Ditbinmas', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ client_type: 'direktorat' }] })
+    .mockResolvedValueOnce({ rows: [] });
+  await getShortcodesTodayByClient('DITBINMAS');
+  const sql = mockQuery.mock.calls[1][0];
+  expect(sql).toContain('LOWER(client_id) = LOWER($1)');
+  expect(sql).not.toContain('insta_post_roles');
+});
+
 test('getShortcodesTodayByClient falls back to role when client not found', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [] })
     .mockResolvedValueOnce({ rows: [] });
-  await getShortcodesTodayByClient('ditbinmas');
+  await getShortcodesTodayByClient('unknown');
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('insta_post_roles');
   expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');


### PR DESCRIPTION
## Summary
- handle Ditbinmas in getShortcodesTodayByClient without insta_post_roles
- cover Ditbinmas scenario in unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0604b4bd48327b05b65f6954ef9fa