### PR TITLE
Queue OTP sending via RabbitMQ

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ import { notFound, errorHandler } from './src/middleware/errorHandler.js';
 import { authRequired } from './src/middleware/authMiddleware.js';
 import { dedupRequest } from './src/middleware/dedupRequestMiddleware.js';
 import { waClient } from './src/service/waService.js';
+import { startOtpWorker } from './src/service/otpQueue.js';
 
 // Import semua cron jobs setelah WhatsApp siap
 const cronModules = [
@@ -38,6 +39,8 @@ const cronModules = [
 waClient.on('ready', async () => {
   await Promise.all(cronModules.map(m => import(m)));
 });
+
+startOtpWorker().catch(err => console.error('[OTP] worker error', err));
 
 const app = express();
 app.disable('etag');

--- a/src/service/otpQueue.js
+++ b/src/service/otpQueue.js
@@ -1,0 +1,21 @@
+import { publishToQueue, consumeQueue } from './rabbitMQService.js';
+import waClient, { waitForWaReady } from './waService.js';
+import { formatToWhatsAppId, safeSendMessage } from '../utils/waHelper.js';
+
+const OTP_QUEUE = 'otp_queue';
+
+export function enqueueOtp(wa, otp) {
+  return publishToQueue(OTP_QUEUE, { wa, otp });
+}
+
+export async function startOtpWorker() {
+  await consumeQueue(OTP_QUEUE, async ({ wa, otp }) => {
+    try {
+      await waitForWaReady();
+      const wid = formatToWhatsAppId(wa);
+      await safeSendMessage(waClient, wid, `Kode OTP Anda: ${otp}`);
+    } catch (err) {
+      console.warn(`[WA] Failed to send OTP to ${wa}: ${err.message}`);
+    }
+  });
+}

--- a/tests/claimControllerRequestOtp.test.js
+++ b/tests/claimControllerRequestOtp.test.js
@@ -22,17 +22,14 @@ beforeEach(async () => {
     clearVerification: jest.fn(),
   }));
   jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
-    formatToWhatsAppId: (n) => n,
     normalizeWhatsappNumber: (nohp) => {
       let number = String(nohp).replace(/\D/g, '');
       if (!number.startsWith('62')) number = '62' + number.replace(/^0/, '');
       return number;
     },
-    safeSendMessage: jest.fn().mockResolvedValue(true),
   }));
-  jest.unstable_mockModule('../src/service/waService.js', () => ({
-    default: {},
-    waitForWaReady: jest.fn().mockResolvedValue(),
+  jest.unstable_mockModule('../src/service/otpQueue.js', () => ({
+    enqueueOtp: jest.fn().mockResolvedValue(),
   }));
   ({ requestOtp } = await import('../src/controller/claimController.js'));
   userModel = await import('../src/model/userModel.js');
@@ -43,7 +40,7 @@ test('allows request when stored whatsapp matches after normalization', async ()
   const req = { body: { nrp: '1', whatsapp: '628123' } };
   const res = createRes();
   await requestOtp(req, res, () => {});
-  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.status).toHaveBeenCalledWith(202);
 });
 
 test('rejects request when stored whatsapp differs', async () => {
@@ -54,22 +51,12 @@ test('rejects request when stored whatsapp differs', async () => {
   expect(res.status).toHaveBeenCalledWith(400);
 });
 
-test('returns 503 when waitForWaReady fails', async () => {
+test('returns 503 when enqueueOtp fails', async () => {
   userModel.findUserById.mockResolvedValue({ user_id: '1', whatsapp: '08123' });
   const req = { body: { nrp: '1', whatsapp: '628123' } };
   const res = createRes();
-  const { waitForWaReady } = await import('../src/service/waService.js');
-  waitForWaReady.mockRejectedValue(new Error('not ready'));
-  await requestOtp(req, res, () => {});
-  expect(res.status).toHaveBeenCalledWith(503);
-});
-
-test('returns 503 when safeSendMessage returns false', async () => {
-  userModel.findUserById.mockResolvedValue({ user_id: '1', whatsapp: '08123' });
-  const req = { body: { nrp: '1', whatsapp: '628123' } };
-  const res = createRes();
-  const { safeSendMessage } = await import('../src/utils/waHelper.js');
-  safeSendMessage.mockResolvedValue(false);
+  const { enqueueOtp } = await import('../src/service/otpQueue.js');
+  enqueueOtp.mockRejectedValue(new Error('queue fail'));
   await requestOtp(req, res, () => {});
   expect(res.status).toHaveBeenCalledWith(503);
 });

--- a/tests/claimControllerUpdateUserData.test.js
+++ b/tests/claimControllerUpdateUserData.test.js
@@ -17,9 +17,8 @@ describe('updateUserData', () => {
       generateOtp: jest.fn(),
       verifyOtp: jest.fn()
     }));
-    jest.unstable_mockModule('../src/service/waService.js', () => ({
-      default: {},
-      waitForWaReady: jest.fn()
+    jest.unstable_mockModule('../src/service/otpQueue.js', () => ({
+      enqueueOtp: jest.fn(),
     }));
     ({ updateUserData } = await import('../src/controller/claimController.js'));
     userModel = await import('../src/model/userModel.js');

--- a/tests/claimControllerVerifyOtp.test.js
+++ b/tests/claimControllerVerifyOtp.test.js
@@ -22,9 +22,8 @@ beforeEach(async () => {
     isVerified: jest.fn(),
     clearVerification: jest.fn(),
   }));
-  jest.unstable_mockModule('../src/service/waService.js', () => ({
-    default: {},
-    waitForWaReady: jest.fn(),
+  jest.unstable_mockModule('../src/service/otpQueue.js', () => ({
+    enqueueOtp: jest.fn(),
   }));
   ({ verifyOtpController } = await import('../src/controller/claimController.js'));
   userModel = await import('../src/model/userModel.js');

--- a/tests/claimRoutes.test.js
+++ b/tests/claimRoutes.test.js
@@ -8,7 +8,7 @@ let app;
 beforeAll(async () => {
   process.env.JWT_SECRET = 'testsecret';
   jest.unstable_mockModule('../src/controller/claimController.js', () => ({
-    requestOtp: (req, res) => res.status(200).json({ success: true }),
+    requestOtp: (req, res) => res.status(202).json({ success: true }),
     verifyOtpController: (req, res) => res.status(200).json({ success: true }),
     updateUserData: (req, res) => res.status(200).json({ success: true })
   }));
@@ -25,7 +25,7 @@ beforeAll(async () => {
 
 describe('claim routes access', () => {
   test('allows access without token', async () => {
-    await request(app).post('/api/claim/request-otp').send({ nrp: '1', whatsapp: '1' }).expect(200);
+    await request(app).post('/api/claim/request-otp').send({ nrp: '1', whatsapp: '1' }).expect(202);
     await request(app).post('/api/claim/verify-otp').send({ nrp: '1', whatsapp: '1', otp: '123' }).expect(200);
     await request(app).put('/api/claim/update').send({ nrp: '1', whatsapp: '1' }).expect(200);
   });


### PR DESCRIPTION
## Summary
- enqueue OTP messages to RabbitMQ instead of blocking for WhatsApp readiness
- return 202 for request-otp and start background worker to send queued OTPs
- update claim routes and tests for async OTP flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c6ca0ae883279d475f6b64b14ebd