### PR TITLE
refactor: remove redundant auth checks

### DIFF
--- a/src/routes/clientRoutes.js
+++ b/src/routes/clientRoutes.js
@@ -1,29 +1,28 @@
 import express from "express";
 import * as clientController from "../controller/clientController.js";
-import { authRequired } from "../middleware/authMiddleware.js"; // pastikan punya middleware ini
 
 
 const router = express.Router();
 // Routes untuk client
 router.get("/", clientController.getAllClients);
 // routes profile client
-router.get("/profile", authRequired, clientController.getClientProfile);
+router.get("/profile", clientController.getClientProfile);
 router.get("/active", clientController.getActiveClients);
 router.get("/:client_id", clientController.getClientById);
 router.put("/:client_id", clientController.updateClient);
 router.delete("/:client_id", clientController.deleteClient);
-router.get("/:client_id/users", authRequired, clientController.getUsers);
-router.get("/:client_id/posts/instagram", authRequired, clientController.getInstagramPosts);
+router.get("/:client_id/users", clientController.getUsers);
+router.get("/:client_id/posts/instagram", clientController.getInstagramPosts);
 router.get(
   "/:client_id/posts/instagram/likes",
   clientController.getInstagramLikes
 );
-router.get("/:client_id/posts/tiktok", authRequired, clientController.getTiktokPosts);
+router.get("/:client_id/posts/tiktok", clientController.getTiktokPosts);
 router.get(
   "/:client_id/posts/tiktok/comments",
   clientController.getTiktokComments
 );
-router.get("/:client_id/summary", authRequired, clientController.getSummary);
+router.get("/:client_id/summary", clientController.getSummary);
 
 // Profil client
 


### PR DESCRIPTION
## Summary
- remove `authRequired` from client routes and rely on global middleware

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27cafffac83279c5efa8a3fce05dd