### PR TITLE
refactor: simplify directorate likes report

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -105,20 +105,20 @@ export async function absensiLikes(client_id, opts = {}) {
         else belum.push(u);
       });
       reports.push(
-        `*Client*: *${clientName}*\n` +
-          `*Jumlah user:* ${users.length}\n` +
-          `✅ *Sudah melaksanakan* : *${sudah.length} user*\n` +
-          `⚠️ *Kurang melaksanakan* : *${kurang.length} user*\n` +
-          `❌ *Belum melaksanakan* : *${belum.length} user*\n` +
-          `❓ *Tanpa username* : *${tanpaUsername.length} user*`
+        `${clientName}\n` +
+          `Jumlah Personil : ${users.length}\n` +
+          `Sudah Melaksanakan Lengkap : ${sudah.length}\n` +
+          `Melaksanakan Kurang Lengkap : ${kurang.length}\n` +
+          `Belum Melaksanakan : ${belum.length}\n` +
+          `Belum Update Username : ${tanpaUsername.length}`
       );
     }
 
     let msg =
       `Mohon ijin Komandan,\n\n` +
-      `📋 *Rekap Akumulasi Likes Instagram*\n*Direktorat*: *${clientNama}*\n${hari}, ${tanggal}\nJam: ${jam}\n\n` +
-      `*Jumlah Konten:* ${totalKonten}\n` +
-      `*Daftar Link Konten:*\n${kontenLinks.length ? kontenLinks.join("\n") : "-"}\n\n` +
+      `Rekap Akumulasi Likes Instagram\nDirektorat: ${clientNama}\n${hari}, ${tanggal}\nJam: ${jam}\n\n` +
+      `Jumlah Konten: ${totalKonten}\n` +
+      `Daftar Link Konten:\n${kontenLinks.length ? kontenLinks.join("\n") : "-"}\n\n` +
       reports.join("\n\n") +
       "\n\nTerimakasih.";
     return msg.trim();

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -142,7 +142,11 @@ test('directorate summarizes across clients', async () => {
     'POLRESA',
     'POLRESB',
   ]);
-  expect(msg).toMatch(/Client\*: \*POLRES A\*[\s\S]*Sudah melaksanakan\* : \*0 user\*[\s\S]*Kurang melaksanakan\* : \*1 user\*[\s\S]*Belum melaksanakan\* : \*0 user\*[\s\S]*Tanpa username\* : \*1 user/);
-  expect(msg).toMatch(/Client\*: \*POLRES B\*[\s\S]*Sudah melaksanakan\* : \*1 user\*[\s\S]*Kurang melaksanakan\* : \*0 user\*[\s\S]*Belum melaksanakan\* : \*1 user\*[\s\S]*Tanpa username\* : \*0 user/);
+  expect(msg).toMatch(
+    /POLRES A\nJumlah Personil : 2\nSudah Melaksanakan Lengkap : 0\nMelaksanakan Kurang Lengkap : 1\nBelum Melaksanakan : 0\nBelum Update Username : 1/
+  );
+  expect(msg).toMatch(
+    /POLRES B\nJumlah Personil : 2\nSudah Melaksanakan Lengkap : 1\nMelaksanakan Kurang Lengkap : 0\nBelum Melaksanakan : 1\nBelum Update Username : 0/
+  );
 });
 


### PR DESCRIPTION
## Summary
- simplify dirrequest Instagram likes report to group stats per client and remove user details
- update tests for new report format

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b069e3a1a48327b70c838afd8ab58a