### PR TITLE
feat: add WhatsApp adapter with Baileys fallback

### DIFF
--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -1,0 +1,83 @@
+import { EventEmitter } from 'events';
+import pkg from 'whatsapp-web.js';
+const { Client, LocalAuth } = pkg;
+import qrcode from 'qrcode-terminal';
+import makeWASocket, { useSingleFileAuthState } from '@whiskeysockets/baileys';
+import fs from 'fs';
+import path from 'path';
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function createWwebClient() {
+  const client = new Client({
+    authStrategy: new LocalAuth({
+      clientId: process.env.APP_SESSION_NAME,
+    }),
+    puppeteer: {
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+    },
+    takeoverOnConflict: true,
+    takeoverTimeoutMs: 10000,
+  });
+
+  client.connect = () => client.initialize();
+  client.disconnect = () => client.destroy();
+  client.onMessage = (handler) => client.on('message', handler);
+  client.onDisconnect = (handler) => client.on('disconnected', handler);
+  client.isReady = async () => {
+    try {
+      const state = await client.getState();
+      return state === 'CONNECTED';
+    } catch {
+      return false;
+    }
+  };
+  // Display QR via console
+  client.on('qr', (qr) => qrcode.generate(qr, { small: true }));
+  return client;
+}
+
+export function createBaileysClient() {
+  const sessionsDir = path.join('sessions', 'baileys');
+  ensureDir(sessionsDir);
+  const { state, saveState } = useSingleFileAuthState(path.join(sessionsDir, 'auth.json'));
+  const sock = makeWASocket({
+    auth: state,
+    printQRInTerminal: true,
+  });
+  sock.ev.on('creds.update', saveState);
+
+  const emitter = new EventEmitter();
+
+  emitter.connect = async () => {};
+  emitter.disconnect = async () => sock.end();
+  emitter.sendMessage = (jid, message, options = {}) =>
+    sock.sendMessage(jid, { text: message }, options);
+  emitter.onMessage = (handler) => emitter.on('message', handler);
+  emitter.onDisconnect = (handler) => emitter.on('disconnected', handler);
+  emitter.isReady = async () => Boolean(sock.authState?.creds?.me);
+  emitter.getState = async () => (await emitter.isReady()) ? 'open' : 'close';
+
+  sock.ev.on('messages.upsert', (m) => {
+    if (m.type !== 'notify') return;
+    for (const msg of m.messages) {
+      const body =
+        msg.message?.conversation ||
+        msg.message?.extendedTextMessage?.text ||
+        '';
+      emitter.emit('message', { from: msg.key.remoteJid, body });
+    }
+  });
+
+  sock.ev.on('connection.update', (update) => {
+    if (update.connection === 'open') emitter.emit('ready');
+    if (update.connection === 'close') emitter.emit('disconnected', update.lastDisconnect?.error);
+  });
+
+  return emitter;
+}

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -26,13 +26,10 @@ export async function sendWAReport(waClient, message, chatIds = null) {
       continue;
     }
     try {
-      const wid = await waClient.getNumberId(target);
-      if (!wid) {
-        console.warn(`[SKIP WA] Unregistered wid: ${target}`);
-        continue;
-      }
-      await waClient.sendMessage(wid._serialized, message);
-      console.log(`[WA CRON] Sent WA to ${target}: ${message.substring(0, 64)}...`);
+      await waClient.sendMessage(target, message);
+      console.log(
+        `[WA CRON] Sent WA to ${target}: ${message.substring(0, 64)}...`
+      );
     } catch (err) {
       console.error(`[WA CRON] ERROR send WA to ${target}:`, err.message);
     }
@@ -158,7 +155,10 @@ async function waitUntilReady(waClient, timeout = 10000) {
   if (!waClient) return false;
 
   try {
-    if (typeof waClient.getState === 'function') {
+    if (typeof waClient.isReady === 'function') {
+      const ok = await waClient.isReady();
+      if (ok) return true;
+    } else if (typeof waClient.getState === 'function') {
       const state = await waClient.getState();
       if (state === 'CONNECTED' || state === 'open') return true;
     }

--- a/tests/waServiceFailover.test.js
+++ b/tests/waServiceFailover.test.js
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+process.env.JWT_SECRET = 'test';
+
+const baileysClient = new EventEmitter();
+baileysClient.connect = jest.fn().mockResolvedValue();
+baileysClient.disconnect = jest.fn().mockResolvedValue();
+baileysClient.sendMessage = jest.fn().mockResolvedValue();
+baileysClient.isReady = jest.fn().mockResolvedValue(true);
+baileysClient.onDisconnect = jest.fn((handler) => baileysClient.on('disconnected', handler));
+
+jest.unstable_mockModule('../src/service/waAdapter.js', () => ({
+  createWwebClient: jest.fn(() => {
+    throw new Error('wweb fail');
+  }),
+  createBaileysClient: jest.fn(() => baileysClient),
+}));
+
+const waService = await import('../src/service/waService.js');
+const waHelper = await import('../src/utils/waHelper.js');
+const adapter = await import('../src/service/waAdapter.js');
+
+const { default: waClient } = waService;
+const { safeSendMessage } = waHelper;
+const { createWwebClient, createBaileysClient } = adapter;
+
+test('fallback to Baileys when wweb client fails', async () => {
+  baileysClient.emit('ready');
+  await safeSendMessage(waClient, '123@c.us', 'hello');
+  expect(createWwebClient).toHaveBeenCalled();
+  expect(createBaileysClient).toHaveBeenCalled();
+  expect(baileysClient._originalSendMessage).toHaveBeenCalledWith(
+    '123@c.us',
+    'hello',
+    {}
+  );
+});


### PR DESCRIPTION
## Summary
- add adapter to unify whatsapp-web.js and Baileys clients
- refactor waService to use adapter with automatic fallback
- adjust wa helper utilities and add fallback test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b8f29dbc83279ff46a461fdcc643