### PR TITLE
Disable ETag caching in Express

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ if (env.ENABLE_CRON_JOBS) {
 }
 
 const app = express();
+app.disable('etag');
 
 app.use(cors({
   origin: env.CORS_ORIGIN,


### PR DESCRIPTION
## Summary
- Disable Express ETag generation to prevent cached 304 responses

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b288e57ee8832793685b5646f50c66