### PR TITLE
feat: schedule dirrequest laphar reports

### DIFF
--- a/src/cron/cronDirRequestLaphar.js
+++ b/src/cron/cronDirRequestLaphar.js
@@ -5,43 +5,74 @@ dotenv.config();
 import waClient from "../service/waService.js";
 import { sendDebug } from "../middleware/debugHandler.js";
 import { lapharDitbinmas } from "../handler/fetchabsensi/insta/absensiLikesInsta.js";
-import { sendWAFile, getAdminWhatsAppList } from "../utils/waHelper.js";
+import { sendWAFile } from "../utils/waHelper.js";
 
 const cronTag = "CRON DIRREQUEST LAPHAR";
+const dirRequestGroup = "120363419830216549@g.us";
+const dirRequestNumber = "6281234560377@c.us";
+
+async function sendLaphar(chatIds) {
+  sendDebug({ tag: cronTag, msg: "Mulai rekap laphar dirrequest" });
+  try {
+    const {
+      text,
+      filename,
+      narrative,
+      textBelum,
+      filenameBelum,
+    } = await lapharDitbinmas();
+    const buffer = Buffer.from(text, "utf-8");
+    await sendWAFile(waClient, buffer, filename, chatIds);
+    if (textBelum && filenameBelum) {
+      const bufferBelum = Buffer.from(textBelum, "utf-8");
+      await sendWAFile(waClient, bufferBelum, filenameBelum, chatIds);
+    }
+    for (const wa of chatIds) {
+      await waClient
+        .sendMessage(wa, narrative || "✅ Laphar Ditbinmas dikirim.")
+        .catch(() => {});
+    }
+    sendDebug({
+      tag: cronTag,
+      msg: `Laphar dirrequest dikirim ke ${chatIds.length} target`,
+    });
+  } catch (err) {
+    sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
+  }
+}
+
+const options = { timezone: "Asia/Jakarta" };
 
 cron.schedule(
-  "55 17,19 * * *",
+  "0 15 * * *",
   async () => {
-    sendDebug({ tag: cronTag, msg: "Mulai rekap laphar dirrequest" });
-      try {
-        const {
-          text,
-          filename,
-          narrative,
-          textBelum,
-          filenameBelum,
-        } = await lapharDitbinmas();
-        const buffer = Buffer.from(text, "utf-8");
-        await sendWAFile(waClient, buffer, filename);
-        if (textBelum && filenameBelum) {
-          const bufferBelum = Buffer.from(textBelum, "utf-8");
-          await sendWAFile(waClient, bufferBelum, filenameBelum);
-        }
-        const admins = getAdminWhatsAppList();
-        for (const wa of admins) {
-          await waClient
-            .sendMessage(wa, narrative || "✅ Laphar Ditbinmas dikirim.")
-            .catch(() => {});
-        }
-        sendDebug({
-          tag: cronTag,
-          msg: `Laphar dirrequest dikirim ke ${admins.length} admin`,
-        });
-      } catch (err) {
-        sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
-      }
+    await sendLaphar([dirRequestGroup]);
   },
-  { timezone: "Asia/Jakarta" }
+  options
+);
+
+cron.schedule(
+  "0 18 * * *",
+  async () => {
+    await sendLaphar([dirRequestGroup]);
+  },
+  options
+);
+
+cron.schedule(
+  "0 20 * * *",
+  async () => {
+    await sendLaphar([dirRequestGroup, dirRequestNumber]);
+  },
+  options
+);
+
+cron.schedule(
+  "0 22 * * 4",
+  async () => {
+    await sendLaphar([dirRequestGroup, dirRequestNumber]);
+  },
+  options
 );
 
 export default null;


### PR DESCRIPTION
## Summary
- schedule dirrequest laphar reports at 15:00, 18:00, and 20:00 daily
- add extra Thursday 22:00 run
- deliver laphar reports to specified group and special number

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68fda856c8327a0f3b4fc9e426e93