### PR TITLE
feat: add Baileys session deletion

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -357,7 +357,7 @@ waClient.on("message", async (msg) => {
       setSession(chatId, { menu: "clientrequest", step: "main" });
       await waClient.sendMessage(
         chatId,
-        `┏━━━ *MENU CLIENT CICERO* ━━━\n1️⃣ Tambah client baru\n2️⃣ Kelola client (update/hapus/info)\n3️⃣ Kelola user (update/exception/status)\n4️⃣ Proses Instagram\n5️⃣ Proses TikTok\n6️⃣ Absensi Username Instagram\n7️⃣ Absensi Username TikTok\n8️⃣ Transfer User\n9️⃣ Exception Info\n🔟 Hapus WA Admin\n1️⃣1️⃣ Hapus WA User\n1️⃣2️⃣ Transfer User Sheet\n1️⃣3️⃣ Download Sheet Amplifikasi\n1️⃣4️⃣ Download Docs\n1️⃣5️⃣ Absensi Operator Ditbinmas\n┗━━━━━━━━━━━━━━━━━━━━━━━━━━━\nKetik *angka* menu, atau *batal* untuk keluar.`
+        `┏━━━ *MENU CLIENT CICERO* ━━━\n1️⃣ Tambah client baru\n2️⃣ Kelola client (update/hapus/info)\n3️⃣ Kelola user (update/exception/status)\n4️⃣ Proses Instagram\n5️⃣ Proses TikTok\n6️⃣ Absensi Username Instagram\n7️⃣ Absensi Username TikTok\n8️⃣ Transfer User\n9️⃣ Exception Info\n🔟 Hapus WA Admin\n1️⃣1️⃣ Hapus WA User\n1️⃣2️⃣ Transfer User Sheet\n1️⃣3️⃣ Download Sheet Amplifikasi\n1️⃣4️⃣ Download Docs\n1️⃣5️⃣ Absensi Operator Ditbinmas\n1️⃣6️⃣ Hapus Session Baileys\n┗━━━━━━━━━━━━━━━━━━━━━━━━━━━\nKetik *angka* menu, atau *batal* untuk keluar.`
       );
       return;
     }
@@ -708,6 +708,7 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
 1️⃣3️⃣ Download Sheet Amplifikasi
 1️⃣4️⃣ Download Docs
 1️⃣5️⃣ Absensi Operator Ditbinmas
+1️⃣6️⃣ Hapus Session Baileys
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Ketik *angka* menu, atau *batal* untuk keluar.
 `.trim()

--- a/tests/deleteBaileysSession.test.js
+++ b/tests/deleteBaileysSession.test.js
@@ -1,0 +1,54 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js', () => ({
+  absensiRegistrasiDashboardDitbinmas: jest.fn(),
+}));
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: jest.fn() }));
+jest.unstable_mockModule('../src/service/linkReportExcelService.js', () => ({
+  saveLinkReportExcel: jest.fn(),
+}));
+jest.unstable_mockModule('../src/service/googleContactsService.js', () => ({
+  saveContactIfNew: jest.fn(),
+}));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  getAdminWANumbers: jest.fn(),
+  getAdminWAIds: jest.fn(),
+  sendWAFile: jest.fn(),
+  formatToWhatsAppId: jest.fn(),
+}));
+jest.unstable_mockModule('../src/model/linkReportModel.js', () => ({}));
+jest.unstable_mockModule('../src/handler/fetchengagement/fetchLikesInstagram.js', () => ({
+  handleFetchLikesInstagram: jest.fn(),
+}));
+jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js', () => ({
+  absensiKomentar: jest.fn(),
+  absensiKomentarTiktokPerKonten: jest.fn(),
+}));
+
+process.env.JWT_SECRET = 'test';
+
+let clientRequestHandlers;
+
+beforeAll(async () => {
+  ({ clientRequestHandlers } = await import('../src/handler/menu/clientRequestHandlers.js'));
+});
+
+test('deleteBaileysSession_confirm removes files containing number', async () => {
+  const sessionsDir = path.join('sessions', 'baileys');
+  await fs.mkdir(sessionsDir, { recursive: true });
+  const filePath = path.join(sessionsDir, 'creds-test.json');
+  await fs.writeFile(filePath, '62812345');
+  const waClient = { sendMessage: jest.fn() };
+  const session = { target_wa: '62812345', step: 'deleteBaileysSession_confirm' };
+  await clientRequestHandlers.deleteBaileysSession_confirm(session, 'chat', 'ya', waClient);
+  let exists = true;
+  try {
+    await fs.access(filePath);
+  } catch {
+    exists = false;
+  }
+  expect(exists).toBe(false);
+  await fs.rm(path.join('sessions'), { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add menu item to remove Baileys auth session files by WhatsApp number
- expose handler and helper to search and delete session files
- add unit test for session file removal

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b69250d58483278cbb2c3078c1b4c2