### PR TITLE
Allow profile retrieval using token's client_id

### DIFF
--- a/src/controller/clientController.js
+++ b/src/controller/clientController.js
@@ -147,7 +147,11 @@ export const getSummary = async (req, res, next) => {
 
 export const getClientProfile = async (req, res, next) => {
   try {
-    const client_id = req.params.client_id || req.query.client_id || req.body.client_id;
+    const client_id =
+      req.params.client_id ||
+      req.query.client_id ||
+      req.body.client_id ||
+      req.user?.client_id;
     if (!client_id) {
       return res.status(400).json({ error: "client_id required" });
     }

--- a/tests/clientController.test.js
+++ b/tests/clientController.test.js
@@ -64,3 +64,16 @@ test('uses role client data for social media fields when non-operator org', asyn
     }),
   });
 });
+
+test('uses token client_id when not provided in request', async () => {
+  mockFindClientById.mockResolvedValueOnce({ client_id: 'C1', client_type: 'org' });
+  const req = { params: {}, query: {}, body: {}, user: { client_id: 'C1' } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { json, status };
+
+  await getClientProfile(req, res, () => {});
+
+  expect(mockFindClientById).toHaveBeenCalledWith('C1');
+  expect(json).toHaveBeenCalledWith({ success: true, client: { client_id: 'C1', client_type: 'org' } });
+});


### PR DESCRIPTION
## Summary
- Allow `/client/profile` to infer `client_id` from JWT when not provided
- Add test to cover token-based client_id fallback

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7152bfda483278ad8e3c173b1ffb3