### PR TITLE
feat: add OTP claim workflow for user data updates

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -1,0 +1,74 @@
+import * as userModel from '../model/userModel.js';
+import { sendSuccess } from '../utils/response.js';
+import { formatToWhatsAppId, normalizeWhatsappNumber, safeSendMessage } from '../utils/waHelper.js';
+import waClient, { waitForWaReady } from '../service/waService.js';
+import { generateOtp, verifyOtp, isVerified, clearVerification } from '../service/otpService.js';
+
+export async function requestOtp(req, res, next) {
+  try {
+    const { nrp, whatsapp } = req.body;
+    if (!nrp || !whatsapp) {
+      return res.status(400).json({ success: false, message: 'nrp dan whatsapp wajib diisi' });
+    }
+    const wa = normalizeWhatsappNumber(whatsapp);
+    const user = await userModel.findUserById(nrp);
+    if (!user) {
+      return res.status(404).json({ success: false, message: 'User tidak ditemukan' });
+    }
+    if (user.whatsapp && user.whatsapp !== wa) {
+      return res.status(400).json({ success: false, message: 'whatsapp tidak sesuai' });
+    }
+    const otp = generateOtp(nrp, wa);
+    try {
+      await waitForWaReady();
+      const wid = formatToWhatsAppId(wa);
+      await safeSendMessage(waClient, wid, `Kode OTP Anda: ${otp}`);
+    } catch (err) {
+      console.warn(`[WA] Failed to send OTP to ${wa}: ${err.message}`);
+    }
+    sendSuccess(res, { message: 'OTP dikirim' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function verifyOtpController(req, res, next) {
+  try {
+    const { nrp, whatsapp, otp } = req.body;
+    if (!nrp || !whatsapp || !otp) {
+      return res.status(400).json({ success: false, message: 'nrp, whatsapp, dan otp wajib diisi' });
+    }
+    const wa = normalizeWhatsappNumber(whatsapp);
+    const valid = verifyOtp(nrp, wa, otp);
+    if (!valid) {
+      return res.status(400).json({ success: false, message: 'OTP tidak valid' });
+    }
+    const user = await userModel.findUserById(nrp);
+    if (user && !user.whatsapp) {
+      await userModel.updateUserField(nrp, 'whatsapp', wa);
+    }
+    sendSuccess(res, { verified: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateUserData(req, res, next) {
+  try {
+    const { nrp, whatsapp, nama, title, divisi, jabatan, desa, insta, tiktok } = req.body;
+    if (!nrp || !whatsapp) {
+      return res.status(400).json({ success: false, message: 'nrp dan whatsapp wajib diisi' });
+    }
+    const wa = normalizeWhatsappNumber(whatsapp);
+    if (!isVerified(nrp, wa)) {
+      return res.status(403).json({ success: false, message: 'OTP belum diverifikasi' });
+    }
+    const data = { nama, title, divisi, jabatan, desa, insta, tiktok };
+    Object.keys(data).forEach((k) => data[k] === undefined && delete data[k]);
+    const updated = await userModel.updateUser(nrp, data);
+    clearVerification(nrp);
+    sendSuccess(res, updated);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/routes/claimRoutes.js
+++ b/src/routes/claimRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { requestOtp, verifyOtpController, updateUserData } from '../controller/claimController.js';
+
+const router = express.Router();
+
+router.post('/request-otp', requestOtp);
+router.post('/verify-otp', verifyOtpController);
+router.put('/update', updateUserData);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,6 +18,7 @@ import approvalRequestRoutes from './approvalRequestRoutes.js';
 import pressReleaseDetailRoutes from './pressReleaseDetailRoutes.js';
 import premiumRequestRoutes from './premiumRequestRoutes.js';
 import likesRoutes from './likesRoutes.js';
+import claimRoutes from './claimRoutes.js';
 
 const router = express.Router();
 
@@ -28,6 +29,7 @@ router.use("/dashboard", dashboardRoutes);
 router.use("/insta", instaRoutes);
 router.use("/tiktok", tiktokRoutes);
 router.use('/likes', likesRoutes);
+router.use('/claim', claimRoutes);
 router.use('/quotes', quoteRoutes);
 router.use('/oauth', oauthRoutes);
 router.use('/metadata', metaRoutes);

--- a/src/service/otpService.js
+++ b/src/service/otpService.js
@@ -1,0 +1,36 @@
+import { normalizeWhatsappNumber } from '../utils/waHelper.js';
+
+const otpStore = new Map();
+const verifiedStore = new Map();
+
+export function generateOtp(nrp, whatsapp) {
+  const wa = normalizeWhatsappNumber(whatsapp);
+  const otp = String(Math.floor(100000 + Math.random() * 900000));
+  const expires = Date.now() + 5 * 60 * 1000; // 5 minutes
+  otpStore.set(nrp, { otp, whatsapp: wa, expires });
+  return otp;
+}
+
+export function verifyOtp(nrp, whatsapp, code) {
+  const wa = normalizeWhatsappNumber(whatsapp);
+  const record = otpStore.get(nrp);
+  if (!record) return false;
+  if (record.whatsapp !== wa) return false;
+  if (record.expires < Date.now()) {
+    otpStore.delete(nrp);
+    return false;
+  }
+  if (record.otp !== code) return false;
+  otpStore.delete(nrp);
+  verifiedStore.set(nrp, wa);
+  return true;
+}
+
+export function isVerified(nrp, whatsapp) {
+  const wa = normalizeWhatsappNumber(whatsapp);
+  return verifiedStore.get(nrp) === wa;
+}
+
+export function clearVerification(nrp) {
+  verifiedStore.delete(nrp);
+}

--- a/tests/otpService.test.js
+++ b/tests/otpService.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+
+let generateOtp;
+let verifyOtp;
+let isVerified;
+let clearVerification;
+
+beforeAll(async () => {
+  ({ generateOtp, verifyOtp, isVerified, clearVerification } = await import('../src/service/otpService.js'));
+});
+
+test('generateOtp and verifyOtp flow', () => {
+  const otp = generateOtp('u1', '0812');
+  expect(otp).toHaveLength(6);
+  expect(verifyOtp('u1', '0812', '000000')).toBe(false);
+  expect(verifyOtp('u1', '0812', otp)).toBe(true);
+  expect(isVerified('u1', '0812')).toBe(true);
+  clearVerification('u1');
+  expect(isVerified('u1', '0812')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add in-memory OTP service to issue and verify WhatsApp codes
- create claim controller and routes for requesting OTP, verifying, and updating user data
- register claim routes and test OTP service behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6cf0823d883279a0a21fed2f22626