### PR TITLE
Fix user login to support non-normalized WhatsApp numbers

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -418,9 +418,10 @@ router.post('/user-login', async (req, res) => {
       .json({ success: false, message: 'nrp dan whatsapp wajib diisi' });
   }
   const wa = normalizeWhatsappNumber(whatsapp);
+  const rawWa = String(whatsapp).replace(/\D/g, "");
   const { rows } = await query(
-    'SELECT user_id, nama FROM "user" WHERE user_id = $1 AND whatsapp = $2',
-    [nrp, wa]
+    'SELECT user_id, nama FROM "user" WHERE user_id = $1 AND (whatsapp = $2 OR whatsapp = $3)',
+    [nrp, wa, rawWa]
   );
   const user = rows[0];
   if (!user) {

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -573,8 +573,8 @@ describe('POST /user-login', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(mockQuery).toHaveBeenCalledWith(
-      'SELECT user_id, nama FROM "user" WHERE user_id = $1 AND whatsapp = $2',
-      ['u1', '62808']
+      'SELECT user_id, nama FROM "user" WHERE user_id = $1 AND (whatsapp = $2 OR whatsapp = $3)',
+      ['u1', '62808', '0808']
     );
     expect(mockRedis.sAdd).toHaveBeenCalledWith('user_login:u1', res.body.token);
     expect(mockRedis.set).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Allow `/user-login` to match both normalized and raw WhatsApp numbers so existing accounts with 08- prefixes can log in
- Adjust tests for new login query

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b70e0088f483278acecfcf454cfbfe