### PR TITLE
Fix XLS media type handling for WhatsApp attachments

### DIFF
--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -2,11 +2,16 @@
 import dotenv from 'dotenv';
 import pkg from 'whatsapp-web.js';
 import mime from 'mime-types';
+import path from 'path';
 const { MessageMedia } = pkg;
 dotenv.config();
 
-const defaultMimeType =
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+const spreadsheetMimeTypes = {
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+const defaultMimeType = spreadsheetMimeTypes['.xlsx'];
 
 export function getAdminWhatsAppList() {
   return (process.env.ADMIN_WHATSAPP || '')
@@ -49,8 +54,9 @@ export async function sendWAFile(
       ? chatIds
       : [chatIds]
     : getAdminWhatsAppList();
+  const ext = path.extname(filename).toLowerCase();
   const resolvedMimeType =
-    mimeType || mime.lookup(filename) || defaultMimeType;
+    mimeType || spreadsheetMimeTypes[ext] || mime.lookup(filename) || defaultMimeType;
   const base64 = buffer.toString('base64');
   const media = new MessageMedia(resolvedMimeType, base64, filename);
   for (const target of targets) {

--- a/tests/waHelper.test.js
+++ b/tests/waHelper.test.js
@@ -46,3 +46,14 @@ test('sendWAFile falls back to onWhatsApp when getNumberId missing', async () =>
     fileName: 'file.txt',
   });
 });
+
+test('sendWAFile uses Excel mime when sending .xls file', async () => {
+  const waClient = {
+    getNumberId: jest.fn().mockResolvedValue({ _serialized: '123@c.us' }),
+    sendMessage: jest.fn().mockResolvedValue(),
+  };
+  const buffer = Buffer.from('excel');
+  await sendWAFile(waClient, buffer, 'report.xls', '123@c.us');
+  const [, media] = waClient.sendMessage.mock.calls[0];
+  expect(media.mimetype).toBe('application/vnd.ms-excel');
+});


### PR DESCRIPTION
## Summary
- map `.xls` to the correct Excel MIME type when sending WhatsApp files
- test `sendWAFile` to ensure `.xls` uses `application/vnd.ms-excel`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47c3c378c8327969f62c1316d1fcc