### PR TITLE
feat: add refreshable Baileys auth state

### DIFF
--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -9,8 +9,15 @@ function ensureDir(dir) {
   }
 }
 
-export async function createBaileysClient() {
+function clearDir(dir) {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export async function createBaileysClient({ refreshAuth = false } = {}) {
   const sessionsDir = path.join('sessions', 'baileys');
+  if (refreshAuth) clearDir(sessionsDir);
   ensureDir(sessionsDir);
   const { state, saveCreds } = await useMultiFileAuthState(sessionsDir);
 
@@ -90,8 +97,14 @@ export async function createBaileysClient() {
   return emitter;
 }
 
-export async function requestPairingCode(phoneNumber) {
+export function refreshAuthState() {
   const sessionsDir = path.join('sessions', 'baileys');
+  clearDir(sessionsDir);
+}
+
+export async function requestPairingCode(phoneNumber, { refreshAuth = false } = {}) {
+  const sessionsDir = path.join('sessions', 'baileys');
+  if (refreshAuth) clearDir(sessionsDir);
   ensureDir(sessionsDir);
   const { state, saveCreds } = await useMultiFileAuthState(sessionsDir);
 

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -7,7 +7,7 @@ import { query } from "../db/index.js";
 const pool = { query };
 
 // Adapter creators for WhatsApp clients
-import { createBaileysClient } from "./waAdapter.js";
+import { createBaileysClient, refreshAuthState } from "./waAdapter.js";
 
 // Service & Utility Imports
 import * as clientService from "./clientService.js";
@@ -119,7 +119,11 @@ function formatUserSummary(user) {
 // =======================
 
 // Inisialisasi WhatsApp client melalui Baileys
-export let waClient = await createBaileysClient();
+const refreshAuth = process.env.WA_REFRESH_AUTH === "true";
+if (refreshAuth) {
+  refreshAuthState();
+}
+export let waClient = await createBaileysClient({ refreshAuth });
 
 async function reconnectBaileys() {
   console.log("[WA] Reconnecting to Baileys client");


### PR DESCRIPTION
## Summary
- allow clearing Baileys session data via `refreshAuthState`
- support `refreshAuth` option in Baileys client and pairing code helpers
- add `WA_REFRESH_AUTH` env flag to wipe old credentials on startup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd521e30832797cc4e256c4cb0a8