### PR TITLE
Handle DB connection errors in OTP controllers

### DIFF
--- a/tests/claimControllerRequestOtp.test.js
+++ b/tests/claimControllerRequestOtp.test.js
@@ -73,3 +73,13 @@ test('returns 503 when safeSendMessage returns false', async () => {
   await requestOtp(req, res, () => {});
   expect(res.status).toHaveBeenCalledWith(503);
 });
+
+test('returns 503 when findUserById throws connection error', async () => {
+  const err = Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' });
+  userModel.findUserById.mockRejectedValue(err);
+  const req = { body: { nrp: '1', whatsapp: '628123' } };
+  const res = createRes();
+  await requestOtp(req, res, () => {});
+  expect(res.status).toHaveBeenCalledWith(503);
+  expect(res.json).toHaveBeenCalledWith({ success: false, message: 'Database tidak tersedia' });
+});

--- a/tests/claimControllerVerifyOtp.test.js
+++ b/tests/claimControllerVerifyOtp.test.js
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+
+let verifyOtpController;
+let userModel;
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.unstable_mockModule('../src/model/userModel.js', () => ({
+    findUserById: jest.fn(),
+    updateUserField: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/service/otpService.js', () => ({
+    generateOtp: jest.fn(),
+    verifyOtp: jest.fn().mockReturnValue(true),
+    isVerified: jest.fn(),
+    clearVerification: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/service/waService.js', () => ({
+    default: {},
+    waitForWaReady: jest.fn(),
+  }));
+  ({ verifyOtpController } = await import('../src/controller/claimController.js'));
+  userModel = await import('../src/model/userModel.js');
+});
+
+test('returns 503 when findUserById throws connection error', async () => {
+  const err = Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' });
+  userModel.findUserById.mockRejectedValue(err);
+  const req = { body: { nrp: '1', whatsapp: '08123', otp: '123456' } };
+  const res = createRes();
+  await verifyOtpController(req, res, () => {});
+  expect(res.status).toHaveBeenCalledWith(503);
+  expect(res.json).toHaveBeenCalledWith({ success: false, message: 'Database tidak tersedia' });
+});


### PR DESCRIPTION
## Summary
- handle database connection failures in `requestOtp` and `verifyOtpController`
- add tests covering database connection error responses

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ba5b6378832788d19741c50c02a7