### PR TITLE
Handle duplicate saved_contact insert

### DIFF
--- a/src/service/googleContactsService.js
+++ b/src/service/googleContactsService.js
@@ -178,7 +178,7 @@ export async function saveContactIfNew(chatId) {
     }
     await saveGoogleContact(auth, { name: displayName, phone });
     await query(
-      'INSERT INTO saved_contact (phone_number) VALUES ($1)',
+      'INSERT INTO saved_contact (phone_number) VALUES ($1) ON CONFLICT DO NOTHING',
       [phone]
     );
     addToCache(phone);

--- a/tests/googleContactsService.test.js
+++ b/tests/googleContactsService.test.js
@@ -171,6 +171,9 @@ describe('saveContactIfNew', () => {
       })
     );
     expect(mockQuery).toHaveBeenCalledTimes(3);
+    expect(mockQuery.mock.calls[2][0]).toMatch(
+      /INSERT INTO saved_contact \(phone_number\) VALUES \(\$1\) ON CONFLICT DO NOTHING/
+    );
   });
 
   test('queries database only for new numbers', async () => {


### PR DESCRIPTION
## Summary
- prevent duplicate key errors when saving contacts by ignoring existing entries
- assert saved_contact insert uses ON CONFLICT DO NOTHING in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27f64c0f08327af886234fcddba00