### PR TITLE
fix: allow operator access to read-only dashboard routes

### DIFF
--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -8,8 +8,19 @@ export function authRequired(req, res, next) {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded;
     if (decoded.role === 'operator') {
+      const path = req.path;
+      const method = req.method.toLowerCase();
+
+      // Routes that operator can access with any method
       const allowedPrefixes = ['/claim', '/clients/profile'];
-      const allowed = allowedPrefixes.some(p => req.path.startsWith(p));
+
+      // Additional data-fetching routes allowed only for GET requests
+      const allowedGetPrefixes = ['/users', '/dashboard', '/amplify'];
+
+      const allowed =
+        allowedPrefixes.some(p => path.startsWith(p)) ||
+        (method === 'get' && allowedGetPrefixes.some(p => path.startsWith(p)));
+
       if (!allowed) {
         return res.status(403).json({ success: false, message: 'Forbidden' });
       }

--- a/tests/authMiddleware.test.js
+++ b/tests/authMiddleware.test.js
@@ -14,6 +14,10 @@ describe('authRequired middleware', () => {
     router.get('/claim/ok', (req, res) => res.json({ success: true }));
     router.get('/clients/data', (req, res) => res.json({ success: true }));
     router.get('/clients/profile', (req, res) => res.json({ success: true }));
+    router.get('/users/list', (req, res) => res.json({ success: true }));
+    router.post('/users/list', (req, res) => res.json({ success: true }));
+    router.get('/dashboard/stats', (req, res) => res.json({ success: true }));
+    router.get('/amplify/rekap', (req, res) => res.json({ success: true }));
     router.get('/other', (req, res) => res.json({ success: true }));
     app.use('/api', authRequired, router);
   });
@@ -34,6 +38,42 @@ describe('authRequired middleware', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
+  });
+
+  test('allows operator role on user directory route', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/users/list')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('allows operator role on dashboard stats route', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/dashboard/stats')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('allows operator role on amplify rekap route', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/amplify/rekap')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('blocks operator role on disallowed methods', async () => {
+    const token = jwt.sign({ user_id: 'o1', role: 'operator' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .post('/api/users/list')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
   });
 
   test('allows user role on client routes', async () => {


### PR DESCRIPTION
## Summary
- permit operator role to fetch user directory, dashboard stats, and amplify rekap data
- cover operator access rules and disallowed methods in auth middleware tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b78a190c908327a366a4141e859bcb