### PR TITLE
Handle unsupported WhatsApp versions in user menu

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -87,6 +87,7 @@ import {
   formatClientData,
   safeSendMessage,
   getAdminWAIds,
+  isUnsupportedVersionError,
 } from "../utils/waHelper.js";
 import {
   IG_PROFILE_REGEX,
@@ -654,14 +655,26 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
   if (text.toLowerCase() === "userrequest") {
     userMenuContext[chatId] = {};
     setMenuTimeout(chatId, waClient);
-    await userMenuHandlers.main(
-      userMenuContext[chatId],
-      chatId,
-      "",
-      waClient,
-      pool,
-      userModel
-    );
+    try {
+      await userMenuHandlers.main(
+        userMenuContext[chatId],
+        chatId,
+        "",
+        waClient,
+        pool,
+        userModel
+      );
+    } catch (err) {
+      if (isUnsupportedVersionError(err)) {
+        await safeSendMessage(
+          waClient,
+          chatId,
+          "Versi WhatsApp Anda tidak mendukung menu ini. Silakan update aplikasi melalui Play Store:\nhttps://play.google.com/store/apps/details?id=com.whatsapp"
+        );
+      } else {
+        console.error(`[WA] userrequest menu error: ${err.message}`);
+      }
+    }
     return;
   }
 

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -223,3 +223,15 @@ export async function safeSendMessage(waClient, chatId, message, options = {}) {
     console.error(`[WA] Failed to send message to ${chatId}:`, err.message);
   }
 }
+
+export function isUnsupportedVersionError(err) {
+  const msg = (err?.message || '').toLowerCase();
+  if (!msg) return false;
+  return (
+    msg.includes('update whatsapp') ||
+    msg.includes('upgrade whatsapp') ||
+    (msg.includes('update') && msg.includes('whatsapp')) ||
+    msg.includes('unsupported version') ||
+    msg.includes('versi whatsapp anda terlalu lama')
+  );
+}

--- a/tests/waHelper.test.js
+++ b/tests/waHelper.test.js
@@ -4,9 +4,10 @@ import { EventEmitter } from 'events';
 let safeSendMessage;
 let isAdminWhatsApp;
 let sendWAFile;
+let isUnsupportedVersionError;
 
 beforeAll(async () => {
-  ({ safeSendMessage, isAdminWhatsApp, sendWAFile } = await import('../src/utils/waHelper.js'));
+  ({ safeSendMessage, isAdminWhatsApp, sendWAFile, isUnsupportedVersionError } = await import('../src/utils/waHelper.js'));
 });
 
 test('safeSendMessage waits for client ready', async () => {
@@ -74,4 +75,13 @@ test('sendWAFile accepts s.whatsapp.net wid', async () => {
     mimetype: 'text/plain',
     fileName: 'file.txt',
   });
+});
+
+test('isUnsupportedVersionError detects update prompts', () => {
+  expect(
+    isUnsupportedVersionError(
+      new Error('please update whatsapp to continue')
+    )
+  ).toBe(true);
+  expect(isUnsupportedVersionError(new Error('random error'))).toBe(false);
 });


### PR DESCRIPTION
## Summary
- add utility to identify unsupported WhatsApp client errors
- fall back to Play Store update link when userrequest workflow fails
- cover new helper with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d1f921c08327bb21917edc227179