### PR TITLE
feat: expand dirrequest laphar format

### DIFF
--- a/tests/lapharDitbinmas.test.js
+++ b/tests/lapharDitbinmas.test.js
@@ -59,4 +59,7 @@ test('orders clients by likes with ditbinmas first and returns narrative', async
   expect(idxDit).toBeLessThan(idxA);
   expect(idxA).toBeLessThan(idxB);
   expect(result.narrative).toMatch(/POLRES A 1/);
+  expect(result.narrative).toMatch(/Kontributor likes terbesar/);
+  expect(result.narrative).toMatch(/Anomali/);
+  expect(result.narrative).toMatch(/nihil/);
 });


### PR DESCRIPTION
## Summary
- enrich dirrequest laphar generation with per-client update stats and anomaly detection
- extend laphar narrative with contributor, segmentation, and anomaly sections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a9e17f708327ada0d01e2e7a1448