### PR TITLE
Normalize admin WhatsApp ID check

### DIFF
--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -76,7 +76,13 @@ export function isAdminWhatsApp(number) {
     .map((n) => n.trim())
     .filter(Boolean)
     .map((n) => (n.endsWith("@c.us") ? n : n.replace(/\D/g, "") + "@c.us"));
-  return adminNumbers.includes(number);
+  const normalized =
+    typeof number === "string"
+      ? number.endsWith("@c.us")
+        ? number
+        : number.replace(/\D/g, "") + "@c.us"
+      : "";
+  return adminNumbers.includes(normalized);
 }
 
 // Konversi nomor ke WhatsAppID (xxxx@c.us)

--- a/tests/waHelper.test.js
+++ b/tests/waHelper.test.js
@@ -2,9 +2,10 @@ import { jest } from '@jest/globals';
 import { EventEmitter } from 'events';
 
 let safeSendMessage;
+let isAdminWhatsApp;
 
 beforeAll(async () => {
-  ({ safeSendMessage } = await import('../src/utils/waHelper.js'));
+  ({ safeSendMessage, isAdminWhatsApp } = await import('../src/utils/waHelper.js'));
 });
 
 test('safeSendMessage waits for client ready', async () => {
@@ -18,4 +19,14 @@ test('safeSendMessage waits for client ready', async () => {
   waClient.emit('ready');
   await promise;
   expect(waClient.sendMessage).toHaveBeenCalledWith('123@c.us', 'hello', {});
+});
+
+test('isAdminWhatsApp recognizes various input formats', () => {
+  const original = process.env.ADMIN_WHATSAPP;
+  process.env.ADMIN_WHATSAPP = '6281';
+  expect(isAdminWhatsApp('6281@c.us')).toBe(true);
+  expect(isAdminWhatsApp('6281@s.whatsapp.net')).toBe(true);
+  expect(isAdminWhatsApp('+62 81')).toBe(true);
+  expect(isAdminWhatsApp('999@c.us')).toBe(false);
+  process.env.ADMIN_WHATSAPP = original;
 });


### PR DESCRIPTION
## Summary
- normalize WhatsApp admin ID comparisons
- test isAdminWhatsApp with varied number formats

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d9a4438c83279c942bd4d7e6f289