### PR TITLE
feat: ensure WA client readiness before sending

### DIFF
--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -6,7 +6,13 @@ import bcrypt from 'bcrypt';
 const mockQuery = jest.fn();
 const mockRedis = { sAdd: jest.fn(), set: jest.fn() };
 const mockInsertLoginLog = jest.fn();
-const mockWAClient = { info: {}, sendMessage: jest.fn() };
+const mockWAClient = {
+  info: {},
+  sendMessage: jest.fn(),
+  getState: jest.fn().mockResolvedValue('CONNECTED'),
+  once: jest.fn(),
+  off: jest.fn(),
+};
 const actualWaHelper = await import('../src/utils/waHelper.js');
 
 jest.unstable_mockModule('../src/db/index.js', () => ({

--- a/tests/waHelper.test.js
+++ b/tests/waHelper.test.js
@@ -1,0 +1,21 @@
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+let safeSendMessage;
+
+beforeAll(async () => {
+  ({ safeSendMessage } = await import('../src/utils/waHelper.js'));
+});
+
+test('safeSendMessage waits for client ready', async () => {
+  const waClient = new EventEmitter();
+  waClient.getState = jest.fn().mockResolvedValue('INITIALIZING');
+  waClient.sendMessage = jest.fn().mockResolvedValue();
+
+  const promise = safeSendMessage(waClient, '123@c.us', 'hello');
+  await Promise.resolve();
+  expect(waClient.sendMessage).not.toHaveBeenCalled();
+  waClient.emit('ready');
+  await promise;
+  expect(waClient.sendMessage).toHaveBeenCalledWith('123@c.us', 'hello', {});
+});


### PR DESCRIPTION
## Summary
- wait for WhatsApp client to be ready before sending messages
- mock WA client state in auth route tests
- cover readiness behaviour in waHelper tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a4a8da1c8327aecaa5082608da84