### PR TITLE
feat: simplify ditbinmas like recap

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -136,10 +136,8 @@ export async function getRekapLikesByClient(
   let postRoleJoinPosts = '';
   let postRoleFilter = '';
   if (roleLower === 'ditbinmas') {
+    params[0] = 'ditbinmas';
     const roleIdx = params.push(roleLower);
-    postRoleJoinLikes = 'JOIN insta_post_roles pr ON pr.shortcode = l.shortcode';
-    postRoleJoinPosts = 'JOIN insta_post_roles pr ON pr.shortcode = p.shortcode';
-    postRoleFilter = `AND LOWER(pr.role_name) = LOWER($${roleIdx})`;
     userWhere = `EXISTS (
       SELECT 1 FROM user_roles ur
       JOIN roles r ON ur.role_id = r.role_id

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -82,15 +82,14 @@ test('parses jumlah_like as integer', async () => {
 test('filters users by role when role is ditbinmas', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [] });
   mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
-  await getRekapLikesByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
+  await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditbinmas');
   const sql = mockQuery.mock.calls[0][0];
   const params = mockQuery.mock.calls[0][1];
   expect(sql).toContain('user_roles ur');
   expect(sql).toContain('roles r');
-  expect(sql).toContain('insta_post_roles pr');
   expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
   expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).not.toContain('insta_post_roles');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
   expect(params).toEqual(['ditbinmas', 'ditbinmas']);
 });


### PR DESCRIPTION
## Summary
- ensure ditbinmas like recap ignores user client and skips post role joins
- update tests for ditbinmas like recap

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42a7328108327a0cf6f65ed3b0059