### PR TITLE
fix: prevent user_id updates during user updates

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -519,6 +519,8 @@ export async function updateUser(userId, userData) {
       delete userData[rf];
     }
   }
+  // Prevent primary key updates
+  delete userData.user_id;
   const columns = Object.keys(userData);
   if (columns.length > 0) {
     const setClause = columns.map((c, i) => `${c}=$${i + 1}`).join(', ');


### PR DESCRIPTION
## Summary
- ensure updateUser strips out user_id to avoid foreign key constraint violations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4654f065483278ba2a498b9147450