### PR TITLE
Handle Ditbinmas role on Instagram likes

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -16,36 +16,45 @@ import { sendSuccess } from "../utils/response.js";
 import { sendConsoleDebug } from "../middleware/debugHandler.js";
 
 export async function getInstaRekapLikes(req, res) {
-  const client_id = req.query.client_id;
+  let client_id = req.query.client_id;
   const periode = req.query.periode || "harian";
   const tanggal = req.query.tanggal;
   const startDate =
     req.query.start_date || req.query.tanggal_mulai;
   const endDate = req.query.end_date || req.query.tanggal_selesai;
   const role = req.user?.role;
-    if (!client_id) {
-      return res.status(400).json({ success: false, message: "client_id wajib diisi" });
-    }
-    if (req.user?.client_ids) {
-      const idsLower = req.user.client_ids.map((c) => c.toLowerCase());
-      if (
-        !idsLower.includes(client_id.toLowerCase()) &&
-        req.user.role?.toLowerCase() !== client_id.toLowerCase()
-      ) {
-        return res
-          .status(403)
-          .json({ success: false, message: "client_id tidak diizinkan" });
-      }
-    }
+  const roleLower = role?.toLowerCase();
+
+  if (roleLower === "ditbinmas") {
+    client_id = "ditbinmas";
+  }
+
+  if (!client_id) {
+    return res
+      .status(400)
+      .json({ success: false, message: "client_id wajib diisi" });
+  }
+
+  if (req.user?.client_ids) {
+    const idsLower = req.user.client_ids.map((c) => c.toLowerCase());
     if (
-      req.user?.client_id &&
-      req.user.client_id !== client_id &&
-      req.user.role?.toLowerCase() !== client_id.toLowerCase()
+      !idsLower.includes(client_id.toLowerCase()) &&
+      roleLower !== client_id.toLowerCase()
     ) {
       return res
         .status(403)
         .json({ success: false, message: "client_id tidak diizinkan" });
     }
+  }
+  if (
+    req.user?.client_id &&
+    req.user.client_id !== client_id &&
+    roleLower !== client_id.toLowerCase()
+  ) {
+    return res
+      .status(403)
+      .json({ success: false, message: "client_id tidak diizinkan" });
+  }
   try {
     sendConsoleDebug({ tag: "INSTA", msg: `getInstaRekapLikes ${client_id} ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}` });
     const data = await getRekapLikesByClient(

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -99,12 +99,12 @@ test('filters users by role for directorate clients', async () => {
   expect(sql).toContain('user_roles ur');
   expect(sql).toContain('roles r');
   expect(sql).toContain('EXISTS');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
   expect(sql).toContain('insta_post_roles pr');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
-  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas']);
+  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
 });
 
 test('handles mixed-case client_type for directorate', async () => {
@@ -114,10 +114,10 @@ test('handles mixed-case client_type for directorate', async () => {
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
   expect(sql).toContain('user_roles ur');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
-  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas']);
+  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
 });
 
 test('filters users by role for non-directorate clients', async () => {
@@ -174,12 +174,12 @@ test('aggregates likes across multiple client IDs for directorate role', async (
   const rows = await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
   expect(sql).toContain('insta_post_roles pr');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
-  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas']);
+  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
   expect(rows).toHaveLength(2);
   expect(rows.map(r => r.client_id)).toEqual(['c1', 'c2']);
 });


### PR DESCRIPTION
## Summary
- Ensure `/insta/rekap-likes` uses Ditbinmas client data when the requester has Ditbinmas role
- Filter Instagram like recap by role and client for Ditbinmas and update unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e815cbc4832798cedb8489543946