### PR TITLE
Handle WhatsApp client readiness on authentication

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -162,6 +162,11 @@ waClient.on("loading_screen", (percent, message) => {
 
 waClient.on("authenticated", () => {
   console.log("[WA] Client authenticated");
+  if (!waReady) {
+    waReady = true;
+    console.log("[WA] WhatsApp client is ready (authenticated)!");
+    flushPendingMessages();
+  }
 });
 
 waClient.on("auth_failure", (msg) => {


### PR DESCRIPTION
## Summary
- Ensure WhatsApp client enters ready state when `authenticated` event fires
- Flush deferred messages after authentication if `ready` event did not fire

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2933e64148327b7327f6e7e75a294