### PR TITLE
Fix directorate Instagram like recap counts

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -15,7 +15,7 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
   "belumUsers": ["charlie"],
   "sudahUsersCount": 1,
   "kurangUsersCount": 1,
-  "belumUsersCount": 1,
+  "belumUsersCount": 2,
   "noUsernameUsersCount": 1,
   "usersCount": 4
 }
@@ -24,6 +24,7 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
 - **sudahUsers** – usernames that liked at least 50% of posts or are marked as exception.
 - **kurangUsers** – usernames that liked some posts but less than 50%.
 - **belumUsers** – usernames that did not like any posts.
+- **belumUsersCount** – users who did not like any posts **or** have no Instagram username.
 - **noUsernameUsersCount** – number of users without an Instagram username.
 - **usersCount** – total number of users returned in `data`.
 

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -88,6 +88,8 @@ export async function getInstaRekapLikes(req, res) {
       }
     });
 
+    const belumUsersCount = belumUsers.length + noUsernameUsers.length;
+
     res.json({
       success: true,
       data: rows,
@@ -98,7 +100,7 @@ export async function getInstaRekapLikes(req, res) {
       belumUsers,
       sudahUsersCount: sudahUsers.length,
       kurangUsersCount: kurangUsers.length,
-      belumUsersCount: belumUsers.length,
+      belumUsersCount,
       noUsernameUsersCount: noUsernameUsers.length,
       usersCount: length,
     });

--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -94,9 +94,7 @@ export async function getRekapLikesByClient(
   const clientType = clientTypeRes.rows[0]?.client_type?.toLowerCase();
 
   const roleLower = role ? role.toLowerCase() : null;
-  const isDitbinmas =
-    client_id.toLowerCase() === "ditbinmas" || roleLower === "ditbinmas";
-  const params = clientType === "direktorat" && !isDitbinmas ? [] : [client_id];
+  const params = clientType === "direktorat" ? [] : [client_id];
   let tanggalFilter =
     "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   if (start_date && end_date) {
@@ -130,9 +128,7 @@ export async function getRekapLikesByClient(
   }
 
   let postClientFilter =
-    clientType === "direktorat" && !isDitbinmas
-      ? "1=1"
-      : 'LOWER(p.client_id) = LOWER($1)';
+    clientType === "direktorat" ? "1=1" : 'LOWER(p.client_id) = LOWER($1)';
   let userWhere = 'LOWER(u.client_id) = LOWER($1)';
   let likeCountsSelect = `
     SELECT username, client_id, COUNT(DISTINCT shortcode) AS jumlah_like

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -96,7 +96,7 @@ test('returns user like summaries', async () => {
       belumUsers: ['charlie'],
       sudahUsersCount: 1,
       kurangUsersCount: 1,
-      belumUsersCount: 1,
+      belumUsersCount: 2,
       noUsernameUsersCount: 1,
       usersCount: 4
     })

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -108,12 +108,12 @@ test('filters users by role for directorate clients', async () => {
   expect(sql).toContain('user_roles ur');
   expect(sql).toContain('roles r');
   expect(sql).toContain('EXISTS');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
   expect(sql).toContain('insta_post_roles pr');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
+  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
+  expect(params).toEqual(['ditbinmas']);
 });
 
 test('handles mixed-case client_type for directorate', async () => {
@@ -124,10 +124,10 @@ test('handles mixed-case client_type for directorate', async () => {
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
   expect(sql).toContain('user_roles ur');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
+  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
+  expect(params).toEqual(['ditbinmas']);
 });
 
 test('treats ditbinmas role as directorate regardless of client type', async () => {
@@ -202,12 +202,12 @@ test('aggregates likes across multiple client IDs for directorate role', async (
   const { rows } = await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[1][0];
   const params = mockQuery.mock.calls[1][1];
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
   expect(sql).toContain('insta_post_roles pr');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
+  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
+  expect(params).toEqual(['ditbinmas']);
   expect(rows).toHaveLength(2);
   expect(rows.map(r => r.client_id)).toEqual(['c1', 'c2']);
 });


### PR DESCRIPTION
## Summary
- handle directorate roles by aggregating likes across all clients
- include users without usernames in recap's `belum` count
- document new recap behaviour and adjust tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f272836c8327a53fd98eb7f95c7e