### PR TITLE
Allow user login using password field

### DIFF
--- a/docs/login_api.md
+++ b/docs/login_api.md
@@ -28,6 +28,8 @@ All return a JSON Web Token (JWT) that must be included in subsequent requests.
 }
 ```
 
+> **Note:** For legacy Android clients, the `password` field may be used instead of `whatsapp`. Both are treated equivalently.
+
 ### User Registration
 `POST /api/auth/user-register`
 ```json

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -411,14 +411,15 @@ router.post('/user-register', async (req, res) => {
 });
 
 router.post('/user-login', async (req, res) => {
-  const { nrp, whatsapp } = req.body;
-  if (!nrp || !whatsapp) {
+  const { nrp, whatsapp, password } = req.body;
+  const waInput = whatsapp || password;
+  if (!nrp || !waInput) {
     return res
       .status(400)
       .json({ success: false, message: 'nrp dan whatsapp wajib diisi' });
   }
-  const wa = normalizeWhatsappNumber(whatsapp);
-  const rawWa = String(whatsapp).replace(/\D/g, "");
+  const wa = normalizeWhatsappNumber(waInput);
+  const rawWa = String(waInput).replace(/\D/g, "");
   const { rows } = await query(
     'SELECT user_id, nama FROM "user" WHERE user_id = $1 AND (whatsapp = $2 OR whatsapp = $3)',
     [nrp, wa, rawWa]

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -591,4 +591,35 @@ describe('POST /user-login', () => {
       expect.stringContaining('Login user: u1 - User')
     );
   });
+
+  test('logs in user using password field', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ user_id: 'u2', nama: 'User2' }]
+    });
+
+    const res = await request(app)
+      .post('/api/auth/user-login')
+      .send({ nrp: 'u2', password: '0812' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockQuery).toHaveBeenCalledWith(
+      'SELECT user_id, nama FROM "user" WHERE user_id = $1 AND (whatsapp = $2 OR whatsapp = $3)',
+      ['u2', '62812', '0812']
+    );
+    expect(mockRedis.sAdd).toHaveBeenCalledWith('user_login:u2', res.body.token);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      `login_token:${res.body.token}`,
+      'user:u2',
+      { EX: 2 * 60 * 60 }
+    );
+    expect(mockInsertLoginLog).toHaveBeenCalledWith({
+      actorId: 'u2',
+      loginType: 'user',
+      loginSource: 'mobile'
+    });
+    expect(mockQueueAdminNotification).toHaveBeenCalledWith(
+      expect.stringContaining('Login user: u2 - User2')
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Accept `password` as an alias for `whatsapp` in mobile user login
- Document legacy `password` support in login API guide
- Cover `password` field login with new test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7123f81a48327bd2ee3764611823b