### PR TITLE
Fix absensi likes grouping for ditbinmas

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -39,12 +39,17 @@ export async function absensiLikes(client_id, opts = {}) {
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
 
   const { nama: clientNama, clientType } = await getClientInfo(client_id);
+  const allowedRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+  const normalizedRole = (roleFlag || "").toLowerCase();
+  const normalizedClient = (client_id || "").toLowerCase();
+  const isDirektoratContext =
+    clientType === "direktorat" ||
+    (allowedRoles.includes(normalizedRole) && normalizedRole === normalizedClient);
 
-  if (clientType === "direktorat") {
-    const allowedRoles = ["ditbinmas", "ditlantas", "bidhumas"];
-    const roleName = allowedRoles.includes((roleFlag || "").toLowerCase())
-      ? roleFlag.toLowerCase()
-      : client_id.toLowerCase();
+  if (isDirektoratContext) {
+    const roleName = allowedRoles.includes(normalizedRole)
+      ? normalizedRole
+      : normalizedClient;
     const shortcodes = await getShortcodesTodayByClient(roleName);
     if (!shortcodes.length)
       return `Tidak ada konten IG untuk *${clientNama}* hari ini.`;

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -78,6 +78,19 @@ test('uses directorate users when roleFlag matches directorate', async () => {
   expect(mockGetUsersByClient).not.toHaveBeenCalled();
 });
 
+test('roleFlag uses directorate logic even if client is not directorate', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'DITBINMAS', client_type: 'instansi' }] });
+  mockGetClientsByRole.mockResolvedValueOnce([]);
+  mockGetUsersByDirektorat.mockResolvedValueOnce([]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
+  mockGetLikesByShortcode.mockResolvedValueOnce([]);
+
+  await absensiLikes('DITBINMAS', { roleFlag: 'ditbinmas' });
+
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', []);
+  expect(mockGetUsersByClient).not.toHaveBeenCalled();
+});
+
 test('filters users by role when roleFlag provided for polres', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_type: 'instansi' }] });
   mockGetUsersByClient.mockResolvedValueOnce([]);


### PR DESCRIPTION
## Summary
- handle ditbinmas role by grouping Instagram like attendance by client ID
- add regression test for ditbinmas role context

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b07638ad94832787a002b11e21ee2a