### PR TITLE
feat: add Ditbinmas likes absensi cron

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ const cronModules = [
   './src/cron/cronAbsensiOprDitbinmas.js',
   './src/cron/cronRekapUserDataDitbinmas.js',
   './src/cron/cronDirRequest.js',
+  './src/cron/cronDirRequestAbsensiLikes.js',
   './src/cron/cronDirRequestFetchInsta.js',
   './src/cron/cronDbBackup.js',
 ];

--- a/src/cron/cronDirRequestAbsensiLikes.js
+++ b/src/cron/cronDirRequestAbsensiLikes.js
@@ -1,0 +1,40 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import { fetchAndStoreInstaContent } from "../handler/fetchpost/instaFetchPost.js";
+import { handleFetchLikesInstagram } from "../handler/fetchengagement/fetchLikesInstagram.js";
+import { absensiLikes } from "../handler/fetchabsensi/insta/absensiLikesInsta.js";
+import { getShortcodesTodayByClient } from "../model/instaPostModel.js";
+import waClient from "../service/waService.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+
+const groupId = "120363419830216549@g.us";
+const cronTag = "CRON DIRREQUEST ABSENSI LIKES";
+
+cron.schedule(
+  "0 10,15,18,20 * * *",
+  async () => {
+    sendDebug({ tag: cronTag, msg: "Mulai fetch & absensi IG DITBINMAS" });
+    try {
+      const keys = ["shortcode", "caption", "like_count", "timestamp"];
+      await fetchAndStoreInstaContent(keys, null, null, "DITBINMAS");
+      const shortcodes = await getShortcodesTodayByClient("DITBINMAS");
+      if (shortcodes.length === 0) {
+        sendDebug({ tag: cronTag, msg: "Tidak ada tugas IG hari ini" });
+        return;
+      }
+      await handleFetchLikesInstagram(null, null, "DITBINMAS");
+      const msg = await absensiLikes("DITBINMAS", { mode: "all", roleFlag: "ditbinmas" });
+      if (msg) {
+        await waClient.sendMessage(groupId, msg).catch(() => {});
+        sendDebug({ tag: cronTag, msg: "Laporan absensi IG dikirim" });
+      }
+    } catch (err) {
+      sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
+    }
+  },
+  { timezone: "Asia/Jakarta" }
+);
+
+export default null;


### PR DESCRIPTION
## Summary
- add cron job for DITBINMAS to fetch Instagram posts, collect likes, and send absensi reports to group
- register the new cron module in app startup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54d5c47c483278f6373422ed974d8