### PR TITLE
Expose claim routes without auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import routes from './src/routes/index.js';
 import authRoutes from './src/routes/authRoutes.js';
+import claimRoutes from './src/routes/claimRoutes.js';
 import { notFound, errorHandler } from './src/middleware/errorHandler.js';
 import { authRequired } from './src/middleware/authMiddleware.js';
 import { dedupRequest } from './src/middleware/dedupRequestMiddleware.js';
@@ -52,6 +53,7 @@ app.use(dedupRequest);
 
 // ===== ROUTE LOGIN (TANPA TOKEN) =====
 app.use('/api/auth', authRoutes);
+app.use('/api/claim', claimRoutes);
 
 // ===== ROUTE LAIN (WAJIB TOKEN) =====
 app.use('/api', authRequired, routes);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,7 +18,6 @@ import approvalRequestRoutes from './approvalRequestRoutes.js';
 import pressReleaseDetailRoutes from './pressReleaseDetailRoutes.js';
 import premiumRequestRoutes from './premiumRequestRoutes.js';
 import likesRoutes from './likesRoutes.js';
-import claimRoutes from './claimRoutes.js';
 
 const router = express.Router();
 
@@ -29,7 +28,6 @@ router.use("/dashboard", dashboardRoutes);
 router.use("/insta", instaRoutes);
 router.use("/tiktok", tiktokRoutes);
 router.use('/likes', likesRoutes);
-router.use('/claim', claimRoutes);
 router.use('/quotes', quoteRoutes);
 router.use('/oauth', oauthRoutes);
 router.use('/metadata', metaRoutes);

--- a/tests/authMiddleware.test.js
+++ b/tests/authMiddleware.test.js
@@ -17,8 +17,8 @@ describe('authRequired middleware', () => {
     app.use('/api', authRequired, router);
   });
 
-  test('allows user role on claim routes', async () => {
-    const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
+  test('allows operator role on claim routes', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
     const res = await request(app)
       .get('/api/claim/ok')
       .set('Authorization', `Bearer ${token}`);
@@ -35,8 +35,8 @@ describe('authRequired middleware', () => {
     expect(res.body.success).toBe(true);
   });
 
-  test('blocks user role on unauthorized routes', async () => {
-    const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
+  test('blocks operator role on unauthorized routes', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
     const res = await request(app)
       .get('/api/other')
       .set('Authorization', `Bearer ${token}`);
@@ -44,8 +44,8 @@ describe('authRequired middleware', () => {
     expect(res.body.success).toBe(false);
   });
 
-  test('allows non-user roles on non-claim routes', async () => {
-    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
+  test('allows user role on non-claim routes', async () => {
+    const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
     const res = await request(app)
       .get('/api/other')
       .set('Authorization', `Bearer ${token}`);

--- a/tests/claimRoutes.test.js
+++ b/tests/claimRoutes.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+
+let app;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  jest.unstable_mockModule('../src/controller/claimController.js', () => ({
+    requestOtp: (req, res) => res.status(200).json({ success: true }),
+    verifyOtpController: (req, res) => res.status(200).json({ success: true }),
+    updateUserData: (req, res) => res.status(200).json({ success: true })
+  }));
+  const claimMod = await import('../src/routes/claimRoutes.js');
+  const claimRoutes = claimMod.default;
+  const { authRequired } = await import('../src/middleware/authMiddleware.js');
+  app = express();
+  app.use(express.json());
+  app.use('/api/claim', claimRoutes);
+  const router = express.Router();
+  router.get('/protected', (req, res) => res.json({ success: true }));
+  app.use('/api', authRequired, router);
+});
+
+describe('claim routes access', () => {
+  test('allows access without token', async () => {
+    await request(app).post('/api/claim/request-otp').send({ nrp: '1', whatsapp: '1' }).expect(200);
+    await request(app).post('/api/claim/verify-otp').send({ nrp: '1', whatsapp: '1', otp: '123' }).expect(200);
+    await request(app).put('/api/claim/update').send({ nrp: '1', whatsapp: '1' }).expect(200);
+  });
+
+  test('blocks other routes without token', async () => {
+    const res = await request(app).get('/api/protected');
+    expect(res.status).toBe(401);
+    const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
+    const res2 = await request(app).get('/api/protected').set('Authorization', `Bearer ${token}`);
+    expect(res2.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- Mount claim routes outside auth middleware to allow unauthenticated OTP flow
- Adjust auth middleware tests and add integration test for public claim endpoints

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72151b9888327a4cb36ad54f86e22