### PR TITLE
Add cron for dirrequest laphar reports

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ const cronModules = [
   './src/cron/cronRekapUserDataDitbinmas.js',
   './src/cron/cronDirRequest.js',
   './src/cron/cronDirRequestAbsensiLikes.js',
+  './src/cron/cronDirRequestLaphar.js',
   './src/cron/cronDirRequestFetchInsta.js',
   './src/cron/cronDbBackup.js',
 ];

--- a/src/cron/cronDirRequestLaphar.js
+++ b/src/cron/cronDirRequestLaphar.js
@@ -1,0 +1,37 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import waClient from "../service/waService.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+import { lapharDitbinmas } from "../handler/fetchabsensi/insta/absensiLikesInsta.js";
+import { sendWAFile, getAdminWhatsAppList } from "../utils/waHelper.js";
+
+const cronTag = "CRON DIRREQUEST LAPHAR";
+
+cron.schedule(
+  "55 17,19 * * *",
+  async () => {
+    sendDebug({ tag: cronTag, msg: "Mulai rekap laphar dirrequest" });
+    try {
+      const { text, filename, narrative } = await lapharDitbinmas();
+      const buffer = Buffer.from(text, "utf-8");
+      await sendWAFile(waClient, buffer, filename);
+      const admins = getAdminWhatsAppList();
+      for (const wa of admins) {
+        await waClient
+          .sendMessage(wa, narrative || "✅ Laphar Ditbinmas dikirim.")
+          .catch(() => {});
+      }
+      sendDebug({
+        tag: cronTag,
+        msg: `Laphar dirrequest dikirim ke ${admins.length} admin`,
+      });
+    } catch (err) {
+      sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
+    }
+  },
+  { timezone: "Asia/Jakarta" }
+);
+
+export default null;


### PR DESCRIPTION
## Summary
- send dirrequest laphar recap to WhatsApp admins at 17:55 and 19:55
- register new cron module

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d43078d8832796591994f0175615