### PR TITLE
Restrict Instagram likes to Ditbinmas

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -150,9 +150,9 @@ export async function absensiLikes(client_id, opts = {}) {
       `Jumlah Konten: ${totalKonten}\n` +
       `Daftar Link Konten:\n${kontenLinks.length ? kontenLinks.join("\n") : "-"}\n\n` +
       `Jumlah Total Personil : ${totals.total} pers\n` +
-      `Sudah melaksanakan : ${totals.sudah} pers\n` +
+      `✅ Sudah melaksanakan : ${totals.sudah} pers\n` +
       `Melaksanakan kurang lengkap : ${totals.kurang} pers\n` +
-      `Belum melaksanakan : ${totals.belum} pers\n` +
+      `❌ Belum melaksanakan : ${totals.belum} pers\n` +
       `Belum Update Username Instagram : ${totals.noUsername} pers\n\n` +
       reports.join("\n\n");
     return msg.trim();

--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -100,19 +100,20 @@ export async function getPostsTodayByClient(client_id) {
   return res.rows;
 }
 
-export async function getPostsByClientId(client_id) {
+export async function getPostsByClientId() {
+  const clientId = 'ditbinmas';
   const res = await query(
     `SELECT DISTINCT ON (shortcode) *
      FROM insta_post
      WHERE client_id = $1
      ORDER BY shortcode, created_at DESC`,
-    [client_id]
+    [clientId]
   );
   return res.rows;
 }
 
-export async function findByClientId(client_id) {
-  return getPostsByClientId(client_id);
+export async function findByClientId() {
+  return getPostsByClientId();
 }
 
 export async function countPostsByClient(client_id, periode = 'harian', tanggal, start_date, end_date) {

--- a/src/service/instaLikeService.js
+++ b/src/service/instaLikeService.js
@@ -1,5 +1,5 @@
 import * as instaLikeModel from '../model/instaLikeModel.js';
 
 export const findByShortcode = async (shortcode) => {
-  return await instaLikeModel.findByShortcode(shortcode);
+  return await instaLikeModel.getLikesByShortcode(shortcode);
 };

--- a/src/service/instaPostService.js
+++ b/src/service/instaPostService.js
@@ -1,5 +1,6 @@
 import * as instaPostModel from '../model/instaPostModel.js';
 
-export const findByClientId = async (client_id) => {
-  return await instaPostModel.findByClientId(client_id);
+export const findByClientId = async (_clientId) => {
+  const fixedClientId = 'ditbinmas';
+  return await instaPostModel.getPostsByClientId(fixedClientId);
 };

--- a/tests/instaPostModel.test.js
+++ b/tests/instaPostModel.test.js
@@ -20,7 +20,7 @@ test('findByClientId uses DISTINCT ON to avoid duplicates', async () => {
   await findByClientId('c1');
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('DISTINCT ON (shortcode)'),
-    ['c1']
+    ['ditbinmas']
   );
 });
 


### PR DESCRIPTION
## Summary
- fetch Instagram posts for likes attendance only from Ditbinmas client
- use existing model to retrieve likes by shortcode
- add status emojis to Ditbinmas likes report and update related test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b409a368248327b6b77956340aad94