### PR TITLE
feat: prevent duplicate instagram accounts

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -412,7 +412,15 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
         );
         return;
       }
-      value = igMatch[2];
+      value = igMatch[2].toLowerCase();
+      const existing = await userModel.findUserByInsta(value);
+      if (existing && existing.user_id !== user_id) {
+        await waClient.sendMessage(
+          chatId,
+          "❌ Akun Instagram tersebut sudah terdaftar pada pengguna lain."
+        );
+        return;
+      }
     }
     if (field === "tiktok") {
       const ttMatch = value.match(/^https?:\/\/(www\.)?tiktok\.com\/@([A-Za-z0-9._]+)/i);

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -420,6 +420,15 @@ export async function getUsersByDirektorat(flag, clientId = null) {
 }
 
 
+export async function findUserByInsta(insta) {
+  if (!insta) return null;
+  const { rows } = await query(
+    `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE LOWER(u.insta) = LOWER($1)\n     GROUP BY u.user_id`,
+    [insta]
+  );
+  return rows[0];
+}
+
 export async function findUserByWhatsApp(wa) {
   if (!wa) return null;
   const { rows } = await query(


### PR DESCRIPTION
## Summary
- prevent duplicate Instagram account submissions during user updates
- add model helper to lookup users by Instagram username

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15c8e7d388327b84d10c3b2cd464b