### PR TITLE
Limit Instagram likes query to Ditbinmas client

### DIFF
--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -88,11 +88,11 @@ test('filters users by role when role is ditbinmas', async () => {
   expect(sql).toContain('user_roles ur');
   expect(sql).toContain('roles r');
   expect(sql).toContain('insta_post_roles pr');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($1)');
-  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
-  expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas']);
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
+  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
 });
 
 test('filters users by role for non-ditbinmas role', async () => {


### PR DESCRIPTION
## Summary
- Always pass client_id when fetching Instagram like recap to keep results scoped
- Apply client and role filters for Ditbinmas role to avoid cross-client data
- Update tests for new parameter ordering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41ebf1840832793a0e454fe074b71