### PR TITLE
refactor: separate whatsapp service from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ The full architecture is described in [docs/enterprise_architecture.md](docs/ent
 ## Folder Structure
 
 ```
+``` 
 Cicero_V2/
-├── app.js                       # Application entry point
+├── app.js                       # Backend API entry point
+├── wa-bot.js                    # WhatsApp bot & cron entry
 ├── package.json                 # NPM configuration
 ├── src/
 │   ├── config/                  # Environment and Redis config
@@ -101,13 +103,15 @@ This allows operators to scope responses to the correct client.
    sudo systemctl start rabbitmq-server
    ```
 5. **Initialize the database** using scripts in `sql/schema.sql`.
-6. **Start the application**
+6. **Start the services**
     ```bash
-    npm start
+    npm start       # backend API
+    npm run start:wa  # WhatsApp bot & cron workers
     ```
     Or with PM2:
     ```bash
     pm2 start app.js --name cicero_v2
+    pm2 start wa-bot.js --name wa_bot
     ```
 7. **Lint & Test**
     ```bash

--- a/app.js
+++ b/app.js
@@ -9,29 +9,6 @@ import authRoutes from './src/routes/authRoutes.js';
 import { notFound, errorHandler } from './src/middleware/errorHandler.js';
 import { authRequired } from './src/middleware/authMiddleware.js';
 import { dedupRequest } from './src/middleware/dedupRequestMiddleware.js';
-import { waClient } from './src/service/waService.js';
-
-// Import semua cron jobs setelah WhatsApp siap
-const cronModules = [
-  './src/cron/cronInstaService.js',
-  './src/cron/cronTiktokService.js',
-  './src/cron/cronInstaLaphar.js',
-  './src/cron/cronTiktokLaphar.js',
-  './src/cron/cronNotifikasiLikesDanKomentar.js',
-  './src/cron/cronInstaDataMining.js',
-  './src/cron/cronPremiumSubscription.js',
-  './src/cron/cronRekapLink.js',
-  './src/cron/cronAmplifyLinkMonthly.js',
-  './src/cron/cronPremiumRequest.js',
-  './src/cron/cronAbsensiUserData.js',
-  './src/cron/cronAbsensiOprDitbinmas.js',
-  './src/cron/cronDirRequest.js',
-  './src/cron/cronDbBackup.js',
-];
-
-waClient.on('ready', async () => {
-  await Promise.all(cronModules.map(m => import(m)));
-});
 
 const app = express();
 app.disable('etag');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
+    "start:wa": "node wa-bot.js",
     "dev": "nodemon app.js",
+    "dev:wa": "nodemon wa-bot.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.js\""

--- a/src/controller/dashboardUserController.js
+++ b/src/controller/dashboardUserController.js
@@ -1,6 +1,6 @@
 import * as dashboardUserModel from '../model/dashboardUserModel.js';
-import { formatToWhatsAppId, safeSendMessage } from '../utils/waHelper.js';
-import waClient, { waitForWaReady } from '../service/waService.js';
+import { formatToWhatsAppId } from '../utils/waHelper.js';
+import { sendMessage } from '../service/waApiClient.js';
 import { sendSuccess } from '../utils/response.js';
 
 export async function approveDashboardUser(req, res, next) {
@@ -16,10 +16,8 @@ export async function approveDashboardUser(req, res, next) {
     const updated = await dashboardUserModel.updateStatus(id, true);
     if (usr.whatsapp) {
       try {
-        await waitForWaReady();
         const wid = formatToWhatsAppId(usr.whatsapp);
-        await safeSendMessage(
-          waClient,
+        await sendMessage(
           wid,
           `✅ Registrasi dashboard Anda telah disetujui.\nUsername: ${usr.username}`
         );
@@ -48,10 +46,8 @@ export async function rejectDashboardUser(req, res, next) {
     const updated = await dashboardUserModel.updateStatus(id, false);
     if (usr.whatsapp) {
       try {
-        await waitForWaReady();
         const wid = formatToWhatsAppId(usr.whatsapp);
-        await safeSendMessage(
-          waClient,
+        await sendMessage(
           wid,
           `❌ Registrasi dashboard Anda ditolak.\nUsername: ${usr.username}`
         );

--- a/src/controller/linkReportController.js
+++ b/src/controller/linkReportController.js
@@ -6,9 +6,9 @@ import {
   formatNama,
 } from '../utils/utilsHelper.js';
 import { generateLinkReportExcelBuffer } from '../service/amplifyExportService.js';
-import waClient, { waitForWaReady } from '../service/waService.js';
 import { findUserById } from '../model/userModel.js';
-import { formatToWhatsAppId, safeSendMessage } from '../utils/waHelper.js';
+import { formatToWhatsAppId } from '../utils/waHelper.js';
+import { sendMessage } from '../service/waApiClient.js';
 
 export async function getAllLinkReports(req, res, next) {
   try {
@@ -47,7 +47,6 @@ export async function createLinkReport(req, res, next) {
 
     if (data.user_id) {
       try {
-        await waitForWaReady();
         const user = await findUserById(data.user_id);
         if (user?.whatsapp) {
           const wid = formatToWhatsAppId(user.whatsapp);
@@ -69,7 +68,7 @@ export async function createLinkReport(req, res, next) {
             `- https://www.instagram.com/p/${data.shortcode}\n\n` +
             `Link Amplifikasi Anda :\n` +
             links;
-          await safeSendMessage(waClient, wid, msg);
+          await sendMessage(wid, msg);
         }
       } catch (err) {
         console.warn(

--- a/src/controller/premiumRequestController.js
+++ b/src/controller/premiumRequestController.js
@@ -1,6 +1,5 @@
 import * as premiumReqModel from '../model/premiumRequestModel.js';
-import waClient, { waitForWaReady } from '../service/waService.js';
-import { sendWAReport } from '../utils/waHelper.js';
+import { sendReport } from '../service/waApiClient.js';
 
 export async function createPremiumRequest(req, res, next) {
   try {
@@ -21,9 +20,8 @@ export async function updatePremiumRequest(req, res, next) {
     if (!row) return res.status(404).json({ success: false, message: 'not found' });
     if (req.body.screenshot_url) {
       try {
-        await waitForWaReady();
         const msg = `\uD83D\uDD14 Permintaan subscription\nUser: ${row.user_id}\nNama: ${row.sender_name}\nRek: ${row.account_number}\nBank: ${row.bank_name}\nID: ${row.request_id}\nBalas grantsub#${row.request_id} untuk menyetujui atau denysub#${row.request_id} untuk menolak.`;
-        await sendWAReport(waClient, msg);
+        await sendReport(msg);
       } catch (err) {
         console.warn(
           `[WA] Skipping premium request notification for ${row.request_id}: ${err.message}`

--- a/src/middleware/debugHandler.js
+++ b/src/middleware/debugHandler.js
@@ -1,6 +1,6 @@
 // src/middleware/debugHandler.js
 
-import waClient, { waitForWaReady } from "../service/waService.js";
+import { sendMessage } from "../service/waApiClient.js";
 
 // Helper: stringifier aman untuk circular object
 function safeStringify(obj) {
@@ -52,22 +52,13 @@ export function sendDebug({ tag = "DEBUG", msg, client_id = "", clientName = "" 
   const isError = /error/i.test(safeMsg);
 
   if (isStartOrEnd || isError) {
-    waitForWaReady()
-      .then(() => {
-        let waMsg = fullMsg;
-        if (isError) {
-          // kirim hanya potongan pendek agar tidak mengandung raw data
-          waMsg = `${prefix} ${safeMsg.toString().substring(0, 200)}`;
-        }
-        for (const wa of adminWA) {
-          waClient.sendMessage(wa, waMsg).catch(() => {});
-        }
-      })
-      .catch(() => {
-        console.warn(
-          '[WA] Skipping debug WhatsApp send: WhatsApp client not ready'
-        );
-      });
+    let waMsg = fullMsg;
+    if (isError) {
+      waMsg = `${prefix} ${safeMsg.toString().substring(0, 200)}`;
+    }
+    for (const wa of adminWA) {
+      sendMessage(wa, waMsg).catch(() => {});
+    }
   }
 
   console.log(fullMsg);

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -11,24 +11,15 @@ import {
   formatToWhatsAppId,
   getAdminWAIds,
   normalizeWhatsappNumber,
-  safeSendMessage,
 } from "../utils/waHelper.js";
 import redis from "../config/redis.js";
-import waClient, { waitForWaReady } from "../service/waService.js";
+import { sendMessage } from "../service/waApiClient.js";
 import { insertVisitorLog } from "../model/visitorLogModel.js";
 import { insertLoginLog } from "../model/loginLogModel.js";
 
 async function notifyAdmin(message) {
-  try {
-    await waitForWaReady();
-  } catch (err) {
-    console.warn(
-      `[WA] Skipping admin notification: ${err.message}`
-    );
-    return;
-  }
   for (const wa of getAdminWAIds()) {
-    safeSendMessage(waClient, wa, message);
+    sendMessage(wa, message);
   }
 }
 
@@ -190,10 +181,8 @@ router.post('/dashboard-register', async (req, res) => {
   );
   if (whatsapp) {
     try {
-      await waitForWaReady();
       const wid = formatToWhatsAppId(whatsapp);
-      safeSendMessage(
-        waClient,
+      await sendMessage(
         wid,
         "\uD83D\uDCCB Permintaan registrasi dashboard Anda telah diterima dan menunggu persetujuan admin."
       );

--- a/src/service/waApiClient.js
+++ b/src/service/waApiClient.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const baseURL = process.env.WA_SERVICE_URL || 'http://localhost:3001';
+
+export async function sendMessage(to, message, options = {}) {
+  try {
+    await axios.post(`${baseURL}/send`, { to, message, options });
+  } catch (err) {
+    console.warn(`[WA API] Failed to send message to ${to}: ${err.message}`);
+  }
+}
+
+export async function sendReport(message, chatIds = null) {
+  try {
+    await axios.post(`${baseURL}/broadcast`, { message, chatIds });
+  } catch (err) {
+    console.warn(`[WA API] Failed to broadcast message: ${err.message}`);
+  }
+}

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -6,13 +6,7 @@ import bcrypt from 'bcrypt';
 const mockQuery = jest.fn();
 const mockRedis = { sAdd: jest.fn(), set: jest.fn() };
 const mockInsertLoginLog = jest.fn();
-const mockWAClient = {
-  info: {},
-  sendMessage: jest.fn(),
-  getState: jest.fn().mockResolvedValue('CONNECTED'),
-  once: jest.fn(),
-  off: jest.fn(),
-};
+const mockSendMessage = jest.fn();
 const actualWaHelper = await import('../src/utils/waHelper.js');
 
 jest.unstable_mockModule('../src/db/index.js', () => ({
@@ -34,9 +28,9 @@ jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
   formatToWhatsAppId: (nohp) => `${nohp}@c.us`
 }));
 
-jest.unstable_mockModule('../src/service/waService.js', () => ({
-  default: mockWAClient,
-  waitForWaReady: () => Promise.resolve()
+jest.unstable_mockModule('../src/service/waApiClient.js', () => ({
+  sendMessage: mockSendMessage,
+  sendReport: jest.fn()
 }));
 
 let app;
@@ -56,7 +50,7 @@ beforeEach(() => {
   mockRedis.sAdd.mockReset();
   mockRedis.set.mockReset();
   mockInsertLoginLog.mockReset();
-  mockWAClient.sendMessage.mockReset();
+  mockSendMessage.mockReset();
 });
 
 describe('POST /login', () => {
@@ -302,16 +296,14 @@ describe('POST /dashboard-register', () => {
         expect.stringContaining('INSERT INTO dashboard_user_clients'),
         [expect.any(String), 'c1']
       );
-      expect(mockWAClient.sendMessage).toHaveBeenCalledTimes(2);
-      expect(mockWAClient.sendMessage).toHaveBeenCalledWith(
+      expect(mockSendMessage).toHaveBeenCalledTimes(2);
+      expect(mockSendMessage).toHaveBeenCalledWith(
         'admin@c.us',
-        expect.stringContaining('Permintaan User Approval'),
-        {}
+        expect.stringContaining('Permintaan User Approval')
       );
-      expect(mockWAClient.sendMessage).toHaveBeenCalledWith(
+      expect(mockSendMessage).toHaveBeenCalledWith(
         '628121234@c.us',
-        expect.stringContaining('Permintaan registrasi dashboard Anda telah diterima'),
-        {}
+        expect.stringContaining('Permintaan registrasi dashboard Anda telah diterima')
       );
   });
 
@@ -350,7 +342,7 @@ describe('POST /dashboard-register', () => {
     expect(mockQuery.mock.calls[1][0]).toContain('FROM roles');
     expect(mockQuery.mock.calls[1][1]).toEqual(['ditbinmas']);
     expect(mockQuery.mock.calls[2][1][3]).toBe(5);
-    expect(mockWAClient.sendMessage).toHaveBeenCalledTimes(2);
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
   });
 
   test('creates default role when missing', async () => {

--- a/tests/dashboardUserController.test.js
+++ b/tests/dashboardUserController.test.js
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 
 const mockFindById = jest.fn();
 const mockUpdateStatus = jest.fn();
-const mockSafeSendMessage = jest.fn();
+const mockSendMessage = jest.fn();
 
 jest.unstable_mockModule('../src/model/dashboardUserModel.js', () => ({
   findById: mockFindById,
@@ -10,14 +10,12 @@ jest.unstable_mockModule('../src/model/dashboardUserModel.js', () => ({
 }));
 
 jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
-  formatToWhatsAppId: (num) => num,
-  safeSendMessage: mockSafeSendMessage
+  formatToWhatsAppId: (num) => num
 }));
 
-const mockWaClient = {};
-jest.unstable_mockModule('../src/service/waService.js', () => ({
-  default: mockWaClient,
-  waitForWaReady: () => Promise.resolve()
+jest.unstable_mockModule('../src/service/waApiClient.js', () => ({
+  sendMessage: mockSendMessage,
+  sendReport: jest.fn()
 }));
 
 let controller;
@@ -29,7 +27,7 @@ beforeAll(async () => {
 beforeEach(() => {
   mockFindById.mockReset();
   mockUpdateStatus.mockReset();
-  mockSafeSendMessage.mockReset();
+  mockSendMessage.mockReset();
 });
 
 test('approveDashboardUser sends approval message', async () => {
@@ -43,8 +41,7 @@ test('approveDashboardUser sends approval message', async () => {
   await controller.approveDashboardUser(req, res, next);
 
   expect(mockUpdateStatus).toHaveBeenCalledWith('1', true);
-  expect(mockSafeSendMessage).toHaveBeenCalledWith(
-    mockWaClient,
+  expect(mockSendMessage).toHaveBeenCalledWith(
     '0812',
     expect.stringContaining('disetujui')
   );
@@ -63,8 +60,7 @@ test('rejectDashboardUser sends rejection message', async () => {
   await controller.rejectDashboardUser(req, res, next);
 
   expect(mockUpdateStatus).toHaveBeenCalledWith('1', false);
-  expect(mockSafeSendMessage).toHaveBeenCalledWith(
-    mockWaClient,
+  expect(mockSendMessage).toHaveBeenCalledWith(
     '0812',
     expect.stringContaining('ditolak')
   );

--- a/wa-bot.js
+++ b/wa-bot.js
@@ -1,0 +1,59 @@
+import './src/utils/logger.js';
+import express from 'express';
+import cors from 'cors';
+import { waClient } from './src/service/waService.js';
+import { sendWAReport } from './src/utils/waHelper.js';
+
+const cronModules = [
+  './src/cron/cronInstaService.js',
+  './src/cron/cronTiktokService.js',
+  './src/cron/cronInstaLaphar.js',
+  './src/cron/cronTiktokLaphar.js',
+  './src/cron/cronNotifikasiLikesDanKomentar.js',
+  './src/cron/cronInstaDataMining.js',
+  './src/cron/cronPremiumSubscription.js',
+  './src/cron/cronRekapLink.js',
+  './src/cron/cronAmplifyLinkMonthly.js',
+  './src/cron/cronPremiumRequest.js',
+  './src/cron/cronAbsensiUserData.js',
+  './src/cron/cronAbsensiOprDitbinmas.js',
+  './src/cron/cronDirRequest.js',
+  './src/cron/cronDbBackup.js',
+];
+
+waClient.on('ready', async () => {
+  await Promise.all(cronModules.map(m => import(m)));
+});
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/send', async (req, res) => {
+  const { to, message, options } = req.body || {};
+  if (!to || !message) {
+    return res.status(400).json({ success: false, message: 'to and message required' });
+  }
+  try {
+    await waClient.sendMessage(to, message, options);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+app.post('/broadcast', async (req, res) => {
+  const { message, chatIds } = req.body || {};
+  if (!message) {
+    return res.status(400).json({ success: false, message: 'message required' });
+  }
+  try {
+    await sendWAReport(waClient, message, chatIds);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+const PORT = process.env.WA_PORT || 3001;
+app.listen(PORT, () => console.log(`WA service running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- split WhatsApp bot and cron jobs into standalone `wa-bot.js`
- add HTTP-based `waApiClient` and update controllers/middleware to use it
- document new service and startup commands

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bd038a288327b79bf23327e7da7a