### PR TITLE
Use Redis-backed OTP storage with TTL

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -47,7 +47,7 @@ export async function requestOtp(req, res, next) {
         return res.status(400).json({ success: false, message: 'whatsapp tidak sesuai' });
       }
     }
-    const otp = generateOtp(nrp, wa);
+    const otp = await generateOtp(nrp, wa);
     let sent;
     try {
       await waitForWaReady();
@@ -77,7 +77,7 @@ export async function verifyOtpController(req, res, next) {
       return res.status(400).json({ success: false, message: 'nrp, whatsapp, dan otp wajib diisi' });
     }
     const wa = normalizeWhatsappNumber(whatsapp);
-    const valid = verifyOtp(nrp, wa, otp);
+    const valid = await verifyOtp(nrp, wa, otp);
     if (!valid) {
       return res.status(400).json({ success: false, message: 'OTP tidak valid' });
     }
@@ -106,7 +106,7 @@ export async function updateUserData(req, res, next) {
       return res.status(400).json({ success: false, message: 'nrp dan whatsapp wajib diisi' });
     }
     const wa = normalizeWhatsappNumber(whatsapp);
-    if (!isVerified(nrp, wa)) {
+    if (!(await isVerified(nrp, wa))) {
       return res.status(403).json({ success: false, message: 'OTP belum diverifikasi' });
     }
     const data = { nama, title, divisi, jabatan, desa };
@@ -130,7 +130,7 @@ export async function updateUserData(req, res, next) {
     }
     Object.keys(data).forEach((k) => data[k] === undefined && delete data[k]);
     const updated = await userModel.updateUser(nrp, data);
-    clearVerification(nrp);
+    await clearVerification(nrp);
     sendSuccess(res, updated);
   } catch (err) {
     next(err);

--- a/tests/otpService.test.js
+++ b/tests/otpService.test.js
@@ -6,22 +6,43 @@ let isVerified;
 let clearVerification;
 
 beforeAll(async () => {
+  const store = new Map();
+  jest.unstable_mockModule('../src/config/redis.js', () => ({
+    default: {
+      set: jest.fn(async (key, value, opts) => {
+        const expiresAt = opts?.EX ? Date.now() + opts.EX * 1000 : null;
+        store.set(key, { value, expiresAt });
+      }),
+      get: jest.fn(async (key) => {
+        const entry = store.get(key);
+        if (!entry) return null;
+        if (entry.expiresAt && entry.expiresAt < Date.now()) {
+          store.delete(key);
+          return null;
+        }
+        return entry.value;
+      }),
+      del: jest.fn(async (key) => {
+        store.delete(key);
+      }),
+    },
+  }));
   ({ generateOtp, verifyOtp, isVerified, clearVerification } = await import('../src/service/otpService.js'));
 });
 
-test('generateOtp and verifyOtp flow', () => {
-  const otp = generateOtp('u1', '0812');
+test('generateOtp and verifyOtp flow', async () => {
+  const otp = await generateOtp('u1', '0812');
   expect(otp).toHaveLength(6);
-  expect(verifyOtp('u1', '0812', '000000')).toBe(false);
-  expect(verifyOtp('u1', '0812', otp)).toBe(true);
-  expect(isVerified('u1', '0812')).toBe(true);
-  clearVerification('u1');
-  expect(isVerified('u1', '0812')).toBe(false);
+  expect(await verifyOtp('u1', '0812', '000000')).toBe(false);
+  expect(await verifyOtp('u1', '0812', otp)).toBe(true);
+  expect(await isVerified('u1', '0812')).toBe(true);
+  await clearVerification('u1');
+  expect(await isVerified('u1', '0812')).toBe(false);
 });
 
-test('nrp handled consistently for strings and numbers', () => {
-  const otp = generateOtp(1, '0812');
-  expect(verifyOtp('1', '0812', otp)).toBe(true);
-  expect(isVerified(1, '0812')).toBe(true);
-  clearVerification('1');
+test('nrp handled consistently for strings and numbers', async () => {
+  const otp = await generateOtp(1, '0812');
+  expect(await verifyOtp('1', '0812', otp)).toBe(true);
+  expect(await isVerified(1, '0812')).toBe(true);
+  await clearVerification('1');
 });


### PR DESCRIPTION
## Summary
- replace in-memory OTP Maps with Redis so codes and verifications persist and auto-expire
- make claim controller OTP handlers async to await Redis operations
- test OTP flow using mocked Redis store

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7bb97ccd8832798cccd1503cf7e6f