### PR TITLE
Add health check route

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import routes from './src/routes/index.js';
 import authRoutes from './src/routes/authRoutes.js';
+import healthRoutes from './src/routes/healthRoutes.js';
 import { notFound, errorHandler } from './src/middleware/errorHandler.js';
 import { authRequired } from './src/middleware/authMiddleware.js';
 import { dedupRequest } from './src/middleware/dedupRequestMiddleware.js';
@@ -25,6 +26,9 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(morgan('dev'));
 app.use(dedupRequest);
+
+// ===== ROUTE HEALTHCHECK =====
+app.use('/', healthRoutes);
 
 // ===== ROUTE LOGIN (TANPA TOKEN) =====
 app.use('/api/auth', authRoutes);

--- a/src/routes/healthRoutes.js
+++ b/src/routes/healthRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+export default router;

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -1,0 +1,18 @@
+import request from 'supertest';
+import express from 'express';
+import healthRoutes from '../src/routes/healthRoutes.js';
+
+let app;
+
+beforeAll(() => {
+  app = express();
+  app.use('/', healthRoutes);
+});
+
+describe('GET /health', () => {
+  test('returns ok status', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- expose `/health` endpoint to report server status
- test health check route

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2850582648327ae3e71733521cf73