### PR TITLE
refactor: remove client type filter for ditbinmas likes

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -87,12 +87,6 @@ export async function getRekapLikesByClient(
   end_date,
   role
 ) {
-  const clientTypeRes = await query(
-    'SELECT client_type FROM clients WHERE client_id = $1',
-    [client_id]
-  );
-  const clientType = clientTypeRes.rows[0]?.client_type?.toLowerCase();
-
   const roleLower = role ? role.toLowerCase() : null;
   const params = [client_id];
   let tanggalFilter =
@@ -141,8 +135,8 @@ export async function getRekapLikesByClient(
   let postRoleJoinLikes = '';
   let postRoleJoinPosts = '';
   let postRoleFilter = '';
-  if (clientType === 'direktorat' || roleLower === 'ditbinmas') {
-    const roleIdx = params.push(roleLower || client_id);
+  if (roleLower === 'ditbinmas') {
+    const roleIdx = params.push(roleLower);
     postRoleJoinLikes = 'JOIN insta_post_roles pr ON pr.shortcode = l.shortcode';
     postRoleJoinPosts = 'JOIN insta_post_roles pr ON pr.shortcode = p.shortcode';
     postRoleFilter = `AND LOWER(pr.role_name) = LOWER($${roleIdx})`;


### PR DESCRIPTION
## Summary
- drop client_type lookup from getRekapLikesByClient
- limit ditbinmas likes aggregation to role-based filtering
- adjust unit tests for new behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41a621e548327a410f039b6a127c9