### PR TITLE
Ensure dirrequest reports group by polres

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -400,21 +400,13 @@ export async function getUsersByDirektorat(flag, clientId = null) {
     Array.isArray(clientId) ? clientId.length > 0 : typeof clientId === 'string' && clientId.trim() !== '';
 
   if (hasClientId) {
-    sql += ` AND EXISTS (
-        SELECT 1
-        FROM user_roles ur2
-        JOIN roles r2 ON r2.role_id = ur2.role_id
-        WHERE ur2.user_id = u.user_id
-        AND LOWER(r2.role_name) = LOWER(u.client_id)
-      )`;
-
     if (Array.isArray(clientId)) {
       sql += ` AND LOWER(u.client_id) = ANY($${p})`;
       params.push(clientId.map((c) => String(c).toLowerCase()));
       p += 1;
     } else {
       sql += ` AND LOWER(u.client_id) = LOWER($${p})`;
-      params.push(clientId.trim());
+      params.push(clientId.trim().toLowerCase());
       p += 1;
     }
   }

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -230,8 +230,8 @@ test('getUsersByDirektorat filters by client and flag', async () => {
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
   expect(sql).toContain('LOWER(u.client_id) = LOWER($2)');
-  expect(sql).toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
-  expect(sql.match(/EXISTS/g).length).toBeGreaterThanOrEqual(2);
+  expect(sql).not.toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
+  expect(sql.match(/EXISTS/g).length).toBe(1);
 });
 
 test('getClientsByRole returns lowercase client ids', async () => {


### PR DESCRIPTION
## Summary
- remove over-restrictive role check in `getUsersByDirektorat` so client IDs are respected
- update tests for new query filtering behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b074602f008327ab7b600f867ee562