### PR TITLE
fix: auto-detect WA file MIME types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "googleapis": "^131.0.0",
         "jsonwebtoken": "^9.0.0",
         "md-to-pdf": "^5.2.4",
+        "mime-types": "^2.1.35",
         "morgan": "^1.10.0",
         "node-cron": "^3.0.2",
         "node-fetch": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"**/*.js\""
   },
   "dependencies": {
+    "@whiskeysockets/baileys": "^6.7.19",
     "amqplib": "^0.10.8",
     "axios": "^1.6.0",
     "bcrypt": "^5.1.0",
@@ -27,6 +28,7 @@
     "googleapis": "^131.0.0",
     "jsonwebtoken": "^9.0.0",
     "md-to-pdf": "^5.2.4",
+    "mime-types": "^2.1.35",
     "morgan": "^1.10.0",
     "node-cron": "^3.0.2",
     "node-fetch": "^3.3.2",
@@ -36,7 +38,6 @@
     "redis": "^4.6.7",
     "sequelize": "^6.32.1",
     "whatsapp-web.js": "^1.31.0",
-    "@whiskeysockets/baileys": "^6.7.19",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- infer WhatsApp attachment types from filenames to avoid `Invalid media type`
- add `mime-types` dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47a5ee8288327ae4bc0c5ddedd604