### PR TITLE
Handle username extraction from profile links

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -10,14 +10,18 @@ function isConnectionError(err) {
 
 function extractInstagramUsername(value) {
   if (!value) return undefined;
-  const match = value.match(/^https?:\/\/(www\.)?instagram\.com\/([A-Za-z0-9._]+)/i);
+  const match = value.match(
+    /^https?:\/\/(www\.)?instagram\.com\/([A-Za-z0-9._]+)\/?(\?.*)?$/i
+  );
   const username = match ? match[2] : value.replace(/^@/, '');
   return username.toLowerCase();
 }
 
 function extractTiktokUsername(value) {
   if (!value) return undefined;
-  const match = value.match(/^https?:\/\/(www\.)?tiktok\.com\/@([A-Za-z0-9._]+)/i);
+  const match = value.match(
+    /^https?:\/\/(www\.)?tiktok\.com\/@([A-Za-z0-9._]+)\/?(\?.*)?$/i
+  );
   const username = match ? match[2] : value.replace(/^@/, '');
   return `@${username.toLowerCase()}`;
 }

--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -453,17 +453,19 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
         return;
       }
     }
-    if (field === "tiktok") {
-      const ttMatch = value.match(/^https?:\/\/(www\.)?tiktok\.com\/@([A-Za-z0-9._]+)/i);
-      if (!ttMatch) {
-        await waClient.sendMessage(
-          chatId,
-          "❌ Format salah! Masukkan *link profil TikTok* (contoh: https://www.tiktok.com/@username)"
+      if (field === "tiktok") {
+        const ttMatch = value.match(
+          /^https?:\/\/(www\.)?tiktok\.com\/@([A-Za-z0-9._]+)\/?(\?.*)?$/i
         );
-        return;
+        if (!ttMatch) {
+          await waClient.sendMessage(
+            chatId,
+            "❌ Format salah! Masukkan *link profil TikTok* (contoh: https://www.tiktok.com/@username)"
+          );
+          return;
+        }
+        value = "@" + ttMatch[2].toLowerCase();
       }
-      value = "@" + ttMatch[2];
-    }
     if (field === "whatsapp") value = value.replace(/[^0-9]/g, "");
     if (["nama", "title", "divisi", "jabatan", "desa"].includes(field)) value = value.toUpperCase();
 

--- a/tests/claimControllerUpdateUserData.test.js
+++ b/tests/claimControllerUpdateUserData.test.js
@@ -37,8 +37,8 @@ describe('updateUserData', () => {
       body: {
         nrp: '1',
         whatsapp: '08123',
-        insta: 'https://www.instagram.com/TestUser',
-        tiktok: 'https://www.tiktok.com/@TikUser'
+        insta: 'https://www.instagram.com/TestUser?igsh=abc',
+        tiktok: 'https://www.tiktok.com/@TikUser?lang=id'
       }
     };
     const res = createRes();


### PR DESCRIPTION
## Summary
- allow Instagram and TikTok profile links with query strings
- normalize TikTok handles in WhatsApp bot
- cover link parsing with query parameters in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c0091cec8327b57cf0454e8b4b04