### PR TITLE
feat: automate Baileys session cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ const cronModules = [
   './src/cron/cronDirRequestLaphar.js',
   './src/cron/cronDirRequestFetchInsta.js',
   './src/cron/cronDbBackup.js',
+  './src/cron/cronBaileysCleanup.js',
 ];
 
 waClient.on('ready', async () => {

--- a/src/cron/cronBaileysCleanup.js
+++ b/src/cron/cronBaileysCleanup.js
@@ -1,0 +1,14 @@
+import cron from 'node-cron';
+import { clearAllBaileysSessions } from '../service/baileysSessionService.js';
+
+cron.schedule(
+  '0 2 * * *',
+  () => {
+    clearAllBaileysSessions().catch((err) => {
+      console.error('[BAILEYS] cleanup failed:', err.message);
+    });
+  },
+  { timezone: 'Asia/Jakarta' }
+);
+
+export default null;

--- a/src/handler/menu/clientRequestHandlers.js
+++ b/src/handler/menu/clientRequestHandlers.js
@@ -22,46 +22,9 @@ import { mdToPdf } from "md-to-pdf";
 import { query } from "../../db/index.js";
 import { saveContactIfNew } from "../../service/googleContactsService.js";
 import { formatToWhatsAppId } from "../../utils/waHelper.js";
+import { deleteBaileysFilesByNumber } from "../../service/baileysSessionService.js";
 
 function ignore(..._args) {}
-
-async function deleteFilesByNumber(dir, number) {
-  let deleted = 0;
-  try {
-    const entries = await fs.readdir(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        deleted += await deleteFilesByNumber(fullPath, number);
-        const remaining = await fs
-          .readdir(fullPath)
-          .catch(() => []);
-        if (!remaining.length) {
-          await fs.rmdir(fullPath).catch(() => {});
-        }
-      } else if (entry.isFile()) {
-        if (entry.name.includes(number)) {
-          await fs.unlink(fullPath).catch(() => {});
-          deleted++;
-          continue;
-        }
-        const content = await fs.readFile(fullPath, "utf8").catch(() => "");
-        if (content.includes(number)) {
-          await fs.unlink(fullPath).catch(() => {});
-          deleted++;
-        }
-      }
-    }
-  } catch (err) {
-    if (err.code !== "ENOENT") throw err;
-  }
-  return deleted;
-}
-
-export async function deleteBaileysFilesByNumber(number) {
-  const sessionsDir = path.join("sessions", "baileys");
-  return deleteFilesByNumber(sessionsDir, number);
-}
 
 async function collectMarkdownFiles(dir, files = []) {
   const entries = await fs.readdir(dir, { withFileTypes: true });

--- a/src/service/baileysSessionService.js
+++ b/src/service/baileysSessionService.js
@@ -1,0 +1,43 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+async function deleteFilesByNumber(dir, number) {
+  let deleted = 0;
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        deleted += await deleteFilesByNumber(fullPath, number);
+        const remaining = await fs.readdir(fullPath).catch(() => []);
+        if (!remaining.length) {
+          await fs.rmdir(fullPath).catch(() => {});
+        }
+      } else if (entry.isFile()) {
+        if (entry.name.includes(number)) {
+          await fs.unlink(fullPath).catch(() => {});
+          deleted++;
+          continue;
+        }
+        const content = await fs.readFile(fullPath, 'utf8').catch(() => '');
+        if (content.includes(number)) {
+          await fs.unlink(fullPath).catch(() => {});
+          deleted++;
+        }
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+  return deleted;
+}
+
+export async function deleteBaileysFilesByNumber(number) {
+  const sessionsDir = path.join('sessions', 'baileys');
+  return deleteFilesByNumber(sessionsDir, number);
+}
+
+export async function clearAllBaileysSessions() {
+  const sessionsDir = path.join('sessions', 'baileys');
+  await fs.rm(sessionsDir, { recursive: true, force: true });
+}

--- a/tests/baileysSessionService.test.js
+++ b/tests/baileysSessionService.test.js
@@ -1,0 +1,28 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { deleteBaileysFilesByNumber, clearAllBaileysSessions } from '../src/service/baileysSessionService.js';
+
+test('deleteBaileysFilesByNumber removes files containing number', async () => {
+  const sessionsDir = path.join('sessions', 'baileys');
+  await fs.mkdir(sessionsDir, { recursive: true });
+  const file = path.join(sessionsDir, 'creds-123.json');
+  await fs.writeFile(file, '123');
+  const deleted = await deleteBaileysFilesByNumber('123');
+  expect(deleted).toBe(1);
+  await fs.rm(path.join('sessions'), { recursive: true, force: true });
+});
+
+test('clearAllBaileysSessions removes the sessions directory', async () => {
+  const sessionsDir = path.join('sessions', 'baileys');
+  await fs.mkdir(sessionsDir, { recursive: true });
+  await fs.writeFile(path.join(sessionsDir, 'dummy.json'), 'data');
+  await clearAllBaileysSessions();
+  let exists = true;
+  try {
+    await fs.access(sessionsDir);
+  } catch {
+    exists = false;
+  }
+  expect(exists).toBe(false);
+  await fs.rm(path.join('sessions'), { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- remove Baileys auth files for a number when its session closes
- run daily cron at 2 AM to wipe all Baileys sessions
- share session cleanup helpers and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77ff595408327a8aaf9ab8c5a76fa