### PR TITLE
feat: include missing username stats in IG likes report

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -78,7 +78,7 @@ export async function absensiLikes(client_id, opts = {}) {
 
     const totalKonten = shortcodes.length;
     const reports = [];
-    const totals = { total: 0, sudah: 0, kurang: 0, belum: 0 };
+    const totals = { total: 0, sudah: 0, kurang: 0, belum: 0, tanpaUsername: 0 };
     for (let i = 0; i < polresIds.length; i++) {
       const cid = polresIds[i];
       const users = usersByClient[cid] || [];
@@ -106,17 +106,18 @@ export async function absensiLikes(client_id, opts = {}) {
         else if (percentage > 0) kurang.push(u);
         else belum.push(u);
       });
-      const belumCount = belum.length + tanpaUsername.length;
       totals.total += users.length;
       totals.sudah += sudah.length;
       totals.kurang += kurang.length;
-      totals.belum += belumCount;
+      totals.belum += belum.length;
+      totals.tanpaUsername += tanpaUsername.length;
       reports.push(
         `${i + 1}. ${clientName}\n\n` +
           `Jumlah Personil : ${users.length} pers\n` +
           `Sudah melaksanakan : ${sudah.length} pers\n` +
           `Melaksanakan kurang lengkap : ${kurang.length} pers\n` +
-          `Belum melaksanakan : ${belumCount} pers`
+          `Belum melaksanakan : ${belum.length} pers\n` +
+          `Belum update username Instagram : ${tanpaUsername.length} pers`
       );
     }
 
@@ -129,7 +130,8 @@ export async function absensiLikes(client_id, opts = {}) {
       `Jumlah Total Personil : ${totals.total} pers\n` +
       `✅ Sudah melaksanakan : ${totals.sudah} pers\n` +
       `Melaksanakan kurang lengkap : ${totals.kurang} pers\n` +
-      `❌ Belum melaksanakan : ${totals.belum} pers\n\n` +
+      `❌ Belum melaksanakan : ${totals.belum} pers\n` +
+      `Belum update username Instagram : ${totals.tanpaUsername} pers\n\n` +
       reports.join("\n\n");
     return msg.trim();
   }

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -142,15 +142,16 @@ test('directorate summarizes across clients', async () => {
     'POLRESA',
     'POLRESB',
   ]);
-  expect(msg).toMatch(/Jumlah Total Personil : 4 pers/);
-  expect(msg).toMatch(/✅ Sudah melaksanakan : 1 pers/);
-  expect(msg).toMatch(/Melaksanakan kurang lengkap : 1 pers/);
-  expect(msg).toMatch(/❌ Belum melaksanakan : 2 pers/);
-  expect(msg).toMatch(
-    /1\. POLRES A\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 0 pers\nMelaksanakan kurang lengkap : 1 pers\nBelum melaksanakan : 1 pers/
-  );
-  expect(msg).toMatch(
-    /2\. POLRES B\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 1 pers\nMelaksanakan kurang lengkap : 0 pers\nBelum melaksanakan : 1 pers/
-  );
+    expect(msg).toMatch(/Jumlah Total Personil : 4 pers/);
+    expect(msg).toMatch(/✅ Sudah melaksanakan : 1 pers/);
+    expect(msg).toMatch(/Melaksanakan kurang lengkap : 1 pers/);
+    expect(msg).toMatch(/❌ Belum melaksanakan : 1 pers/);
+    expect(msg).toMatch(/Belum update username Instagram : 1 pers/);
+    expect(msg).toMatch(
+      /1\. POLRES A\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 0 pers\nMelaksanakan kurang lengkap : 1 pers\nBelum melaksanakan : 0 pers\nBelum update username Instagram : 1 pers/
+    );
+    expect(msg).toMatch(
+      /2\. POLRES B\n\nJumlah Personil : 2 pers\nSudah melaksanakan : 1 pers\nMelaksanakan kurang lengkap : 0 pers\nBelum melaksanakan : 1 pers\nBelum update username Instagram : 0 pers/
+    );
 });
 


### PR DESCRIPTION
## Summary
- track users without Instagram usernames in directorate IG likes report
- show per-client counts for total personnel, completed, partial, not yet, and missing usernames
- update tests for new report structure

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b073810c988327a7d83b11ea66dd24