### PR TITLE
feat: add ditbinmas rekap user data cron

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ const cronModules = [
   './src/cron/cronPremiumRequest.js',
   './src/cron/cronAbsensiUserData.js',
   './src/cron/cronAbsensiOprDitbinmas.js',
+  './src/cron/cronRekapUserDataDitbinmas.js',
   './src/cron/cronDirRequest.js',
   './src/cron/cronDirRequestFetchInsta.js',
   './src/cron/cronDbBackup.js',

--- a/src/cron/cronRekapUserDataDitbinmas.js
+++ b/src/cron/cronRekapUserDataDitbinmas.js
@@ -1,0 +1,26 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import waClient from "../service/waService.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+import { formatRekapUserData } from "../handler/menu/dirRequestHandlers.js";
+
+const cronTag = "CRON DIRREQUEST DITBINMAS";
+
+export async function runCron() {
+  sendDebug({ tag: cronTag, msg: "Mulai rekap user belum lengkapi data Ditbinmas" });
+  try {
+    const msg = await formatRekapUserData("ditbinmas", "ditbinmas");
+    await waClient
+      .sendMessage("120363419830216549@g.us", msg)
+      .catch(() => {});
+    sendDebug({ tag: cronTag, msg: "Rekap dikirim ke grup Ditbinmas" });
+  } catch (err) {
+    sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message}` });
+  }
+}
+
+cron.schedule("0 6-21 * * *", runCron, { timezone: "Asia/Jakarta" });
+
+export default null;

--- a/tests/cronRekapUserDataDitbinmas.test.js
+++ b/tests/cronRekapUserDataDitbinmas.test.js
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+
+const mockFormatRekapUserData = jest.fn().mockResolvedValue('msg');
+const mockSendMessage = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/handler/menu/dirRequestHandlers.js', () => ({
+  formatRekapUserData: mockFormatRekapUserData,
+}));
+jest.unstable_mockModule('../src/service/waService.js', () => ({
+  default: { sendMessage: mockSendMessage },
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let runCron;
+
+beforeAll(async () => {
+  ({ runCron } = await import('../src/cron/cronRekapUserDataDitbinmas.js'));
+});
+
+test('runCron sends rekap to Ditbinmas group', async () => {
+  await runCron();
+  expect(mockFormatRekapUserData).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
+  expect(mockSendMessage).toHaveBeenCalledWith('120363419830216549@g.us', 'msg');
+});


### PR DESCRIPTION
## Summary
- add hourly cron job to recap Ditbinmas user data completeness and send to WA group
- enable cron on app startup and test behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54726e3008327a203a7aed145c71e