### PR TITLE
Normalize NRP keys in OTP verification

### DIFF
--- a/src/service/otpService.js
+++ b/src/service/otpService.js
@@ -20,40 +20,43 @@ function cleanupStores() {
 setInterval(cleanupStores, CLEANUP_INTERVAL_MS).unref();
 
 export function generateOtp(nrp, whatsapp) {
+  const key = String(nrp);
   const wa = normalizeWhatsappNumber(whatsapp);
   const otp = String(Math.floor(100000 + Math.random() * 900000));
   const expires = Date.now() + OTP_TTL_MS;
-  otpStore.set(nrp, { otp, whatsapp: wa, expires });
+  otpStore.set(key, { otp, whatsapp: wa, expires });
   return otp;
 }
 
 export function verifyOtp(nrp, whatsapp, code) {
+  const key = String(nrp);
   const wa = normalizeWhatsappNumber(whatsapp);
-  const record = otpStore.get(nrp);
+  const record = otpStore.get(key);
   if (!record) return false;
   if (record.whatsapp !== wa) return false;
   if (record.expires < Date.now()) {
-    otpStore.delete(nrp);
+    otpStore.delete(key);
     return false;
   }
   if (record.otp !== code) return false;
-  otpStore.delete(nrp);
-  verifiedStore.set(nrp, { whatsapp: wa, expires: Date.now() + VERIFY_TTL_MS });
+  otpStore.delete(key);
+  verifiedStore.set(key, { whatsapp: wa, expires: Date.now() + VERIFY_TTL_MS });
   return true;
 }
 
 export function isVerified(nrp, whatsapp) {
+  const key = String(nrp);
   const wa = normalizeWhatsappNumber(whatsapp);
-  const record = verifiedStore.get(nrp);
+  const record = verifiedStore.get(key);
   if (!record) return false;
   if (record.whatsapp !== wa) return false;
   if (record.expires < Date.now()) {
-    verifiedStore.delete(nrp);
+    verifiedStore.delete(key);
     return false;
   }
   return true;
 }
 
 export function clearVerification(nrp) {
-  verifiedStore.delete(nrp);
+  verifiedStore.delete(String(nrp));
 }

--- a/tests/otpService.test.js
+++ b/tests/otpService.test.js
@@ -18,3 +18,10 @@ test('generateOtp and verifyOtp flow', () => {
   clearVerification('u1');
   expect(isVerified('u1', '0812')).toBe(false);
 });
+
+test('nrp handled consistently for strings and numbers', () => {
+  const otp = generateOtp(1, '0812');
+  expect(verifyOtp('1', '0812', otp)).toBe(true);
+  expect(isVerified(1, '0812')).toBe(true);
+  clearVerification('1');
+});


### PR DESCRIPTION
## Summary
- normalize NRP values to strings in OTP generation, verification, and checks
- add test ensuring numeric and string NRPs are treated equivalently

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b784bfaf9c83279a49cfbe3ed8d5c8