### PR TITLE
fix(wa): handle message_create events

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -2070,6 +2070,12 @@ Ketik *angka* menu, atau *batal* untuk keluar.
   return;
 });
 
+// Fallback handler for environments that emit `message_create` instead of `message`
+waClient.on("message_create", (msg) => {
+  if (msg.fromMe) return;
+  waClient.emit("message", msg);
+});
+
 // =======================
 // INISIALISASI WA CLIENT
 // =======================


### PR DESCRIPTION
## Summary
- process `message_create` events so WhatsApp integration works across library versions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29b33f3f88327b95e16851ade4a02