### PR TITLE
Handle string client_ids in Instagram likes rekap endpoint

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -36,7 +36,10 @@ export async function getInstaRekapLikes(req, res) {
   }
 
   if (req.user?.client_ids) {
-    const idsLower = req.user.client_ids.map((c) => c.toLowerCase());
+    const userClientIds = Array.isArray(req.user.client_ids)
+      ? req.user.client_ids
+      : [req.user.client_ids];
+    const idsLower = userClientIds.map((c) => c.toLowerCase());
     if (
       !idsLower.includes(client_id.toLowerCase()) &&
       roleLower !== client_id.toLowerCase()
@@ -48,7 +51,7 @@ export async function getInstaRekapLikes(req, res) {
   }
   if (
     req.user?.client_id &&
-    req.user.client_id !== client_id &&
+    req.user.client_id.toLowerCase() !== client_id.toLowerCase() &&
     roleLower !== client_id.toLowerCase()
   ) {
     return res

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -74,6 +74,20 @@ test('allows authorized client_id', async () => {
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
 });
 
+test('supports client_ids as string', async () => {
+  mockGetRekap.mockResolvedValue({ rows: [], totalKonten: 0 });
+  const req = {
+    query: { client_id: 'c1' },
+    user: { client_ids: 'c1' }
+  };
+  const json = jest.fn();
+  const res = { json, status: jest.fn().mockReturnThis() };
+  await getInstaRekapLikes(req, res);
+  expect(res.status).not.toHaveBeenCalledWith(403);
+  expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, undefined, undefined, undefined);
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+});
+
 test('returns user like summaries', async () => {
   const rows = [
     { username: 'alice', jumlah_like: 4 },


### PR DESCRIPTION
## Summary
- avoid crash when `client_ids` in token is a string
- ensure case-insensitive client id comparison
- test string `client_ids` path for getInstaRekapLikes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b43149228c832787bcce46f1d4330e