### PR TITLE
feat: add WhatsApp pairing code requester

### DIFF
--- a/scripts/requestPairingCode.js
+++ b/scripts/requestPairingCode.js
@@ -1,0 +1,16 @@
+import { requestPairingCode } from '../src/service/waAdapter.js';
+
+const number = process.argv[2];
+if (!number) {
+  console.error('Usage: node scripts/requestPairingCode.js <phone-number>');
+  process.exit(1);
+}
+
+requestPairingCode(number)
+  .then((code) => {
+    console.log('Pairing code:', code);
+  })
+  .catch((err) => {
+    console.error('Failed to request pairing code:', err.message);
+    process.exit(1);
+  });

--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -120,3 +120,22 @@ export async function createBaileysClient() {
 
   return emitter;
 }
+
+export async function requestPairingCode(phoneNumber) {
+  const sessionsDir = path.join('sessions', 'baileys');
+  ensureDir(sessionsDir);
+  const { state, saveCreds } = await useMultiFileAuthState(sessionsDir);
+
+  const sock = makeWASocket({
+    auth: state,
+    browser: ['Ubuntu', 'Chrome', '22.04.4'],
+    printQRInTerminal: false,
+  });
+  sock.ev.on('creds.update', saveCreds);
+  try {
+    const code = await sock.requestPairingCode(phoneNumber);
+    return code;
+  } finally {
+    await sock.end();
+  }
+}

--- a/tests/requestPairingCode.test.js
+++ b/tests/requestPairingCode.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+
+const mockRequestPairingCode = jest.fn().mockResolvedValue('654321');
+const mockEnd = jest.fn().mockResolvedValue();
+const mockSock = { requestPairingCode: mockRequestPairingCode, ev: { on: jest.fn() }, end: mockEnd };
+
+jest.unstable_mockModule('@whiskeysockets/baileys', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockSock),
+  useMultiFileAuthState: jest.fn().mockResolvedValue({ state: {}, saveCreds: jest.fn() }),
+}));
+
+const { requestPairingCode } = await import('../src/service/waAdapter.js');
+
+test('requestPairingCode requests code and closes socket', async () => {
+  const code = await requestPairingCode('0895601093339');
+  expect(mockRequestPairingCode).toHaveBeenCalledWith('0895601093339');
+  expect(code).toBe('654321');
+  expect(mockEnd).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add Baileys helper to request pairing codes
- add CLI script for requesting a WhatsApp pairing code
- test pairing code helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d01790b48327a03f61c9e41a5d7a