### PR TITLE
Speed up OTP delivery and expose claim user data endpoint

### DIFF
--- a/src/routes/claimRoutes.js
+++ b/src/routes/claimRoutes.js
@@ -1,10 +1,16 @@
 import express from 'express';
-import { requestOtp, verifyOtpController, updateUserData } from '../controller/claimController.js';
+import {
+  requestOtp,
+  verifyOtpController,
+  getUserData,
+  updateUserData,
+} from '../controller/claimController.js';
 
 const router = express.Router();
 
 router.post('/request-otp', requestOtp);
 router.post('/verify-otp', verifyOtpController);
+router.post('/user-data', getUserData);
 router.put('/update', updateUserData);
 
 export default router;

--- a/src/service/otpQueue.js
+++ b/src/service/otpQueue.js
@@ -1,21 +1,23 @@
-import { publishToQueue, consumeQueue } from './rabbitMQService.js';
 import waClient, { waitForWaReady } from './waService.js';
 import { formatToWhatsAppId, safeSendMessage } from '../utils/waHelper.js';
 
-const OTP_QUEUE = 'otp_queue';
-
-export function enqueueOtp(wa, otp) {
-  return publishToQueue(OTP_QUEUE, { wa, otp });
+/**
+ * Send an OTP message directly via WhatsApp. The previous implementation
+ * used a RabbitMQ queue which introduced noticeable delay. By sending the
+ * message synchronously, the OTP reaches the user immediately.
+ */
+export async function enqueueOtp(wa, otp) {
+  try {
+    await waitForWaReady();
+    const wid = formatToWhatsAppId(wa);
+    await safeSendMessage(waClient, wid, `Kode OTP Anda: ${otp}`);
+  } catch (err) {
+    console.warn(`[WA] Failed to send OTP to ${wa}: ${err.message}`);
+    throw err;
+  }
 }
 
+// Kept for backward compatibility; no longer needed when sending OTP directly.
 export async function startOtpWorker() {
-  await consumeQueue(OTP_QUEUE, async ({ wa, otp }) => {
-    try {
-      await waitForWaReady();
-      const wid = formatToWhatsAppId(wa);
-      await safeSendMessage(waClient, wid, `Kode OTP Anda: ${otp}`);
-    } catch (err) {
-      console.warn(`[WA] Failed to send OTP to ${wa}: ${err.message}`);
-    }
-  });
+  return Promise.resolve();
 }

--- a/tests/claimControllerGetUserData.test.js
+++ b/tests/claimControllerGetUserData.test.js
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+
+let getUserData;
+let userModel;
+let otpService;
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.unstable_mockModule('../src/model/userModel.js', () => ({
+    findUserById: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/service/otpService.js', () => ({
+    generateOtp: jest.fn(),
+    verifyOtp: jest.fn(),
+    isVerified: jest.fn(),
+    clearVerification: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/service/otpQueue.js', () => ({
+    enqueueOtp: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+    normalizeWhatsappNumber: (nohp) => {
+      let number = String(nohp).replace(/\D/g, '');
+      if (!number.startsWith('62')) number = '62' + number.replace(/^0/, '');
+      return number;
+    },
+  }));
+  ({ getUserData } = await import('../src/controller/claimController.js'));
+  userModel = await import('../src/model/userModel.js');
+  otpService = await import('../src/service/otpService.js');
+});
+
+test('returns user data when verified', async () => {
+  userModel.findUserById.mockResolvedValue({ user_id: '1', nama: 'Test' });
+  otpService.isVerified.mockResolvedValue(true);
+  const req = { body: { nrp: '1', whatsapp: '08123' } };
+  const res = createRes();
+  await getUserData(req, res, () => {});
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ success: true, data: { user_id: '1', nama: 'Test' } });
+});
+
+test('rejects when OTP not verified', async () => {
+  otpService.isVerified.mockResolvedValue(false);
+  const req = { body: { nrp: '1', whatsapp: '08123' } };
+  const res = createRes();
+  await getUserData(req, res, () => {});
+  expect(res.status).toHaveBeenCalledWith(403);
+});

--- a/tests/claimRoutes.test.js
+++ b/tests/claimRoutes.test.js
@@ -10,6 +10,7 @@ beforeAll(async () => {
   jest.unstable_mockModule('../src/controller/claimController.js', () => ({
     requestOtp: (req, res) => res.status(202).json({ success: true }),
     verifyOtpController: (req, res) => res.status(200).json({ success: true }),
+    getUserData: (req, res) => res.status(200).json({ success: true }),
     updateUserData: (req, res) => res.status(200).json({ success: true })
   }));
   const claimMod = await import('../src/routes/claimRoutes.js');
@@ -27,6 +28,7 @@ describe('claim routes access', () => {
   test('allows access without token', async () => {
     await request(app).post('/api/claim/request-otp').send({ nrp: '1', whatsapp: '1' }).expect(202);
     await request(app).post('/api/claim/verify-otp').send({ nrp: '1', whatsapp: '1', otp: '123' }).expect(200);
+    await request(app).post('/api/claim/user-data').send({ nrp: '1', whatsapp: '1' }).expect(200);
     await request(app).put('/api/claim/update').send({ nrp: '1', whatsapp: '1' }).expect(200);
   });
 


### PR DESCRIPTION
## Summary
- send OTP synchronously via WhatsApp instead of RabbitMQ queue
- add `/api/claim/user-data` for retrieving user info after OTP verification
- cover new claim endpoint with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cbb749ac8327bbcccfc54334c3d9