### PR TITLE
Guard WA send when client not ready

### DIFF
--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -156,8 +156,10 @@ export function getAdminWANumbers() {
 // Send WhatsApp message with basic error handling
 export async function safeSendMessage(waClient, chatId, message, options = {}) {
   try {
-    if (waClient) {
+    if (waClient && waClient.info) {
       await waClient.sendMessage(chatId, message, options);
+    } else {
+      console.warn(`[WA] Client not ready, cannot send message to ${chatId}`);
     }
   } catch (err) {
     console.error(`[WA] Failed to send message to ${chatId}:`, err.message);

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -6,7 +6,7 @@ import bcrypt from 'bcrypt';
 const mockQuery = jest.fn();
 const mockRedis = { sAdd: jest.fn(), set: jest.fn() };
 const mockInsertLoginLog = jest.fn();
-const mockWAClient = { sendMessage: jest.fn() };
+const mockWAClient = { info: {}, sendMessage: jest.fn() };
 const actualWaHelper = await import('../src/utils/waHelper.js');
 
 jest.unstable_mockModule('../src/db/index.js', () => ({


### PR DESCRIPTION
## Summary
- avoid sending WhatsApp messages before client session is ready
- adapt auth routes tests for new send guard

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b298713e448327b8aee70cb284ab00