### PR TITLE
Fix parameter numbering for ditbinmas like recap query

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -136,7 +136,8 @@ export async function getRekapLikesByClient(
   let postRoleJoinPosts = '';
   let postRoleFilter = '';
   if (roleLower === 'ditbinmas') {
-    params[0] = 'ditbinmas';
+    params.shift();
+    tanggalFilter = tanggalFilter.replace(/\$(\d+)/g, (_, n) => `$${n - 1}`);
     postClientFilter = '1=1';
     const roleIdx = params.push(roleLower);
     userWhere = `EXISTS (

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -87,12 +87,12 @@ test('filters users by role when role is ditbinmas', async () => {
   const params = mockQuery.mock.calls[0][1];
   expect(sql).toContain('user_roles ur');
   expect(sql).toContain('roles r');
-  expect(sql).toContain('LOWER(r.role_name) = LOWER($2)');
+  expect(sql).toContain('LOWER(r.role_name) = LOWER($1)');
   expect(sql).toContain('1=1');
   expect(sql).not.toContain('insta_post_roles');
   expect(sql).not.toContain('LOWER(u.client_id) = LOWER($1)');
   expect(sql).not.toContain('LOWER(p.client_id) = LOWER($1)');
-  expect(params).toEqual(['DITBINMAS', 'ditbinmas']);
+  expect(params).toEqual(['ditbinmas']);
 });
 
 test('ignores non-ditbinmas roles', async () => {


### PR DESCRIPTION
## Summary
- fix missing `$1` placeholder in `getRekapLikesByClient` when role is `ditbinmas`
- update tests for new parameter ordering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b434c1136c832797aaec98ceb1485e