### PR TITLE
feat: accept s.whatsapp.net ids when sending files

### DIFF
--- a/docs/waFileSendingBestPractices.md
+++ b/docs/waFileSendingBestPractices.md
@@ -1,0 +1,32 @@
+# Best Practices for Sending Files via WhatsApp Bot
+
+Pengiriman file melalui bot WhatsApp memerlukan beberapa langkah agar aman dan dapat diandalkan. Ikuti panduan berikut saat mengirim dokumen melalui helper `sendWAFile`:
+
+1. **Normalisasi Nomor**  
+   Gunakan `formatToWhatsAppId` untuk mengubah nomor menjadi ID WhatsApp yang valid. Fungsi ini memastikan awalan `62` dan menambahkan suffix `@c.us`.
+
+2. **Validasi WID**  
+   Sebelum mengirim, pastikan WID menggunakan salah satu suffix yang didukung (`@c.us`, `@s.whatsapp.net`, atau `@g.us`) dengan fungsi `isValidWid`.
+
+3. **Verifikasi Kontak**  
+   Jika `waClient` menyediakan fungsi `onWhatsApp`, panggil fungsi ini untuk memastikan nomor terdaftar sebelum mengirim file. Lewati proses pengiriman jika kontak tidak ada.
+
+4. **Tentukan MIME Type**  
+   Tentukan MIME type secara eksplisit atau biarkan helper mendeteksinya menggunakan `mime-types`. Ini membantu WhatsApp menampilkan file dengan benar.
+
+5. **Tangani Error**  
+   Bungkus proses pengiriman dalam blok `try/catch` dan log error untuk memudahkan debugging jika pengiriman gagal.
+
+6. **Batasi Ukuran File**  
+   Hindari mengirim file yang terlalu besar agar tidak menghabiskan memori. Pertimbangkan untuk mengompres atau membagi file bila perlu.
+
+Contoh penggunaan sederhana:
+
+```javascript
+import { sendWAFile, formatToWhatsAppId } from '../src/utils/waHelper.js';
+
+const target = formatToWhatsAppId('08123456789');
+await sendWAFile(waClient, Buffer.from('isi'), 'laporan.txt', target, 'text/plain');
+```
+
+Dengan mengikuti langkah-langkah di atas, pengiriman file melalui bot WhatsApp akan lebih stabil dan terhindar dari error seperti `Invalid wid`.

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -11,6 +11,15 @@ const spreadsheetMimeTypes = {
 
 const defaultMimeType = spreadsheetMimeTypes['.xlsx'];
 
+const validWaSuffixes = ['@c.us', '@s.whatsapp.net', '@g.us'];
+
+export function isValidWid(wid) {
+  return (
+    typeof wid === 'string' &&
+    validWaSuffixes.some(suffix => wid.endsWith(suffix))
+  );
+}
+
 export function getAdminWhatsAppList() {
   return (process.env.ADMIN_WHATSAPP || '')
     .split(',')
@@ -25,7 +34,7 @@ export async function sendWAReport(waClient, message, chatIds = null) {
     ? (Array.isArray(chatIds) ? chatIds : [chatIds])
     : getAdminWhatsAppList();
   for (const target of targets) {
-    if (!target || !target.endsWith('@c.us')) {
+    if (!isValidWid(target)) {
       console.warn(`[SKIP WA] Invalid wid: ${target}`);
       continue;
     }
@@ -56,7 +65,7 @@ export async function sendWAFile(
   const resolvedMimeType =
     mimeType || spreadsheetMimeTypes[ext] || mime.lookup(filename) || defaultMimeType;
   for (const target of targets) {
-    if (!target || !target.endsWith('@c.us')) {
+    if (!isValidWid(target)) {
       console.warn(`[SKIP WA] Invalid wid: ${target}`);
       continue;
     }

--- a/tests/waHelper.test.js
+++ b/tests/waHelper.test.js
@@ -60,3 +60,18 @@ test('sendWAFile uses Excel mime when sending .xls file', async () => {
     fileName: 'report.xls',
   });
 });
+
+test('sendWAFile accepts s.whatsapp.net wid', async () => {
+  const waClient = {
+    onWhatsApp: jest.fn().mockResolvedValue([{ jid: '123@s.whatsapp.net', exists: true }]),
+    sendMessage: jest.fn().mockResolvedValue(),
+  };
+  const buffer = Buffer.from('hello');
+  await sendWAFile(waClient, buffer, 'file.txt', '123@s.whatsapp.net', 'text/plain');
+  expect(waClient.onWhatsApp).toHaveBeenCalledWith('123@s.whatsapp.net');
+  expect(waClient.sendMessage).toHaveBeenCalledWith('123@s.whatsapp.net', {
+    document: buffer,
+    mimetype: 'text/plain',
+    fileName: 'file.txt',
+  });
+});


### PR DESCRIPTION
## Summary
- allow WhatsApp helper to send files to `@s.whatsapp.net` ids via new `isValidWid`
- test sending files to `s.whatsapp.net` addresses
- document best practices for WA file sending

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58864a5d88327a4c4961c7d78b817