### PR TITLE
Add Ditbinmas Instagram likes recap endpoint

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -40,3 +40,9 @@ client who has the role `ditbinmas`.
 When requesting data for a regular organization and the authenticated user role is
 not `operator`, only users having the same role as the requester are included in
 the response.
+
+## Ditbinmas Shortcut
+
+The `GET /likes/instagram` endpoint returns the same payload as above but
+always aggregates data for users with the `ditbinmas` role. It does not require
+`client_id` and ignores the authenticated user's role and client filters.

--- a/src/controller/likesController.js
+++ b/src/controller/likesController.js
@@ -1,0 +1,64 @@
+import { getRekapLikesByClient } from "../model/instaLikeModel.js";
+import { sendConsoleDebug } from "../middleware/debugHandler.js";
+
+export async function getDitbinmasLikes(req, res) {
+  const periode = req.query.periode || "harian";
+  const tanggal = req.query.tanggal;
+  const startDate = req.query.start_date || req.query.tanggal_mulai;
+  const endDate = req.query.end_date || req.query.tanggal_selesai;
+
+  try {
+    sendConsoleDebug({ tag: "LIKES", msg: `getDitbinmasLikes ${periode} ${tanggal || ''} ${startDate || ''} ${endDate || ''}` });
+    const { rows, totalKonten } = await getRekapLikesByClient(
+      "ditbinmas",
+      periode,
+      tanggal,
+      startDate,
+      endDate,
+      "ditbinmas"
+    );
+    const length = Array.isArray(rows) ? rows.length : 0;
+    const chartHeight = Math.max(length * 30, 300);
+
+    const threshold = Math.ceil(totalKonten * 0.5);
+    const sudahUsers = [];
+    const kurangUsers = [];
+    const belumUsers = [];
+    const noUsernameUsers = [];
+
+    rows.forEach((u) => {
+      if (u.exception === true) {
+        sudahUsers.push(u.username);
+      } else if (!u.username || u.username.trim() === "") {
+        noUsernameUsers.push(u.username);
+      } else if (u.jumlah_like >= threshold) {
+        sudahUsers.push(u.username);
+      } else if (u.jumlah_like > 0) {
+        kurangUsers.push(u.username);
+      } else {
+        belumUsers.push(u.username);
+      }
+    });
+
+    const belumUsersCount = belumUsers.length + noUsernameUsers.length;
+
+    res.json({
+      success: true,
+      data: rows,
+      chartHeight,
+      totalPosts: totalKonten,
+      sudahUsers,
+      kurangUsers,
+      belumUsers,
+      sudahUsersCount: sudahUsers.length,
+      kurangUsersCount: kurangUsers.length,
+      belumUsersCount,
+      noUsernameUsersCount: noUsernameUsers.length,
+      usersCount: length,
+    });
+  } catch (err) {
+    sendConsoleDebug({ tag: "LIKES", msg: `Error getDitbinmasLikes: ${err.message}` });
+    const code = err.statusCode || err.response?.status || 500;
+    res.status(code).json({ success: false, message: err.message });
+  }
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -17,6 +17,7 @@ import editorialEventRoutes from './editorialEventRoutes.js';
 import approvalRequestRoutes from './approvalRequestRoutes.js';
 import pressReleaseDetailRoutes from './pressReleaseDetailRoutes.js';
 import premiumRequestRoutes from './premiumRequestRoutes.js';
+import likesRoutes from './likesRoutes.js';
 
 const router = express.Router();
 
@@ -26,6 +27,7 @@ router.use('/auth', authRoutes);
 router.use("/dashboard", dashboardRoutes);
 router.use("/insta", instaRoutes);
 router.use("/tiktok", tiktokRoutes);
+router.use('/likes', likesRoutes);
 router.use('/quotes', quoteRoutes);
 router.use('/oauth', oauthRoutes);
 router.use('/metadata', metaRoutes);

--- a/src/routes/likesRoutes.js
+++ b/src/routes/likesRoutes.js
@@ -1,0 +1,8 @@
+// src/routes/likesRoutes.js
+import { Router } from "express";
+import { getDitbinmasLikes } from "../controller/likesController.js";
+
+const router = Router();
+router.get("/instagram", getDitbinmasLikes);
+
+export default router;

--- a/tests/ditbinmasLikesController.test.js
+++ b/tests/ditbinmasLikesController.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+
+const mockGetRekap = jest.fn();
+jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({
+  getRekapLikesByClient: mockGetRekap
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendConsoleDebug: jest.fn()
+}));
+
+let getDitbinmasLikes;
+beforeAll(async () => {
+  ({ getDitbinmasLikes } = await import('../src/controller/likesController.js'));
+});
+
+beforeEach(() => {
+  mockGetRekap.mockReset();
+});
+
+test('returns ditbinmas like summaries without client filter', async () => {
+  const rows = [
+    { username: 'alice', jumlah_like: 4 },
+    { username: 'bob', jumlah_like: 1 },
+    { username: 'charlie', jumlah_like: 0 },
+    { username: null, jumlah_like: 0 }
+  ];
+  mockGetRekap.mockResolvedValue({ rows, totalKonten: 4 });
+  const req = { query: {} };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getDitbinmasLikes(req, res);
+  expect(mockGetRekap).toHaveBeenCalledWith('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  expect(json).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sudahUsers: ['alice'],
+      kurangUsers: ['bob'],
+      belumUsers: ['charlie'],
+      sudahUsersCount: 1,
+      kurangUsersCount: 1,
+      belumUsersCount: 2,
+      noUsernameUsersCount: 1,
+      usersCount: 4
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add `/likes/instagram` API to return Instagram like recap for all users with the `ditbinmas` role
- document new shortcut endpoint for Ditbinmas likes
- cover Ditbinmas likes controller with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40eebafc483278a8b17f7f6bde051