### PR TITLE
Simplify role handling in getRekapLikesByClient

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -136,7 +136,8 @@ export async function getRekapLikesByClient(
   let postRoleJoinPosts = '';
   let postRoleFilter = '';
   if (roleLower === 'ditbinmas') {
-    params[0] = 'ditbinmas';
+    params[0] = 'DITBINMAS';
+    postClientFilter = '1=1';
     const roleIdx = params.push(roleLower);
     userWhere = `EXISTS (
       SELECT 1 FROM user_roles ur
@@ -149,16 +150,6 @@ export async function getRekapLikesByClient(
       GROUP BY username
     `;
     likeJoin = "lower(replace(trim(u.insta), '@', '')) = lc.username";
-  } else if (roleLower && roleLower !== 'operator') {
-    const roleIndex = params.push(roleLower);
-    postRoleJoinLikes = 'JOIN insta_post_roles pr ON pr.shortcode = l.shortcode';
-    postRoleJoinPosts = 'JOIN insta_post_roles pr ON pr.shortcode = p.shortcode';
-    postRoleFilter = `AND LOWER(pr.role_name) = LOWER($${roleIndex})`;
-    userWhere = `LOWER(u.client_id) = LOWER($1) AND EXISTS (
-      SELECT 1 FROM user_roles ur
-      JOIN roles r ON ur.role_id = r.role_id
-      WHERE ur.user_id = u.user_id AND LOWER(r.role_name) = LOWER($${roleIndex})
-    )`;
   }
 
   const { rows } = await query(`

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -88,23 +88,24 @@ test('filters users by role when role is ditbinmas', async () => {
   expect(sql).toContain('user_roles ur');
   expect(sql).toContain('roles r');
   expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(sql).toContain('1=1');
   expect(sql).not.toContain('insta_post_roles');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(params).toEqual(['ditbinmas', 'ditbinmas']);
+  expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
+  expect(params).toEqual(['DITBINMAS', 'ditbinmas']);
 });
 
-test('filters users by role for non-ditbinmas role', async () => {
+test('ignores non-ditbinmas roles', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [] });
   mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'ditintelkam');
   const sql = mockQuery.mock.calls[0][0];
   const params = mockQuery.mock.calls[0][1];
   expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
-  expect(sql).toContain('insta_post_roles pr');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
-  expect(sql).toContain('LOWER(pr.role_name) = LOWER($2)');
-  expect(params).toEqual(['c1', 'ditintelkam']);
+  expect(sql).not.toContain('user_roles');
+  expect(sql).not.toContain('insta_post_roles');
+  expect(sql).not.toContain('LOWER(r.role_name)');
+  expect(params).toEqual(['c1']);
 });
 
 test('skips role filter for operator role', async () => {
@@ -112,7 +113,9 @@ test('skips role filter for operator role', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
   await getRekapLikesByClient('c1', 'harian', undefined, undefined, undefined, 'operator');
   const sql = mockQuery.mock.calls[0][0];
+  const params = mockQuery.mock.calls[0][1];
   expect(sql).toContain('LOWER(u.client_id) = LOWER($1)');
   expect(sql).not.toContain('user_roles');
   expect(sql).not.toContain('insta_post_roles');
+  expect(params).toEqual(['c1']);
 });


### PR DESCRIPTION
## Summary
- Adjust `getRekapLikesByClient` so the `ditbinmas` role bypasses client filtering and uses `DITBINMAS` id
- Remove role-based joins for non-ditbinmas roles
- Update tests to reflect simplified role behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b42e2cf8688327850a7be1bcd82ba2