### PR TITLE
feat: add WhatsApp client readiness helper

### DIFF
--- a/src/controller/dashboardUserController.js
+++ b/src/controller/dashboardUserController.js
@@ -1,6 +1,6 @@
 import * as dashboardUserModel from '../model/dashboardUserModel.js';
 import { formatToWhatsAppId, safeSendMessage } from '../utils/waHelper.js';
-import waClient, { waReady } from '../service/waService.js';
+import waClient, { waitForWaReady } from '../service/waService.js';
 import { sendSuccess } from '../utils/response.js';
 
 export async function approveDashboardUser(req, res, next) {
@@ -14,17 +14,20 @@ export async function approveDashboardUser(req, res, next) {
       return res.status(404).json({ success: false, message: 'User not found' });
     }
     const updated = await dashboardUserModel.updateStatus(id, true);
-    if (waReady && usr.whatsapp) {
-      const wid = formatToWhatsAppId(usr.whatsapp);
-      await safeSendMessage(
-        waClient,
-        wid,
-        `✅ Registrasi dashboard Anda telah disetujui.\nUsername: ${usr.username}`
-      );
-    } else if (!waReady && usr.whatsapp) {
-      console.warn(
-        `[WA] Skipping approval notification for ${usr.username}: WhatsApp client not ready`
-      );
+    if (usr.whatsapp) {
+      try {
+        await waitForWaReady();
+        const wid = formatToWhatsAppId(usr.whatsapp);
+        await safeSendMessage(
+          waClient,
+          wid,
+          `✅ Registrasi dashboard Anda telah disetujui.\nUsername: ${usr.username}`
+        );
+      } catch (err) {
+        console.warn(
+          `[WA] Skipping approval notification for ${usr.username}: ${err.message}`
+        );
+      }
     }
     sendSuccess(res, updated);
   } catch (err) {
@@ -43,17 +46,20 @@ export async function rejectDashboardUser(req, res, next) {
       return res.status(404).json({ success: false, message: 'User not found' });
     }
     const updated = await dashboardUserModel.updateStatus(id, false);
-    if (waReady && usr.whatsapp) {
-      const wid = formatToWhatsAppId(usr.whatsapp);
-      await safeSendMessage(
-        waClient,
-        wid,
-        `❌ Registrasi dashboard Anda ditolak.\nUsername: ${usr.username}`
-      );
-    } else if (!waReady && usr.whatsapp) {
-      console.warn(
-        `[WA] Skipping rejection notification for ${usr.username}: WhatsApp client not ready`
-      );
+    if (usr.whatsapp) {
+      try {
+        await waitForWaReady();
+        const wid = formatToWhatsAppId(usr.whatsapp);
+        await safeSendMessage(
+          waClient,
+          wid,
+          `❌ Registrasi dashboard Anda ditolak.\nUsername: ${usr.username}`
+        );
+      } catch (err) {
+        console.warn(
+          `[WA] Skipping rejection notification for ${usr.username}: ${err.message}`
+        );
+      }
     }
     sendSuccess(res, updated);
   } catch (err) {

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -30,7 +30,7 @@ jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
 
 jest.unstable_mockModule('../src/service/waService.js', () => ({
   default: mockWAClient,
-  waReady: true
+  waitForWaReady: () => Promise.resolve()
 }));
 
 let app;

--- a/tests/dashboardUserController.test.js
+++ b/tests/dashboardUserController.test.js
@@ -17,7 +17,7 @@ jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
 const mockWaClient = {};
 jest.unstable_mockModule('../src/service/waService.js', () => ({
   default: mockWaClient,
-  waReady: true
+  waitForWaReady: () => Promise.resolve()
 }));
 
 let controller;


### PR DESCRIPTION
## Summary
- add promise-based `waitForWaReady` utility to centralize WhatsApp client initialization
- await client readiness before sending messages in controllers and middleware
- remove direct `waReady` checks in favor of the helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a0765c188327be85c3c33f8cedb2