### PR TITLE
Allow user role access to client routes

### DIFF
--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -7,8 +7,12 @@ export function authRequired(req, res, next) {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded;
-    if (decoded.role === 'user' && !req.path.startsWith('/claim')) {
-      return res.status(403).json({ success: false, message: 'Forbidden' });
+    if (decoded.role === 'user') {
+      const allowedPaths = ['/claim', '/clients'];
+      const hasAccess = allowedPaths.some((p) => req.path.startsWith(p));
+      if (!hasAccess) {
+        return res.status(403).json({ success: false, message: 'Forbidden' });
+      }
     }
     next();
   } catch (err) {

--- a/tests/authMiddleware.test.js
+++ b/tests/authMiddleware.test.js
@@ -12,6 +12,7 @@ describe('authRequired middleware', () => {
     app = express();
     const router = express.Router();
     router.get('/claim/ok', (req, res) => res.json({ success: true }));
+    router.get('/clients/data', (req, res) => res.json({ success: true }));
     router.get('/other', (req, res) => res.json({ success: true }));
     app.use('/api', authRequired, router);
   });
@@ -25,7 +26,16 @@ describe('authRequired middleware', () => {
     expect(res.body.success).toBe(true);
   });
 
-  test('blocks user role on non-claim routes', async () => {
+  test('allows user role on client routes', async () => {
+    const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/clients/data')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('blocks user role on unauthorized routes', async () => {
     const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
     const res = await request(app)
       .get('/api/other')


### PR DESCRIPTION
## Summary
- extend auth middleware so `user` role can access `/clients` routes
- expand auth middleware tests to cover allowed and blocked paths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b71decdc54832789e96202b11eb1f2