### PR TITLE
fix: remove extra role param from posts query for ditbinmas

### DIFF
--- a/src/model/instaLikeModel.js
+++ b/src/model/instaLikeModel.js
@@ -197,6 +197,8 @@ export async function getRekapLikesByClient(
     user.jumlah_like = parseInt(user.jumlah_like, 10);
   }
 
+  const postParams = roleLower === 'ditbinmas' ? params.slice(0, -1) : params;
+
   const { rows: postRows } = await query(
     `WITH posts AS (
       SELECT p.shortcode
@@ -207,7 +209,7 @@ export async function getRekapLikesByClient(
         AND ${tanggalFilter}
     )
     SELECT COUNT(DISTINCT shortcode) AS total_post FROM posts`,
-    params
+    postParams
   );
   const totalKonten = parseInt(postRows[0]?.total_post || '0', 10);
 

--- a/tests/instaLikeModel.test.js
+++ b/tests/instaLikeModel.test.js
@@ -95,6 +95,14 @@ test('filters users by role when role is ditbinmas', async () => {
   expect(params).toEqual(['ditbinmas']);
 });
 
+test('ditbinmas role passes only date to posts query', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });
+  await getRekapLikesByClient('c1', 'harian', '2023-10-05', undefined, undefined, 'ditbinmas');
+  const paramsSecond = mockQuery.mock.calls[1][1];
+  expect(paramsSecond).toEqual(['2023-10-05']);
+});
+
 test('ignores non-ditbinmas roles', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [] });
   mockQuery.mockResolvedValueOnce({ rows: [{ total_post: 0 }] });


### PR DESCRIPTION
## Summary
- avoid bind errors by excluding the role parameter from the posts count query in `getRekapLikesByClient`
- test that ditbinmas role only passes the date parameter to the posts query

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4369d97b88327bde3fd81e52ec197