### PR TITLE
feat: enhance Instagram likes recap endpoint

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -9,17 +9,22 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
   "success": true,
   "data": [ /* user like rows */ ],
   "chartHeight": 300,
-  "usersWithLikes": ["alice", "charlie"],
-  "usersWithoutLikes": ["bob"],
-  "usersWithLikesCount": 2,
-  "usersWithoutLikesCount": 1,
-  "usersCount": 3
+  "totalPosts": 4,
+  "sudahUsers": ["alice"],
+  "kurangUsers": ["bob"],
+  "belumUsers": ["charlie"],
+  "sudahUsersCount": 1,
+  "kurangUsersCount": 1,
+  "belumUsersCount": 1,
+  "noUsernameUsersCount": 1,
+  "usersCount": 4
 }
 ```
 
-- **usersWithLikes** – usernames with `jumlah_like > 0`.
-- **usersWithoutLikes** – usernames with `jumlah_like = 0`.
-- Count fields provide totals for each category.
+- **sudahUsers** – usernames that liked at least 50% of posts or are marked as exception.
+- **kurangUsers** – usernames that liked some posts but less than 50%.
+- **belumUsers** – usernames that did not like any posts.
+- **noUsernameUsersCount** – number of users without an Instagram username.
 - **usersCount** – total number of users returned in `data`.
 
 ### Directorate Clients

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -31,7 +31,7 @@ beforeEach(() => {
 });
 
 test('accepts tanggal_mulai and tanggal_selesai', async () => {
-  mockGetRekap.mockResolvedValue([]);
+  mockGetRekap.mockResolvedValue({ rows: [], totalKonten: 0 });
   const req = {
     query: {
       client_id: 'c1',
@@ -61,7 +61,7 @@ test('returns 403 when client_id unauthorized', async () => {
 });
 
 test('allows authorized client_id', async () => {
-  mockGetRekap.mockResolvedValue([]);
+  mockGetRekap.mockResolvedValue({ rows: [], totalKonten: 0 });
   const req = {
     query: { client_id: 'c1' },
     user: { client_ids: ['c1', 'c2'] }
@@ -76,11 +76,12 @@ test('allows authorized client_id', async () => {
 
 test('returns user like summaries', async () => {
   const rows = [
-    { username: 'alice', jumlah_like: 3 },
-    { username: 'bob', jumlah_like: 0 },
-    { username: 'charlie', jumlah_like: 1 }
+    { username: 'alice', jumlah_like: 4 },
+    { username: 'bob', jumlah_like: 1 },
+    { username: 'charlie', jumlah_like: 0 },
+    { username: null, jumlah_like: 0 }
   ];
-  mockGetRekap.mockResolvedValue(rows);
+  mockGetRekap.mockResolvedValue({ rows, totalKonten: 4 });
   const req = {
     query: { client_id: 'c1' },
     user: { client_ids: ['c1'] }
@@ -90,11 +91,14 @@ test('returns user like summaries', async () => {
   await getInstaRekapLikes(req, res);
   expect(json).toHaveBeenCalledWith(
     expect.objectContaining({
-      usersWithLikes: ['alice', 'charlie'],
-      usersWithoutLikes: ['bob'],
-      usersWithLikesCount: 2,
-      usersWithoutLikesCount: 1,
-      usersCount: 3
+      sudahUsers: ['alice'],
+      kurangUsers: ['bob'],
+      belumUsers: ['charlie'],
+      sudahUsersCount: 1,
+      kurangUsersCount: 1,
+      belumUsersCount: 1,
+      noUsernameUsersCount: 1,
+      usersCount: 4
     })
   );
 });

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -23,6 +23,7 @@ function mockClientType(type = 'regular') {
 test('harian with specific date uses date filter', async () => {
   mockClientType();
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('1', 'harian', '2023-10-05');
   const expected = "p.created_at::date = $2::date";
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
@@ -31,6 +32,7 @@ test('harian with specific date uses date filter', async () => {
 test('mingguan with date truncs week', async () => {
   mockClientType();
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('1', 'mingguan', '2023-10-05');
   const expected = "date_trunc('week', p.created_at) = date_trunc('week', $2::date)";
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-05']);
@@ -39,6 +41,7 @@ test('mingguan with date truncs week', async () => {
 test('bulanan converts month string', async () => {
   mockClientType();
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('1', 'bulanan', '2023-10');
   const expected = "date_trunc('month', p.created_at AT TIME ZONE 'Asia/Jakarta') = date_trunc('month', $2::date)";
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-01']);
@@ -47,6 +50,7 @@ test('bulanan converts month string', async () => {
 test('semua uses no date filter', async () => {
   mockClientType();
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('1', 'semua');
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining('1=1'), ['1']);
 });
@@ -54,6 +58,7 @@ test('semua uses no date filter', async () => {
 test('date range uses between filter', async () => {
   mockClientType();
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('1', 'harian', undefined, '2023-10-01', '2023-10-07');
   const expected = "(p.created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date";
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining(expected), ['1', '2023-10-01', '2023-10-07']);
@@ -62,6 +67,7 @@ test('date range uses between filter', async () => {
 test('query normalizes instagram usernames', async () => {
   mockClientType();
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('1');
   expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining('jsonb_array_elements(l.likes)'), ['1']);
 });
@@ -77,13 +83,15 @@ test('parses jumlah_like as integer', async () => {
     exception: false,
     jumlah_like: '3',
   }] });
-  const rows = await getRekapLikesByClient('1');
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
+  const { rows } = await getRekapLikesByClient('1');
   expect(rows[0].jumlah_like).toBe(3);
 });
 
 test('filters users by client_id for non-directorate clients', async () => {
   mockClientType('regular');
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('1');
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
@@ -93,6 +101,7 @@ test('filters users by client_id for non-directorate clients', async () => {
 test('filters users by role for directorate clients', async () => {
   mockClientType('direktorat');
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
@@ -110,6 +119,7 @@ test('filters users by role for directorate clients', async () => {
 test('handles mixed-case client_type for directorate', async () => {
   mockClientType('Direktorat');
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
@@ -123,6 +133,7 @@ test('handles mixed-case client_type for directorate', async () => {
 test('treats ditbinmas role as directorate regardless of client type', async () => {
   mockClientType('regular');
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
@@ -137,6 +148,7 @@ test('treats ditbinmas role as directorate regardless of client type', async () 
 test('filters users by role for non-directorate clients with regular role', async () => {
   mockClientType('regular');
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditintelkam');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
@@ -150,6 +162,7 @@ test('filters users by role for non-directorate clients with regular role', asyn
 test('skips role filter for operator role on non-directorate clients', async () => {
   mockClientType('regular');
   mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'operator');
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
@@ -185,7 +198,8 @@ test('aggregates likes across multiple client IDs for directorate role', async (
       },
     ],
   });
-  const rows = await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
+  const { rows } = await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
   expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');


### PR DESCRIPTION
## Summary
- include post counts and remove username filter in Instagram like recap model
- categorize users in /insta/rekap-likes API response with counts for sudah, kurang, belum
- document new API response structure

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ed6becd08327a85d660bdeca5d28