### PR TITLE
fix: handle missing getNumberId when sending WA files

### DIFF
--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -111,8 +111,10 @@ export async function createBaileysClient() {
   };
 
   emitter.disconnect = async () => sock.end();
-  emitter.sendMessage = (jid, message, options = {}) =>
-    sock.sendMessage(jid, { text: message }, options);
+  emitter.sendMessage = (jid, message, options = {}) => {
+    const content = typeof message === 'string' ? { text: message } : message;
+    return sock.sendMessage(jid, content, options);
+  };
   emitter.onMessage = (handler) => emitter.on('message', handler);
   emitter.onDisconnect = (handler) => emitter.on('disconnected', handler);
   emitter.isReady = async () => Boolean(sock.authState?.creds?.me);


### PR DESCRIPTION
## Summary
- support Baileys clients by falling back to `onWhatsApp` when `getNumberId` is unavailable
- allow Baileys adapter to send non-text messages
- cover sendWAFile Baileys path with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47756967c8327841020c9e70e1419