### PR TITLE
Validate Instagram profile links for user updates

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -426,11 +426,13 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
       }
     }
     if (field === "insta") {
-      const igMatch = value.match(/^https?:\/\/(www\.)?instagram\.com\/([A-Za-z0-9._]+)/i);
+      const igMatch = value.match(
+        /^https?:\/\/(www\.)?instagram\.com\/([A-Za-z0-9._]+)\/?(\?.*)?$/i
+      );
       if (!igMatch) {
         await waClient.sendMessage(
           chatId,
-          "❌ Format salah! Masukkan *link profil Instagram* (contoh: https://www.instagram.com/username)"
+          "❌ Link tersebut bukan *link profil Instagram*! Masukkan *link profil Instagram* (contoh: https://www.instagram.com/username)"
         );
         return;
       }


### PR DESCRIPTION
## Summary
- reject non-profile Instagram links when updating user data
- clarify error message when a non-profile link is provided

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6962b205883278a0c2cc4bc153cbd