### PR TITLE
Use client ID parameter for Insta post retrieval

### DIFF
--- a/src/model/instaPostModel.js
+++ b/src/model/instaPostModel.js
@@ -100,8 +100,7 @@ export async function getPostsTodayByClient(client_id) {
   return res.rows;
 }
 
-export async function getPostsByClientId() {
-  const clientId = 'ditbinmas';
+export async function getPostsByClientId(clientId) {
   const res = await query(
     `SELECT DISTINCT ON (shortcode) *
      FROM insta_post
@@ -112,8 +111,8 @@ export async function getPostsByClientId() {
   return res.rows;
 }
 
-export async function findByClientId() {
-  return getPostsByClientId();
+export async function findByClientId(clientId) {
+  return getPostsByClientId(clientId);
 }
 
 export async function countPostsByClient(client_id, periode = 'harian', tanggal, start_date, end_date) {

--- a/src/service/instaPostService.js
+++ b/src/service/instaPostService.js
@@ -1,6 +1,5 @@
 import * as instaPostModel from '../model/instaPostModel.js';
 
-export const findByClientId = async (_clientId) => {
-  const fixedClientId = 'ditbinmas';
-  return await instaPostModel.getPostsByClientId(fixedClientId);
+export const findByClientId = async (clientId) => {
+  return await instaPostModel.getPostsByClientId(clientId);
 };

--- a/tests/instaPostModel.test.js
+++ b/tests/instaPostModel.test.js
@@ -20,7 +20,7 @@ test('findByClientId uses DISTINCT ON to avoid duplicates', async () => {
   await findByClientId('c1');
   expect(mockQuery).toHaveBeenCalledWith(
     expect.stringContaining('DISTINCT ON (shortcode)'),
-    ['ditbinmas']
+    ['c1']
   );
 });
 


### PR DESCRIPTION
## Summary
- Use provided clientId to look up Instagram posts instead of fixed "ditbinmas" value
- Allow `instaPostModel.getPostsByClientId` to accept a clientId argument
- Update tests for new clientId handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5612bd404832793b38511b5448c91