### PR TITLE
fix: remove outdated web version configuration

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -121,9 +121,6 @@ export const waClient = new Client({
   authStrategy: new LocalAuth({
     clientId: process.env.APP_SESSION_NAME,
   }),
-  webVersion: "2.2412.54",
-  webVersionCache: { type: 'local', path: './.wwebjs_cache' }
-,
   puppeteer: {
     headless: "new",
     args: [


### PR DESCRIPTION
## Summary
- allow whatsapp-web.js to negotiate its own supported web version by removing the pinned value

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b9089d1883278e47e0648185806d