### PR TITLE
Sort dirrequest Instagram like attendance by performance

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -82,7 +82,7 @@ export async function absensiLikes(client_id, opts = {}) {
     });
 
     const totalKonten = shortcodes.length;
-    const reports = [];
+    const reportEntries = [];
     const totals = { total: 0, sudah: 0, kurang: 0, belum: 0 };
     for (let i = 0; i < polresIds.length; i++) {
       const cid = polresIds[i];
@@ -116,14 +116,29 @@ export async function absensiLikes(client_id, opts = {}) {
       totals.sudah += sudah.length;
       totals.kurang += kurang.length;
       totals.belum += belumCount;
-      reports.push(
-        `${i + 1}. ${clientName}\n\n` +
-          `Jumlah Personil : ${users.length} pers\n` +
-          `Sudah melaksanakan : ${sudah.length} pers\n` +
-          `Melaksanakan kurang lengkap : ${kurang.length} pers\n` +
-          `Belum melaksanakan : ${belumCount} pers`
-      );
+      reportEntries.push({
+        clientName,
+        usersCount: users.length,
+        sudahCount: sudah.length,
+        kurangCount: kurang.length,
+        belumCount,
+      });
     }
+
+    reportEntries.sort((a, b) => {
+      if (a.sudahCount !== b.sudahCount) return b.sudahCount - a.sudahCount;
+      if (a.usersCount !== b.usersCount) return b.usersCount - a.usersCount;
+      return a.clientName.localeCompare(b.clientName);
+    });
+
+    const reports = reportEntries.map(
+      (r, idx) =>
+        `${idx + 1}. ${r.clientName}\n\n` +
+        `Jumlah Personil : ${r.usersCount} pers\n` +
+        `Sudah melaksanakan : ${r.sudahCount} pers\n` +
+        `Melaksanakan kurang lengkap : ${r.kurangCount} pers\n` +
+        `Belum melaksanakan : ${r.belumCount} pers`
+    );
 
     let msg =
       `Mohon ijin Komandan,\n\n` +

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -160,10 +160,10 @@ test('directorate summarizes across clients', async () => {
   expect(msg).toMatch(/Melaksanakan kurang lengkap : 1 pers/);
   expect(msg).toMatch(/❌ Belum melaksanakan : 2 pers/);
   expect(msg).toMatch(
-    /1\. POLRES A\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 0 pers\nMelaksanakan kurang lengkap : 1 pers\nBelum melaksanakan : 1 pers/
+    /1\. POLRES B\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 1 pers\nMelaksanakan kurang lengkap : 0 pers\nBelum melaksanakan : 1 pers/
   );
   expect(msg).toMatch(
-    /2\. POLRES B\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 1 pers\nMelaksanakan kurang lengkap : 0 pers\nBelum melaksanakan : 1 pers/
+    /2\. POLRES A\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 0 pers\nMelaksanakan kurang lengkap : 1 pers\nBelum melaksanakan : 1 pers/
   );
 });
 


### PR DESCRIPTION
## Summary
- sort dirrequest Instagram like recap by highest completed likes then by user count
- update unit test to reflect sorted order

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b078134ad083278674af1f200d7bed