### PR TITLE
Add missing-user report to DirRequest laphar

### DIFF
--- a/src/cron/cronDirRequestLaphar.js
+++ b/src/cron/cronDirRequestLaphar.js
@@ -13,23 +13,33 @@ cron.schedule(
   "55 17,19 * * *",
   async () => {
     sendDebug({ tag: cronTag, msg: "Mulai rekap laphar dirrequest" });
-    try {
-      const { text, filename, narrative } = await lapharDitbinmas();
-      const buffer = Buffer.from(text, "utf-8");
-      await sendWAFile(waClient, buffer, filename);
-      const admins = getAdminWhatsAppList();
-      for (const wa of admins) {
-        await waClient
-          .sendMessage(wa, narrative || "✅ Laphar Ditbinmas dikirim.")
-          .catch(() => {});
+      try {
+        const {
+          text,
+          filename,
+          narrative,
+          textBelum,
+          filenameBelum,
+        } = await lapharDitbinmas();
+        const buffer = Buffer.from(text, "utf-8");
+        await sendWAFile(waClient, buffer, filename);
+        if (textBelum && filenameBelum) {
+          const bufferBelum = Buffer.from(textBelum, "utf-8");
+          await sendWAFile(waClient, bufferBelum, filenameBelum);
+        }
+        const admins = getAdminWhatsAppList();
+        for (const wa of admins) {
+          await waClient
+            .sendMessage(wa, narrative || "✅ Laphar Ditbinmas dikirim.")
+            .catch(() => {});
+        }
+        sendDebug({
+          tag: cronTag,
+          msg: `Laphar dirrequest dikirim ke ${admins.length} admin`,
+        });
+      } catch (err) {
+        sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
       }
-      sendDebug({
-        tag: cronTag,
-        msg: `Laphar dirrequest dikirim ke ${admins.length} admin`,
-      });
-    } catch (err) {
-      sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
-    }
   },
   { timezone: "Asia/Jakarta" }
 );

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -330,14 +330,26 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = "✅ Selesai fetch komentar TikTok DITBINMAS.";
       break;
     }
-    case "9": {
-      const { text, filename, narrative } = await lapharDitbinmas();
-      const buffer = Buffer.from(text, "utf-8");
-      await writeFile(filename, buffer);
-      await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
-      msg = narrative || "✅ Laphar Ditbinmas dikirim.";
-      break;
-    }
+      case "9": {
+        const { text, filename, narrative, textBelum, filenameBelum } =
+          await lapharDitbinmas();
+        const buffer = Buffer.from(text, "utf-8");
+        await writeFile(filename, buffer);
+        await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
+        if (textBelum && filenameBelum) {
+          const bufferBelum = Buffer.from(textBelum, "utf-8");
+          await writeFile(filenameBelum, bufferBelum);
+          await sendWAFile(
+            waClient,
+            bufferBelum,
+            filenameBelum,
+            chatId,
+            "text/plain"
+          );
+        }
+        msg = narrative || "✅ Laphar Ditbinmas dikirim.";
+        break;
+      }
     default:
       msg = "Menu tidak dikenal.";
   }

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -257,6 +257,8 @@ test('choose_menu option 9 sends laphar file and narrative', async () => {
   mockLapharDitbinmas.mockResolvedValue({
     text: 'lap',
     filename: 'lap.txt',
+    textBelum: 'belum',
+    filenameBelum: 'belum.txt',
     narrative: 'narasi',
   });
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
@@ -266,11 +268,29 @@ test('choose_menu option 9 sends laphar file and narrative', async () => {
   await dirRequestHandlers.choose_menu(session, chatId, '9', waClient);
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
-  expect(mockWriteFile).toHaveBeenCalledWith('lap.txt', expect.any(Buffer));
-  expect(mockSendWAFile).toHaveBeenCalledWith(
+  expect(mockWriteFile).toHaveBeenNthCalledWith(
+    1,
+    'lap.txt',
+    expect.any(Buffer)
+  );
+  expect(mockSendWAFile).toHaveBeenNthCalledWith(
+    1,
     waClient,
     expect.any(Buffer),
     'lap.txt',
+    chatId,
+    'text/plain'
+  );
+  expect(mockWriteFile).toHaveBeenNthCalledWith(
+    2,
+    'belum.txt',
+    expect.any(Buffer)
+  );
+  expect(mockSendWAFile).toHaveBeenNthCalledWith(
+    2,
+    waClient,
+    expect.any(Buffer),
+    'belum.txt',
     chatId,
     'text/plain'
   );

--- a/tests/lapharDitbinmas.test.js
+++ b/tests/lapharDitbinmas.test.js
@@ -62,4 +62,7 @@ test('orders clients by likes with ditbinmas first and returns narrative', async
   expect(result.narrative).toMatch(/Kontributor likes terbesar/);
   expect(result.narrative).toMatch(/Anomali/);
   expect(result.narrative).toMatch(/nihil/);
+  expect(result.filename).toMatch(/^Absensi_All_Likes_IG_Ditbinmas_/);
+  expect(result.filenameBelum).toMatch(/^Absensi_Belum_Likes_IG_Ditbinmas_/);
+  expect(result.textBelum).toMatch(/Belum Input Sosial media/);
 });


### PR DESCRIPTION
## Summary
- rename laphar output to include timestamp and All_Likes
- generate additional report listing users without likes or usernames
- send both reports from DirRequest menu and cron job

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6895bb6308327b60d0938c1e65f16