### PR TITLE
Block Super Admin Instagram username in user menu

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -437,6 +437,13 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
         return;
       }
       value = igMatch[2].toLowerCase();
+      if (value === "cicero_devs") {
+        await waClient.sendMessage(
+          chatId,
+          "❌ Instagram tersebut adalah milik Super Admin. Gunakan akun Instagram Anda sendiri."
+        );
+        return;
+      }
       const existing = await userModel.findUserByInsta(value);
       if (existing && existing.user_id !== user_id) {
         await waClient.sendMessage(


### PR DESCRIPTION
## Summary
- reject `cicero_devs` Instagram link during menu input

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b69a4bc0288327a294c3b41f884345