### PR TITLE
Handle operator role in user lookups

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -284,7 +284,7 @@ export async function getUsersSocialByClient(clientId, roleFilter = null) {
 
 export async function findUserById(user_id) {
   const { rows } = await query(
-    `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id=$1\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id=$1\n     GROUP BY u.user_id`,
     [user_id]
   );
   return rows[0];
@@ -294,7 +294,7 @@ export async function findUserById(user_id) {
 export async function findUserByIdAndClient(user_id, client_id, roleFilter = null) {
   const { clause, params: clientParams } = await buildClientFilter(client_id, 'u', 2, roleFilter);
   const { rows } = await query(
-    `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id=$1 AND ${clause}\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id=$1 AND ${clause}\n     GROUP BY u.user_id`,
     [user_id, ...clientParams]
   );
   return rows[0];
@@ -424,7 +424,7 @@ export async function getUsersByDirektorat(flag, clientId = null) {
 export async function findUserByInsta(insta) {
   if (!insta) return null;
   const { rows } = await query(
-    `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE LOWER(u.insta) = LOWER($1)\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE LOWER(u.insta) = LOWER($1)\n     GROUP BY u.user_id`,
     [insta]
   );
   return rows[0];
@@ -433,7 +433,7 @@ export async function findUserByInsta(insta) {
 export async function findUserByWhatsApp(wa) {
   if (!wa) return null;
   const { rows } = await query(
-    `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.whatsapp = $1\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.whatsapp = $1\n     GROUP BY u.user_id`,
     [wa]
   );
   return rows[0];
@@ -442,7 +442,7 @@ export async function findUserByWhatsApp(wa) {
 export async function findUserByIdAndWhatsApp(userId, wa) {
   if (!userId || !wa) return null;
   const { rows } = await query(
-    `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id = $1 AND u.whatsapp = $2\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id = $1 AND u.whatsapp = $2\n     GROUP BY u.user_id`,
     [userId, wa]
   );
   return rows[0];

--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -243,7 +243,7 @@ describe('POST /user-register', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: false, ditlantas: false, bidhumas: false }] });
+        .mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false }] });
 
     const res = await request(app)
       .post('/api/auth/user-register')

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -209,7 +209,7 @@ test('updateUserRoles updates roles based on array', async () => {
 test('reactivates existing user and attaches ditbinmas role', async () => {
   mockFindUserById
     .mockResolvedValueOnce({ user_id: '1', status: false })
-    .mockResolvedValueOnce({ user_id: '1', status: true, ditbinmas: true, nama: 'B' });
+    .mockResolvedValueOnce({ user_id: '1', status: true, ditbinmas: true, nama: 'B', operator: false });
   const req = { body: { user_id: '1', nama: 'B' }, user: { role: 'ditbinmas', client_id: 'c2' } };
   const json = jest.fn();
   const status = jest.fn().mockReturnThis();
@@ -224,7 +224,7 @@ test('reactivates existing user and attaches ditbinmas role', async () => {
   expect(status).toHaveBeenCalledWith(200);
   expect(json).toHaveBeenCalledWith({
     success: true,
-    data: { user_id: '1', status: true, ditbinmas: true, nama: 'B' }
+    data: { user_id: '1', status: true, ditbinmas: true, nama: 'B', operator: false }
   });
 });
 

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -34,9 +34,9 @@ beforeEach(() => {
 });
 
 test('findUserByIdAndWhatsApp returns user', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '1', nama: 'Test', ditbinmas: false, ditlantas: false, bidhumas: false }] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '1', nama: 'Test', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false }] });
   const user = await findUserByIdAndWhatsApp('1', '0808');
-  expect(user).toEqual({ user_id: '1', nama: 'Test', ditbinmas: false, ditlantas: false, bidhumas: false });
+  expect(user).toEqual({ user_id: '1', nama: 'Test', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false });
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('FROM "user" u');
   expect(sql).toContain('u.user_id = $1 AND u.whatsapp = $2');
@@ -46,9 +46,9 @@ test('findUserByIdAndWhatsApp returns user', async () => {
 test('findUserByIdAndClient returns user for non-direktorat client', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ client_type: 'instansi' }] })
-    .mockResolvedValueOnce({ rows: [{ user_id: '1', client_id: 'C1', ditbinmas: false, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '1', client_id: 'C1', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false }] });
   const user = await findUserByIdAndClient('1', 'C1');
-  expect(user).toEqual({ user_id: '1', client_id: 'C1', ditbinmas: false, ditlantas: false, bidhumas: false });
+  expect(user).toEqual({ user_id: '1', client_id: 'C1', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false });
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('FROM "user" u');
   expect(sql).toContain('u.user_id=$1');
@@ -59,9 +59,9 @@ test('findUserByIdAndClient returns user for non-direktorat client', async () =>
 test('findUserByIdAndClient ignores client_id for direktorat', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ client_type: 'direktorat' }] })
-    .mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false }] });
   const user = await findUserByIdAndClient('1', 'ditbinmas');
-  expect(user).toEqual({ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false });
+  expect(user).toEqual({ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false });
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('EXISTS');
   expect(sql).not.toContain('u.client_id =');
