### PR TITLE
feat: log instagram likes requests

### DIFF
--- a/src/routes/likesRoutes.js
+++ b/src/routes/likesRoutes.js
@@ -3,6 +3,12 @@ import { Router } from "express";
 import { getDitbinmasLikes } from "../controller/likesController.js";
 
 const router = Router();
-router.get("/instagram", getDitbinmasLikes);
+
+function logLikesRequest(req, res, next) {
+  console.log("\x1b[33m%s\x1b[0m", "GET /api/likes/instagram");
+  next();
+}
+
+router.get("/instagram", logLikesRequest, getDitbinmasLikes);
 
 export default router;

--- a/tests/likesRoutes.test.js
+++ b/tests/likesRoutes.test.js
@@ -31,6 +31,8 @@ test('GET /likes/instagram returns ditbinmas like summary', async () => {
   const app = express();
   app.use('/api/likes', likesRoutes);
 
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
   const res = await request(app).get('/api/likes/instagram');
 
   expect(res.status).toBe(200);
@@ -49,4 +51,7 @@ test('GET /likes/instagram returns ditbinmas like summary', async () => {
       success: true
     })
   );
+
+  expect(logSpy).toHaveBeenCalledWith('\x1b[33m%s\x1b[0m', 'GET /api/likes/instagram');
+  logSpy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- log incoming /api/likes/instagram requests in yellow for easier tracing
- test likes route logs access to console

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b413ad1f148327bec8828fc2842561