### PR TITLE
Await Baileys socket readiness before using WA client

### DIFF
--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -54,7 +54,15 @@ export async function createBaileysClient() {
 
   const emitter = new EventEmitter();
 
-  emitter.connect = async () => {};
+  emitter.connect = async () => {
+    // Ensure the underlying websocket is opened and wait for the 'ready' event
+    if (typeof sock.ws?.open === 'function') {
+      await sock.ws.open();
+    }
+    if (!(await emitter.isReady())) {
+      await new Promise((resolve) => emitter.once('ready', resolve));
+    }
+  };
   emitter.disconnect = async () => sock.end();
   emitter.sendMessage = (jid, message, options = {}) =>
     sock.sendMessage(jid, { text: message }, options);

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -2143,11 +2143,11 @@ waClient.on("message_create", (msg) => {
 // INISIALISASI WA CLIENT
 // =======================
 console.log("[WA] Starting WhatsApp client initialization");
-waClient
-  .connect()
-  .catch((err) => {
-    console.error("[WA] Initialization failed:", err.message);
-  });
+try {
+  await waClient.connect();
+} catch (err) {
+  console.error("[WA] Initialization failed:", err.message);
+}
 
 // Watchdog: jika event 'ready' tidak muncul, cek state setelah 60 detik
 setTimeout(async () => {

--- a/tests/waServiceFailover.test.js
+++ b/tests/waServiceFailover.test.js
@@ -4,7 +4,9 @@ import { EventEmitter } from 'events';
 process.env.JWT_SECRET = 'test';
 
 const baileysClient = new EventEmitter();
-baileysClient.connect = jest.fn().mockResolvedValue();
+baileysClient.connect = jest.fn(
+  () => new Promise((resolve) => baileysClient.once('ready', resolve))
+);
 baileysClient.disconnect = jest.fn().mockResolvedValue();
 baileysClient.sendMessage = jest.fn().mockResolvedValue();
 baileysClient.isReady = jest.fn().mockResolvedValue(true);
@@ -17,16 +19,21 @@ jest.unstable_mockModule('../src/service/waAdapter.js', () => ({
   createBaileysClient: jest.fn(() => baileysClient),
 }));
 
-const waService = await import('../src/service/waService.js');
-const waHelper = await import('../src/utils/waHelper.js');
-const adapter = await import('../src/service/waAdapter.js');
+const waServicePromise = import('../src/service/waService.js');
+const waHelperPromise = import('../src/utils/waHelper.js');
+const adapterPromise = import('../src/service/waAdapter.js');
+
+setImmediate(() => baileysClient.emit('ready'));
+
+const waService = await waServicePromise;
+const waHelper = await waHelperPromise;
+const adapter = await adapterPromise;
 
 const { default: waClient } = waService;
 const { safeSendMessage } = waHelper;
 const { createWWebClient, createBaileysClient } = adapter;
 
 test('fallback to Baileys when wweb client fails', async () => {
-  baileysClient.emit('ready');
   await safeSendMessage(waClient, '123@c.us', 'hello');
   expect(createWWebClient).toHaveBeenCalled();
   expect(createBaileysClient).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- ensure Baileys adapter waits for underlying websocket to open before resolving
- await `waClient.connect()` during service startup for reliable initialization
- adjust Baileys failover test to resolve only after mocked connection is ready

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c223a544832786dc05effb132566