@@ -137,9 +137,9 @@ test('getUsersSocialByClient filters by client or role for non-direktorat', asyn
 test('findUserByIdAndClient filters by role for instansi', async () => {
   mockQuery
     .mockResolvedValueOnce({ rows: [{ client_type: 'instansi' }] })
-    .mockResolvedValueOnce({ rows: [{ user_id: '1', client_id: 'C1', ditbinmas: true, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '1', client_id: 'C1', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false }] });
   const user = await findUserByIdAndClient('1', 'C1', 'ditbinmas');
-  expect(user).toEqual({ user_id: '1', client_id: 'C1', ditbinmas: true, ditlantas: false, bidhumas: false });
+  expect(user).toEqual({ user_id: '1', client_id: 'C1', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false });
   const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('u.user_id=$1');
   expect(sql).toContain('u.client_id = $2');
@@ -152,10 +152,10 @@ test('createUser inserts with directorate flags only', async () => {
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({})
-    .mockResolvedValueOnce({ rows: [{ user_id: '9', ditbinmas: true, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '9', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false }] });
   const data = { user_id: '9', nama: 'X', ditbinmas: true, ditlantas: false };
   const row = await createUser(data);
-  expect(row).toEqual({ user_id: '9', ditbinmas: true, ditlantas: false, bidhumas: false });
+  expect(row).toEqual({ user_id: '9', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false });
   expect(mockQuery.mock.calls[0][0]).toContain('INSERT INTO "user"');
   expect(mockQuery.mock.calls[1][1]).toEqual(['ditbinmas']);
   expect(mockQuery.mock.calls[2][1][1]).toBe('ditbinmas');
@@ -167,7 +167,7 @@ test('createUser assigns operator role when specified', async () => {
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({})
-    .mockResolvedValueOnce({ rows: [{ user_id: '10', ditbinmas: false, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '10', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false }] });
   const data = { user_id: '10', nama: 'Y', operator: true };
   await createUser(data);
   expect(mockQuery.mock.calls[1][1]).toEqual(['operator']);
@@ -177,7 +177,7 @@ test('createUser assigns operator role when specified', async () => {
 test('createUser without role does not assign any', async () => {
   mockQuery
     .mockResolvedValueOnce({})
-    .mockResolvedValueOnce({ rows: [{ user_id: '11', ditbinmas: false, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '11', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false }] });
   const data = { user_id: '11', nama: 'Z' };
   await createUser(data);
   expect(mockQuery.mock.calls.length).toBe(2);
@@ -187,18 +187,18 @@ test('updateUserField updates ditbinmas field', async () => {
   mockQuery
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({})
-    .mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false }] });
   const row = await updateUserField('1', 'ditbinmas', true);
-  expect(row).toEqual({ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false });
+  expect(row).toEqual({ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false });
   expect(mockQuery.mock.calls[1][0]).toContain('user_roles');
 });
 
 test('updateUserField updates desa field', async () => {
   mockQuery
     .mockResolvedValueOnce({})
-    .mockResolvedValueOnce({ rows: [{ user_id: '1', desa: 'ABC', ditbinmas: false, ditlantas: false, bidhumas: false }] });
+    .mockResolvedValueOnce({ rows: [{ user_id: '1', desa: 'ABC', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false }] });
   const row = await updateUserField('1', 'desa', 'ABC');
-  expect(row).toEqual({ user_id: '1', desa: 'ABC', ditbinmas: false, ditlantas: false, bidhumas: false });
+  expect(row).toEqual({ user_id: '1', desa: 'ABC', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false });
   expect(mockQuery.mock.calls[0][0]).toContain('UPDATE "user" SET desa=$1 WHERE user_id=$2');
 });
 
@@ -213,9 +213,9 @@ test('updatePremiumStatus updates fields', async () => {
 });
 
 test('getUsersByDirektorat queries by flag', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '2', ditbinmas: true, ditlantas: false, bidhumas: false }] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '2', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false }] });
   const users = await getUsersByDirektorat('ditbinmas');
-  expect(users).toEqual([{ user_id: '2', ditbinmas: true, ditlantas: false, bidhumas: false }]);
+  expect(users).toEqual([{ user_id: '2', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false }]);
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
   expect(sql).toContain('r1.role_name = $1');
@@ -225,9 +225,9 @@ test('getUsersByDirektorat queries by flag', async () => {
 });
 
 test('getUsersByDirektorat filters by client and flag', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '3', bidhumas: true, ditbinmas: false, ditlantas: false }] });
+  mockQuery.mockResolvedValueOnce({ rows: [{ user_id: '3', bidhumas: true, ditbinmas: false, ditlantas: false, operator: false }] });
   const users = await getUsersByDirektorat('bidhumas', 'c1');
-  expect(users).toEqual([{ user_id: '3', bidhumas: true, ditbinmas: false, ditlantas: false }]);
+  expect(users).toEqual([{ user_id: '3', bidhumas: true, ditbinmas: false, ditlantas: false, operator: false }]);
   const sql = mockQuery.mock.calls[0][0];
   expect(sql).toContain('user_roles');
   expect(sql).toContain('LOWER(u.client_id) = LOWER($2)');


### PR DESCRIPTION
## Summary
- return operator role flag in user lookup queries
- update tests for operator-aware user objects

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b718cbed4c8327bad0fb5b3cc7d5fd