### PR TITLE
Allow operator access to client profile endpoint

### DIFF
--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -7,8 +7,12 @@ export function authRequired(req, res, next) {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded;
-    if (decoded.role === 'operator' && !req.path.startsWith('/claim')) {
-      return res.status(403).json({ success: false, message: 'Forbidden' });
+    if (decoded.role === 'operator') {
+      const allowedPrefixes = ['/claim', '/clients/profile'];
+      const allowed = allowedPrefixes.some(p => req.path.startsWith(p));
+      if (!allowed) {
+        return res.status(403).json({ success: false, message: 'Forbidden' });
+      }
     }
     next();
   } catch (err) {

--- a/tests/authMiddleware.test.js
+++ b/tests/authMiddleware.test.js
@@ -13,6 +13,7 @@ describe('authRequired middleware', () => {
     const router = express.Router();
     router.get('/claim/ok', (req, res) => res.json({ success: true }));
     router.get('/clients/data', (req, res) => res.json({ success: true }));
+    router.get('/clients/profile', (req, res) => res.json({ success: true }));
     router.get('/other', (req, res) => res.json({ success: true }));
     app.use('/api', authRequired, router);
   });
@@ -21,6 +22,15 @@ describe('authRequired middleware', () => {
     const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
     const res = await request(app)
       .get('/api/claim/ok')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('allows operator role on client profile route', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/clients/profile')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);


### PR DESCRIPTION
## Summary
- permit operator role to call `/api/clients/profile`
- test operator access to client profile endpoint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77c51eecc832780d4d862e428cfce