### PR TITLE
fix: use remote web version cache

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -2,7 +2,7 @@
 // IMPORTS & KONFIGURASI
 // =======================
 import pkg from "whatsapp-web.js";
-const { Client, LocalAuth, RemoteWebCache } = pkg;
+const { Client, LocalAuth } = pkg;
 import qrcode from "qrcode-terminal";
 import dotenv from "dotenv";
 import { query } from "../db/index.js";
@@ -122,10 +122,11 @@ export const waClient = new Client({
     clientId: process.env.APP_SESSION_NAME,
   }),
   webVersion: "2.2412.54",
-  webVersionCache: new RemoteWebCache({
+  webVersionCache: {
+    type: "remote",
     remotePath:
       "https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/{version}.html",
-  }),
+  },
   puppeteer: {
     headless: "new",
     args: [


### PR DESCRIPTION
## Summary
- avoid RemoteWebCache constructor and configure remote web cache object for whatsapp client

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ab7a85d883279cf5505905c13d36