### PR TITLE
feat: add user roles update endpoint

### DIFF
--- a/src/controller/userController.js
+++ b/src/controller/userController.js
@@ -115,6 +115,23 @@ export const updateUser = async (req, res, next) => {
   }
 };
 
+export const updateUserRoles = async (req, res, next) => {
+  try {
+    const roles = Array.isArray(req.body.roles)
+      ? req.body.roles.map((r) => r.toLowerCase())
+      : [];
+    const allowed = ['ditbinmas', 'ditlantas', 'bidhumas', 'operator'];
+    const data = {};
+    for (const r of allowed) {
+      data[r] = roles.includes(r);
+    }
+    const user = await userModel.updateUser(req.params.id, data);
+    sendSuccess(res, user);
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const deleteUser = async (req, res, next) => {
   try {
     const user = await userModel.deleteUser(req.params.id);

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -11,6 +11,7 @@ router.get('/list', userController.getUserList);
 router.get('/by-client/:client_id', userController.getUsersByClient);
 router.get('/by-client-full/:client_id', userController.getUsersByClientFull);
 router.post('/create', userController.createUser);
+router.put('/:id/roles', userController.updateUserRoles);
 router.get('/:id', userController.getUserById);
 router.post('/', userController.createUser);
 router.put('/:id', userController.updateUser);

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -24,12 +24,14 @@ jest.unstable_mockModule('../src/service/clientService.js', () => ({
 let createUser;
 let getUserList;
 let getUsersByClientCtrl;
+let updateUserRolesCtrl;
 
 beforeAll(async () => {
   const mod = await import('../src/controller/userController.js');
   createUser = mod.createUser;
   getUserList = mod.getUserList;
   getUsersByClientCtrl = mod.getUsersByClient;
+  updateUserRolesCtrl = mod.updateUserRoles;
 });
 
 beforeEach(() => {
@@ -167,6 +169,40 @@ test('operator reactivates existing user with multiple roles', async () => {
       ditbinmas: true,
       nama: 'E'
     }
+  });
+});
+
+test('updateUserRoles updates roles based on array', async () => {
+  mockUpdateUser.mockResolvedValue({
+    user_id: '1',
+    operator: true,
+    ditbinmas: true,
+    ditlantas: false,
+    bidhumas: false,
+  });
+  const req = { params: { id: '1' }, body: { roles: ['operator', 'ditbinmas'] } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { status, json };
+
+  await updateUserRolesCtrl(req, res, () => {});
+
+  expect(mockUpdateUser).toHaveBeenCalledWith('1', {
+    operator: true,
+    ditbinmas: true,
+    ditlantas: false,
+    bidhumas: false,
+  });
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({
+    success: true,
+    data: {
+      user_id: '1',
+      operator: true,
+      ditbinmas: true,
+      ditlantas: false,
+      bidhumas: false,
+    },
   });
 });
 


### PR DESCRIPTION
## Summary
- add route to update roles for a user
- implement controller to normalize roles array and update user record
- cover role update with controller test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4685296448327b3f3d0bc1be09e8a