### PR TITLE
Normalize WhatsApp number when validating OTP requests

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -29,8 +29,11 @@ export async function requestOtp(req, res, next) {
     if (!user) {
       return res.status(404).json({ success: false, message: 'User tidak ditemukan' });
     }
-    if (user.whatsapp && user.whatsapp !== wa) {
-      return res.status(400).json({ success: false, message: 'whatsapp tidak sesuai' });
+    if (user.whatsapp) {
+      const storedWa = normalizeWhatsappNumber(user.whatsapp);
+      if (storedWa !== wa) {
+        return res.status(400).json({ success: false, message: 'whatsapp tidak sesuai' });
+      }
     }
     const otp = generateOtp(nrp, wa);
     try {

--- a/tests/claimControllerRequestOtp.test.js
+++ b/tests/claimControllerRequestOtp.test.js
@@ -1,0 +1,55 @@
+import { jest } from '@jest/globals';
+
+let requestOtp;
+let userModel;
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.unstable_mockModule('../src/model/userModel.js', () => ({
+    findUserById: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/service/otpService.js', () => ({
+    generateOtp: jest.fn().mockReturnValue('123456'),
+    verifyOtp: jest.fn(),
+    isVerified: jest.fn(),
+    clearVerification: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+    formatToWhatsAppId: (n) => n,
+    normalizeWhatsappNumber: (nohp) => {
+      let number = String(nohp).replace(/\D/g, '');
+      if (!number.startsWith('62')) number = '62' + number.replace(/^0/, '');
+      return number;
+    },
+    safeSendMessage: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/service/waService.js', () => ({
+    default: {},
+    waitForWaReady: jest.fn(),
+  }));
+  ({ requestOtp } = await import('../src/controller/claimController.js'));
+  userModel = await import('../src/model/userModel.js');
+});
+
+test('allows request when stored whatsapp matches after normalization', async () => {
+  userModel.findUserById.mockResolvedValue({ user_id: '1', whatsapp: '08123' });
+  const req = { body: { nrp: '1', whatsapp: '628123' } };
+  const res = createRes();
+  await requestOtp(req, res, () => {});
+  expect(res.status).toHaveBeenCalledWith(200);
+});
+
+test('rejects request when stored whatsapp differs', async () => {
+  userModel.findUserById.mockResolvedValue({ user_id: '1', whatsapp: '08123' });
+  const req = { body: { nrp: '1', whatsapp: '08124' } };
+  const res = createRes();
+  await requestOtp(req, res, () => {});
+  expect(res.status).toHaveBeenCalledWith(400);
+});


### PR DESCRIPTION
## Summary
- Normalize stored WhatsApp numbers before OTP validation to avoid false mismatches
- Add tests covering OTP requests with stored numbers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7aedf98508327841c21bbc730f1a0