### PR TITLE
Filter Ditbinmas like recap by role instead of client type

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -88,7 +88,7 @@ export async function getRekapLikesByClient(
   role
 ) {
   const roleLower = role ? role.toLowerCase() : null;
-  const params = [client_id];
+  const params = roleLower === 'ditbinmas' ? [] : [client_id];
   let tanggalFilter =
     "p.created_at::date = (NOW() AT TIME ZONE 'Asia/Jakarta')::date";
   if (start_date && end_date) {
@@ -137,6 +137,7 @@ export async function getRekapLikesByClient(
   let postRoleFilter = '';
   if (roleLower === 'ditbinmas') {
     const roleIdx = params.push(roleLower);
+    postClientFilter = '1=1';
     postRoleJoinLikes = 'JOIN insta_post_roles pr ON pr.shortcode = l.shortcode';
     postRoleJoinPosts = 'JOIN insta_post_roles pr ON pr.shortcode = p.shortcode';
     postRoleFilter = `AND LOWER(pr.role_name) = LOWER($${roleIdx})`;

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -88,11 +88,11 @@ test('filters users by role when role is ditbinmas', async () => {
   expect(sql).toContain('user_roles ur');
   expect(sql).toContain('roles r');
   expect(sql).toContain('insta_post_roles pr');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
+  expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
+  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
+  expect(params).toEqual(['ditbinmas']);
 });
 
 test('filters users by role for non-ditbinmas role', async () => {


### PR DESCRIPTION
## Summary
- ignore client_id when fetching Instagram like recaps for Ditbinmas
- use role-based joins for posts and users tagged as Ditbinmas
- adjust unit tests for Ditbinmas-only aggregation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41c748af08327a2e3e109d44e801f