### PR TITLE
Restrict OTP logins to user update routes

### DIFF
--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -7,6 +7,9 @@ export function authRequired(req, res, next) {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded;
+    if (decoded.role === 'user' && !req.path.startsWith('/claim')) {
+      return res.status(403).json({ success: false, message: 'Forbidden' });
+    }
     next();
   } catch (err) {
     // Bisa log err di backend untuk trace

--- a/tests/authMiddleware.test.js
+++ b/tests/authMiddleware.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { authRequired } from '../src/middleware/authMiddleware.js';
+
+describe('authRequired middleware', () => {
+  let app;
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'testsecret';
+    app = express();
+    const router = express.Router();
+    router.get('/claim/ok', (req, res) => res.json({ success: true }));
+    router.get('/other', (req, res) => res.json({ success: true }));
+    app.use('/api', authRequired, router);
+  });
+
+  test('allows user role on claim routes', async () => {
+    const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/claim/ok')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('blocks user role on non-claim routes', async () => {
+    const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/other')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('allows non-user roles on non-claim routes', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/other')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- block tokens with `user` role from accessing non-claim endpoints
- add tests covering auth middleware restrictions

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d067d64c832797b45d98c04c59aa