### PR TITLE
Handle Baileys QR via connection.update

### DIFF
--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -48,7 +48,6 @@ export async function createBaileysClient() {
   const { state, saveCreds } = await useMultiFileAuthState(sessionsDir);
   const sock = makeWASocket({
     auth: state,
-    printQRInTerminal: true,
   });
   sock.ev.on('creds.update', saveCreds);
 
@@ -96,6 +95,7 @@ export async function createBaileysClient() {
   });
 
   sock.ev.on('connection.update', (update) => {
+    if (update.qr) qrcode.generate(update.qr, { small: true });
     if (update.connection === 'open') emitter.emit('ready');
     if (update.connection === 'close') emitter.emit('disconnected', update.lastDisconnect?.error);
   });


### PR DESCRIPTION
## Summary
- remove deprecated `printQRInTerminal`
- generate QR codes from `connection.update` events

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError in tests/waServiceFailover.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c581559c8327bbe2291bf3fb2b9f