### PR TITLE
Add logging for WhatsApp readiness checks

### DIFF
--- a/src/controller/dashboardUserController.js
+++ b/src/controller/dashboardUserController.js
@@ -21,6 +21,10 @@ export async function approveDashboardUser(req, res, next) {
         wid,
         `✅ Registrasi dashboard Anda telah disetujui.\nUsername: ${usr.username}`
       );
+    } else if (!waReady && usr.whatsapp) {
+      console.warn(
+        `[WA] Skipping approval notification for ${usr.username}: WhatsApp client not ready`
+      );
     }
     sendSuccess(res, updated);
   } catch (err) {
@@ -45,6 +49,10 @@ export async function rejectDashboardUser(req, res, next) {
         waClient,
         wid,
         `❌ Registrasi dashboard Anda ditolak.\nUsername: ${usr.username}`
+      );
+    } else if (!waReady && usr.whatsapp) {
+      console.warn(
+        `[WA] Skipping rejection notification for ${usr.username}: WhatsApp client not ready`
       );
     }
     sendSuccess(res, updated);

--- a/src/controller/linkReportController.js
+++ b/src/controller/linkReportController.js
@@ -69,6 +69,10 @@ export async function createLinkReport(req, res, next) {
           links;
         await safeSendMessage(waClient, wid, msg);
       }
+    } else if (!waReady && data.user_id) {
+      console.warn(
+        '[WA] Skipping link report notification: WhatsApp client not ready'
+      );
     }
 
     sendSuccess(res, report, 201);

--- a/src/controller/premiumRequestController.js
+++ b/src/controller/premiumRequestController.js
@@ -22,6 +22,10 @@ export async function updatePremiumRequest(req, res, next) {
     if (req.body.screenshot_url && waReady) {
       const msg = `\uD83D\uDD14 Permintaan subscription\nUser: ${row.user_id}\nNama: ${row.sender_name}\nRek: ${row.account_number}\nBank: ${row.bank_name}\nID: ${row.request_id}\nBalas grantsub#${row.request_id} untuk menyetujui atau denysub#${row.request_id} untuk menolak.`;
       await sendWAReport(waClient, msg);
+    } else if (req.body.screenshot_url && !waReady) {
+      console.warn(
+        `[WA] Skipping premium request notification for ${row.request_id}: WhatsApp client not ready`
+      );
     }
     res.json({ success: true, request: row });
   } catch (err) {

--- a/src/middleware/debugHandler.js
+++ b/src/middleware/debugHandler.js
@@ -60,6 +60,10 @@ export function sendDebug({ tag = "DEBUG", msg, client_id = "", clientName = "" 
     for (const wa of adminWA) {
       waClient.sendMessage(wa, waMsg).catch(() => {});
     }
+  } else if (!waReady && (isStartOrEnd || isError)) {
+    console.warn(
+      '[WA] Skipping debug WhatsApp send: WhatsApp client not ready'
+    );
   }
 
   console.log(fullMsg);

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -19,7 +19,10 @@ import { insertVisitorLog } from "../model/visitorLogModel.js";
 import { insertLoginLog } from "../model/loginLogModel.js";
 
 function notifyAdmin(message) {
-  if (!waReady) return;
+  if (!waReady) {
+    console.warn('[WA] Skipping admin notification: WhatsApp client not ready');
+    return;
+  }
   for (const wa of getAdminWAIds()) {
     safeSendMessage(waClient, wa, message);
   }
@@ -187,6 +190,10 @@ router.post('/dashboard-register', async (req, res) => {
       waClient,
       wid,
       "\uD83D\uDCCB Permintaan registrasi dashboard Anda telah diterima dan menunggu persetujuan admin."
+    );
+  } else if (!waReady && whatsapp) {
+    console.warn(
+      `[WA] Skipping user notification for ${whatsapp}: WhatsApp client not ready`
     );
   }
   return res


### PR DESCRIPTION
## Summary
- log when admin notifications are skipped because WhatsApp client is not ready
- warn on user, report, and premium request flows when WhatsApp messages are skipped due to client not ready
- trace skipped debug WhatsApp messages if client not ready

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28e9f555c8327b4254d30153d67bc