### PR TITLE
feat: support date range in insta khusus posts

### DIFF
--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -437,8 +437,23 @@ export async function getInstagramUser(req, res) {
           .status(403)
           .json({ success: false, message: "client_id tidak diizinkan" });
       }
-      sendConsoleDebug({ tag: "INSTA", msg: `getInstaPostsKhusus ${client_id}` });
-      const posts = await instaPostKhususService.findTodayByClientId(client_id);
+      const days = req.query.days ? parseInt(req.query.days) : undefined;
+      const startDate = req.query.start_date;
+      const endDate = req.query.end_date;
+
+      sendConsoleDebug({
+        tag: "INSTA",
+        msg: `getInstaPostsKhusus ${client_id} ${days || ''} ${startDate || ''} ${endDate || ''}`,
+      });
+
+      let posts = await instaPostKhususService.findTodayByClientId(client_id);
+      if (posts.length === 0 && (days || startDate || endDate)) {
+        posts = await instaPostKhususService.findByClientIdRange(client_id, {
+          days,
+          startDate,
+          endDate,
+        });
+      }
       sendSuccess(res, posts);
     } catch (err) {
     sendConsoleDebug({

--- a/src/model/instaPostKhususModel.js
+++ b/src/model/instaPostKhususModel.js
@@ -90,3 +90,31 @@ export async function getPostsByClientId(client_id) {
 export async function findByClientId(client_id) {
   return getPostsByClientId(client_id);
 }
+
+export async function getPostsByClientAndDateRange(
+  client_id,
+  { days, startDate, endDate } = {}
+) {
+  let text =
+    'SELECT * FROM insta_post_khusus WHERE client_id = $1';
+  const values = [client_id];
+
+  if (days) {
+    const safeDays = parseInt(days);
+    text += ` AND created_at >= NOW() - INTERVAL '${safeDays} days'`;
+  } else {
+    if (startDate) {
+      values.push(startDate);
+      text += ` AND created_at::date >= $${values.length}`;
+    }
+    if (endDate) {
+      values.push(endDate);
+      text += ` AND created_at::date <= $${values.length}`;
+    }
+  }
+
+  text += ' ORDER BY created_at DESC';
+
+  const res = await query(text, values);
+  return res.rows;
+}

--- a/src/service/instaPostKhususService.js
+++ b/src/service/instaPostKhususService.js
@@ -7,3 +7,14 @@ export const findByClientId = async (client_id) => {
 export const findTodayByClientId = async (client_id) => {
   return await instaPostKhususModel.getPostsTodayByClient(client_id);
 };
+
+export const findByClientIdRange = async (
+  client_id,
+  { days, startDate, endDate } = {}
+) => {
+  return await instaPostKhususModel.getPostsByClientAndDateRange(client_id, {
+    days,
+    startDate,
+    endDate,
+  });
+};

--- a/tests/instaControllerKhususRange.test.js
+++ b/tests/instaControllerKhususRange.test.js
@@ -1,0 +1,89 @@
+import { jest } from '@jest/globals';
+
+const mockFindToday = jest.fn();
+const mockFindRange = jest.fn();
+jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({
+  getRekapLikesByClient: jest.fn(),
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendConsoleDebug: jest.fn(),
+}));
+jest.unstable_mockModule('../src/service/instaPostService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaPostKhususService.js', () => ({
+  findTodayByClientId: mockFindToday,
+  findByClientIdRange: mockFindRange,
+}));
+jest.unstable_mockModule('../src/service/instagramApi.js', () => ({
+  fetchInstagramPosts: jest.fn(),
+  fetchInstagramProfile: jest.fn(),
+  fetchInstagramInfo: jest.fn(),
+  fetchInstagramPostsByMonthToken: jest.fn(),
+}));
+jest.unstable_mockModule('../src/service/instaProfileService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instagramUserService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaPostCacheService.js', () => ({}));
+jest.unstable_mockModule('../src/service/profileCacheService.js', () => ({}));
+
+const mockSendSuccess = jest.fn();
+jest.unstable_mockModule('../src/utils/response.js', () => ({
+  sendSuccess: mockSendSuccess,
+}));
+
+let getInstaPostsKhusus;
+beforeAll(async () => {
+  ({ getInstaPostsKhusus } = await import('../src/controller/instaController.js'));
+});
+
+beforeEach(() => {
+  mockFindToday.mockReset();
+  mockFindRange.mockReset();
+  mockSendSuccess.mockReset();
+});
+
+test('returns today\'s posts when available', async () => {
+  const posts = [{ id: 1 }];
+  mockFindToday.mockResolvedValue(posts);
+  const req = { query: { client_id: 'c1' } };
+  const res = {};
+  await getInstaPostsKhusus(req, res);
+  expect(mockFindToday).toHaveBeenCalledWith('c1');
+  expect(mockFindRange).not.toHaveBeenCalled();
+  expect(mockSendSuccess).toHaveBeenCalledWith(res, posts);
+});
+
+test('falls back to range when today empty and days provided', async () => {
+  mockFindToday.mockResolvedValue([]);
+  const rangePosts = [{ id: 2 }];
+  mockFindRange.mockResolvedValue(rangePosts);
+  const req = { query: { client_id: 'c1', days: '7' } };
+  const res = {};
+  await getInstaPostsKhusus(req, res);
+  expect(mockFindToday).toHaveBeenCalledWith('c1');
+  expect(mockFindRange).toHaveBeenCalledWith('c1', {
+    days: 7,
+    startDate: undefined,
+    endDate: undefined,
+  });
+  expect(mockSendSuccess).toHaveBeenCalledWith(res, rangePosts);
+});
+
+test('falls back to range when today empty and start/end provided', async () => {
+  mockFindToday.mockResolvedValue([]);
+  const rangePosts = [{ id: 3 }];
+  mockFindRange.mockResolvedValue(rangePosts);
+  const req = {
+    query: {
+      client_id: 'c1',
+      start_date: '2024-01-01',
+      end_date: '2024-01-10',
+    },
+  };
+  const res = {};
+  await getInstaPostsKhusus(req, res);
+  expect(mockFindRange).toHaveBeenCalledWith('c1', {
+    days: undefined,
+    startDate: '2024-01-01',
+    endDate: '2024-01-10',
+  });
+  expect(mockSendSuccess).toHaveBeenCalledWith(res, rangePosts);
+});

--- a/tests/instaPostKhususModel.test.js
+++ b/tests/instaPostKhususModel.test.js
@@ -2,12 +2,16 @@ import { jest } from '@jest/globals';
 
 const mockQuery = jest.fn();
 jest.unstable_mockModule('../src/repository/db.js', () => ({
-  query: mockQuery
+  query: mockQuery,
 }));
 
 let findByClientId;
+let getPostsByClientAndDateRange;
 beforeAll(async () => {
-  ({ findByClientId } = await import('../src/model/instaPostKhususModel.js'));
+  ({
+    findByClientId,
+    getPostsByClientAndDateRange,
+  } = await import('../src/model/instaPostKhususModel.js'));
 });
 
 beforeEach(() => {
@@ -21,4 +25,28 @@ test('findByClientId uses DISTINCT ON to avoid duplicates', async () => {
     expect.stringContaining('DISTINCT ON (shortcode)'),
     ['c1']
   );
+});
+
+test('getPostsByClientAndDateRange supports days option', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getPostsByClientAndDateRange('c1', { days: 7 });
+  const sql = mockQuery.mock.calls[0][0];
+  expect(sql).toContain("created_at >= NOW() - INTERVAL '7 days'");
+  expect(mockQuery.mock.calls[0][1]).toEqual(['c1']);
+});
+
+test('getPostsByClientAndDateRange supports start and end dates', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await getPostsByClientAndDateRange('c1', {
+    startDate: '2024-01-01',
+    endDate: '2024-01-31',
+  });
+  const sql = mockQuery.mock.calls[0][0];
+  expect(sql).toContain('created_at::date >= $2');
+  expect(sql).toContain('created_at::date <= $3');
+  expect(mockQuery.mock.calls[0][1]).toEqual([
+    'c1',
+    '2024-01-01',
+    '2024-01-31',
+  ]);
 });


### PR DESCRIPTION
## Summary
- allow getInstaPostsKhusus to fetch by days or date range when today has no posts
- add service and model helpers for date-ranged insta_khusus queries
- cover today vs range behaviors with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57c1932508327ab3e08fe7ff26428