### PR TITLE
Group Instagram like attendance by client

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -78,7 +78,9 @@ export async function absensiLikes(client_id, opts = {}) {
 
     const totalKonten = shortcodes.length;
     const reports = [];
-    for (const cid of polresIds) {
+    const totals = { total: 0, sudah: 0, kurang: 0, belum: 0 };
+    for (let i = 0; i < polresIds.length; i++) {
+      const cid = polresIds[i];
       const users = usersByClient[cid] || [];
       const { nama: clientName } = await getClientInfo(cid);
       const sudah = [];
@@ -104,23 +106,31 @@ export async function absensiLikes(client_id, opts = {}) {
         else if (percentage > 0) kurang.push(u);
         else belum.push(u);
       });
+      const belumCount = belum.length + tanpaUsername.length;
+      totals.total += users.length;
+      totals.sudah += sudah.length;
+      totals.kurang += kurang.length;
+      totals.belum += belumCount;
       reports.push(
-        `${clientName}\n` +
-          `Jumlah Personil : ${users.length}\n` +
-          `Sudah Melaksanakan Lengkap : ${sudah.length}\n` +
-          `Melaksanakan Kurang Lengkap : ${kurang.length}\n` +
-          `Belum Melaksanakan : ${belum.length}\n` +
-          `Belum Update Username : ${tanpaUsername.length}`
+        `${i + 1}. ${clientName}\n\n` +
+          `Jumlah Personil : ${users.length} pers\n` +
+          `Sudah melaksanakan : ${sudah.length} pers\n` +
+          `Melaksanakan kurang lengkap : ${kurang.length} pers\n` +
+          `Belum melaksanakan : ${belumCount} pers`
       );
     }
 
     let msg =
       `Mohon ijin Komandan,\n\n` +
-      `Rekap Akumulasi Likes Instagram\nDirektorat: ${clientNama}\n${hari}, ${tanggal}\nJam: ${jam}\n\n` +
+      `📋 Rekap Akumulasi Likes Instagram\n` +
+      `Polres: ${clientNama}\n${hari}, ${tanggal}\nJam: ${jam}\n\n` +
       `Jumlah Konten: ${totalKonten}\n` +
       `Daftar Link Konten:\n${kontenLinks.length ? kontenLinks.join("\n") : "-"}\n\n` +
-      reports.join("\n\n") +
-      "\n\nTerimakasih.";
+      `Jumlah Total Personil : ${totals.total} pers\n` +
+      `✅ Sudah melaksanakan : ${totals.sudah} pers\n` +
+      `Melaksanakan kurang lengkap : ${totals.kurang} pers\n` +
+      `❌ Belum melaksanakan : ${totals.belum} pers\n\n` +
+      reports.join("\n\n");
     return msg.trim();
   }
 

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -142,11 +142,15 @@ test('directorate summarizes across clients', async () => {
     'POLRESA',
     'POLRESB',
   ]);
+  expect(msg).toMatch(/Jumlah Total Personil : 4 pers/);
+  expect(msg).toMatch(/✅ Sudah melaksanakan : 1 pers/);
+  expect(msg).toMatch(/Melaksanakan kurang lengkap : 1 pers/);
+  expect(msg).toMatch(/❌ Belum melaksanakan : 2 pers/);
   expect(msg).toMatch(
-    /POLRES A\nJumlah Personil : 2\nSudah Melaksanakan Lengkap : 0\nMelaksanakan Kurang Lengkap : 1\nBelum Melaksanakan : 0\nBelum Update Username : 1/
+    /1\. POLRES A\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 0 pers\nMelaksanakan kurang lengkap : 1 pers\nBelum melaksanakan : 1 pers/
   );
   expect(msg).toMatch(
-    /POLRES B\nJumlah Personil : 2\nSudah Melaksanakan Lengkap : 1\nMelaksanakan Kurang Lengkap : 0\nBelum Melaksanakan : 1\nBelum Update Username : 0/
+    /2\. POLRES B\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 1 pers\nMelaksanakan kurang lengkap : 0 pers\nBelum melaksanakan : 1 pers/
   );
 });
 


### PR DESCRIPTION
## Summary
- aggregate Instagram like attendance across polres for directorate view
- show per-client breakdown with personnel counts and status totals
- update tests for new grouped report format

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b071580ce483278a694ef94a3eda03