### PR TITLE
Queue WA admin notifications until ready

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -14,7 +14,10 @@ import {
   safeSendMessage,
 } from "../utils/waHelper.js";
 import redis from "../config/redis.js";
-import waClient, { waitForWaReady } from "../service/waService.js";
+import waClient, {
+  waitForWaReady,
+  queueAdminNotification,
+} from "../service/waService.js";
 import { insertVisitorLog } from "../model/visitorLogModel.js";
 import { insertLoginLog } from "../model/loginLogModel.js";
 
@@ -23,8 +26,9 @@ async function notifyAdmin(message) {
     await waitForWaReady();
   } catch (err) {
     console.warn(
-      `[WA] Skipping admin notification: ${err.message}`
+      `[WA] Queueing admin notification: ${err.message}`
     );
+    queueAdminNotification(message);
     return;
   }
   for (const wa of getAdminWAIds()) {

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -36,7 +36,8 @@ jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
 
 jest.unstable_mockModule('../src/service/waService.js', () => ({
   default: mockWAClient,
-  waitForWaReady: () => Promise.resolve()
+  waitForWaReady: () => Promise.resolve(),
+  queueAdminNotification: jest.fn(),
 }));
 
 let app;


### PR DESCRIPTION
## Summary
- Queue admin notification messages when WhatsApp client isn't ready and deliver them once connected
- Expose queue helpers in `waService` and flush queued notifications when the client becomes ready
- Adjust auth route tests to mock new queue behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e8fa3d208327ac4273c5c2d54cb9