### PR TITLE
fix: handle role-specific Instagram likes

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -159,7 +159,8 @@ export async function absensiLikes(client_id, opts = {}) {
   }
 
   const users = await getUsersByClient(clientFilter || client_id, roleFlag);
-  const shortcodes = await getShortcodesTodayByClient(client_id);
+  const targetClient = roleFlag || client_id;
+  const shortcodes = await getShortcodesTodayByClient(targetClient);
 
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *Polres*: *${clientNama}* hari ini.`;
@@ -289,7 +290,9 @@ export async function absensiLikesPerKonten(client_id, opts = {}) {
 
   const { nama: clientNama } = await getClientInfo(client_id);
   const users = await getUsersByClient(client_id);
-  const shortcodes = await getShortcodesTodayByClient(client_id);
+  const roleFlag = opts.roleFlag;
+  const targetClient = roleFlag || client_id;
+  const shortcodes = await getShortcodesTodayByClient(targetClient);
 
   if (!shortcodes.length)
     return `Tidak ada konten IG untuk *Polres*: *${clientNama}* hari ini.`;

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -99,6 +99,7 @@ test('filters users by role when roleFlag provided for polres', async () => {
   await absensiLikes('POLRES', { roleFlag: 'ditbinmas' });
 
   expect(mockGetUsersByClient).toHaveBeenCalledWith('POLRES', 'ditbinmas');
+  expect(mockGetShortcodesTodayByClient).toHaveBeenCalledWith('ditbinmas');
 });
 
 test('directorate summarizes across clients', async () => {


### PR DESCRIPTION
## Summary
- ensure absensi likes checks Ditbinmas content when roleFlag is provided
- cover roleFlag shortcodes in absensi likes tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f5b1ed408327aba29fbc03f862c0