### PR TITLE
Include assignee in editorial events query

### DIFF
--- a/docs/penmas_api_design.md
+++ b/docs/penmas_api_design.md
@@ -88,7 +88,7 @@ CREATE TABLE change_log (
 - `POST /api/auth/penmas-register` – body: `{ username, password, role }` → returns `{ success, user_id }`.
 
 ### Editorial Calendar
-- `GET /api/events` – list all events for the authenticated user.
+- `GET /api/events` – list events created by or assigned to the authenticated user.
 - `POST /api/events` – create a new event.
 - `PUT /api/events/:id` – update an event.
 - `DELETE /api/events/:id` – remove an event.

--- a/src/model/editorialEventModel.js
+++ b/src/model/editorialEventModel.js
@@ -6,7 +6,7 @@ export async function getEvents(userId) {
     `SELECT e.*, u.username AS updated_by_username
      FROM editorial_event e
      LEFT JOIN penmas_user u ON u.user_id = e.updated_by
-     WHERE e.created_by = $1
+     WHERE e.created_by = $1 OR e.assignee = $1
      ORDER BY e.event_date ASC`,
     [userId]
   );

--- a/tests/editorialEventModel.test.js
+++ b/tests/editorialEventModel.test.js
@@ -25,3 +25,12 @@ test('getEvents joins with penmas_user for username', async () => {
     ['u1']
   );
 });
+
+test('getEvents filters by creator or assignee', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getEvents('u2');
+  expect(mockQuery).toHaveBeenCalledWith(
+    expect.stringContaining('WHERE e.created_by = $1 OR e.assignee = $1'),
+    ['u2']
+  );
+});


### PR DESCRIPTION
## Summary
- Expand editorial events retrieval to include events assigned to the user
- Document that `/api/events` returns both created and assigned events
- Add unit test covering assignee-based event access

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b562137a7c832794aca2a7af756372