### PR TITLE
Filter directorate users by active status

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -394,7 +394,8 @@ export async function getUsersByDirektorat(flag, clientId = null) {
       JOIN roles r1 ON r1.role_id = ur1.role_id
       WHERE ur1.user_id = u.user_id
         AND r1.role_name = $1
-    )`;
+    )
+    AND u.status = true`;
 
   const hasClientId =
     Array.isArray(clientId) ? clientId.length > 0 : typeof clientId === 'string' && clientId.trim() !== '';

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -220,6 +220,7 @@ test('getUsersByDirektorat queries by flag', async () => {
   expect(sql).toContain('user_roles');
   expect(sql).toContain('r1.role_name = $1');
   expect(sql).toContain('EXISTS');
+  expect(sql).toContain('status = true');
   expect(sql).not.toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
 });
 
@@ -230,6 +231,7 @@ test('getUsersByDirektorat filters by client and flag', async () => {
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
   expect(sql).toContain('LOWER(u.client_id) = LOWER($2)');
+  expect(sql).toContain('status = true');
   expect(sql).not.toContain('LOWER(r2.role_name) = LOWER(u.client_id)');
   expect(sql.match(/EXISTS/g).length).toBe(1);
 });


### PR DESCRIPTION
## Summary
- ensure getUsersByDirektorat only returns active users
- update userModel tests for new status filter

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d89400bc8327ae5754d6e155b67f