### PR TITLE
refactor: rename createWwebClient function

### DIFF
--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -12,7 +12,7 @@ function ensureDir(dir) {
   }
 }
 
-export function createWwebClient() {
+export function createWWebClient() {
   const client = new Client({
     authStrategy: new LocalAuth({
       clientId: process.env.APP_SESSION_NAME,

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -8,7 +8,7 @@ const pool = { query };
 
 // Adapter creators for WhatsApp clients
 import {
-  createWwebClient,
+  createWWebClient,
   createBaileysClient,
 } from "./waAdapter.js";
 
@@ -124,9 +124,9 @@ function formatUserSummary(user) {
 // Inisialisasi WhatsApp client melalui adapter
 export let waClient;
 try {
-  waClient = createWwebClient();
+  waClient = createWWebClient();
 } catch (err) {
-  console.warn("[WA] createWwebClient failed:", err.message);
+  console.warn("[WA] createWWebClient failed:", err.message);
   waClient = await createBaileysClient();
 }
 

--- a/tests/waServiceFailover.test.js
+++ b/tests/waServiceFailover.test.js
@@ -11,7 +11,7 @@ baileysClient.isReady = jest.fn().mockResolvedValue(true);
 baileysClient.onDisconnect = jest.fn((handler) => baileysClient.on('disconnected', handler));
 
 jest.unstable_mockModule('../src/service/waAdapter.js', () => ({
-  createWwebClient: jest.fn(() => {
+  createWWebClient: jest.fn(() => {
     throw new Error('wweb fail');
   }),
   createBaileysClient: jest.fn(() => baileysClient),
@@ -23,12 +23,12 @@ const adapter = await import('../src/service/waAdapter.js');
 
 const { default: waClient } = waService;
 const { safeSendMessage } = waHelper;
-const { createWwebClient, createBaileysClient } = adapter;
+const { createWWebClient, createBaileysClient } = adapter;
 
 test('fallback to Baileys when wweb client fails', async () => {
   baileysClient.emit('ready');
   await safeSendMessage(waClient, '123@c.us', 'hello');
-  expect(createWwebClient).toHaveBeenCalled();
+  expect(createWWebClient).toHaveBeenCalled();
   expect(createBaileysClient).toHaveBeenCalled();
   expect(baileysClient._originalSendMessage).toHaveBeenCalledWith(
     '123@c.us',


### PR DESCRIPTION
## Summary
- rename WhatsApp adapter factory to createWWebClient
- update waService import and failover test

## Testing
- `npm run lint`
- `npm test`
- `npm start` *(fails: missing libatk-1.0.so.0 and Redis connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3be3bf7dc8327aaca6132efd25989