### PR TITLE
refactor: run cron jobs in dedicated worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,12 @@ This allows operators to scope responses to the correct client.
     GOOGLE_IMPERSONATE_EMAIL=admin@example.com
     BACKUP_DIR=./backups
     GOOGLE_DRIVE_FOLDER_ID=your-drive-folder-id
+    ENABLE_CRON_JOBS=false
+    CRON_JOBS=
     ```
    `ADMIN_WHATSAPP` accepts numbers with or without the `@c.us` suffix. When the suffix is omitted, the application automatically appends it.
    `GOOGLE_SERVICE_ACCOUNT` may be set to a JSON string or a path to a JSON file. If the value starts with `/` or ends with `.json`, the application reads the file; otherwise it parses the variable directly as JSON. `GOOGLE_IMPERSONATE_EMAIL` should be set to the Workspace user to impersonate when performing contact operations.
+   Set `ENABLE_CRON_JOBS=true` to load cron jobs within `app.js` (useful for development). `CRON_JOBS` accepts a comma-separated list of cron identifiers (e.g. `cronInstaService,cronTiktokService`) to limit which jobs run; leave empty to run all.
 
 3. **Set up Redis**
     ```bash
@@ -108,6 +111,7 @@ This allows operators to scope responses to the correct client.
     Or with PM2:
     ```bash
     pm2 start app.js --name cicero_v2
+    pm2 start cronRunner.js --name cicero_cron
     ```
 7. **Lint & Test**
     ```bash

--- a/app.js
+++ b/app.js
@@ -10,21 +10,9 @@ import { notFound, errorHandler } from './src/middleware/errorHandler.js';
 import { authRequired } from './src/middleware/authMiddleware.js';
 import { dedupRequest } from './src/middleware/dedupRequestMiddleware.js';
 
-// Import semua cron jobs (jalankan di background)
-import './src/cron/cronInstaService.js';
-import './src/cron/cronTiktokService.js';
-import './src/cron/cronInstaLaphar.js';
-import './src/cron/cronTiktokLaphar.js';
-import './src/cron/cronNotifikasiLikesDanKomentar.js';
-import './src/cron/cronInstaDataMining.js';
-import './src/cron/cronPremiumSubscription.js';
-import './src/cron/cronRekapLink.js';
-import './src/cron/cronAmplifyLinkMonthly.js';
-import './src/cron/cronPremiumRequest.js';
-import './src/cron/cronAbsensiUserData.js';
-import './src/cron/cronAbsensiOprDitbinmas.js';
-import './src/cron/cronDirRequest.js';
-import './src/cron/cronDbBackup.js';
+if (env.ENABLE_CRON_JOBS) {
+  await import('./cronRunner.js');
+}
 
 const app = express();
 

--- a/cronRunner.js
+++ b/cronRunner.js
@@ -1,0 +1,30 @@
+import './src/utils/logger.js';
+import { env } from './src/config/env.js';
+
+const cronJobs = {
+  cronInstaService: () => import('./src/cron/cronInstaService.js'),
+  cronTiktokService: () => import('./src/cron/cronTiktokService.js'),
+  cronInstaLaphar: () => import('./src/cron/cronInstaLaphar.js'),
+  cronTiktokLaphar: () => import('./src/cron/cronTiktokLaphar.js'),
+  cronNotifikasiLikesDanKomentar: () => import('./src/cron/cronNotifikasiLikesDanKomentar.js'),
+  cronInstaDataMining: () => import('./src/cron/cronInstaDataMining.js'),
+  cronPremiumSubscription: () => import('./src/cron/cronPremiumSubscription.js'),
+  cronRekapLink: () => import('./src/cron/cronRekapLink.js'),
+  cronAmplifyLinkMonthly: () => import('./src/cron/cronAmplifyLinkMonthly.js'),
+  cronPremiumRequest: () => import('./src/cron/cronPremiumRequest.js'),
+  cronAbsensiUserData: () => import('./src/cron/cronAbsensiUserData.js'),
+  cronAbsensiOprDitbinmas: () => import('./src/cron/cronAbsensiOprDitbinmas.js'),
+  cronDirRequest: () => import('./src/cron/cronDirRequest.js'),
+  cronDbBackup: () => import('./src/cron/cronDbBackup.js')
+};
+
+const selectedJobs = env.CRON_JOBS
+  ? env.CRON_JOBS.split(',').map((j) => j.trim()).filter(Boolean)
+  : Object.keys(cronJobs);
+
+for (const job of selectedJobs) {
+  const loader = cronJobs[job];
+  if (loader) {
+    await loader();
+  }
+}

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -27,5 +27,7 @@ export const env = cleanEnv(process.env, {
   GOOGLE_IMPERSONATE_EMAIL: str({ default: '' }),
   GOOGLE_CONTACT_SCOPE: str({
     default: 'https://www.googleapis.com/auth/contacts'
-  })
+  }),
+  ENABLE_CRON_JOBS: bool({ default: false }),
+  CRON_JOBS: str({ default: '' })
 });


### PR DESCRIPTION
## Summary
- load cron jobs through new `cronRunner.js` worker with optional job selection
- trigger cron worker only when `ENABLE_CRON_JOBS` flag is set
- document cron worker deployment steps

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2777572b48327b39d0e8cb68ba69b