### PR TITLE
Normalize NRP handling and streamline OTP dispatch

### DIFF
--- a/src/service/otpService.js
+++ b/src/service/otpService.js
@@ -1,11 +1,12 @@
 import redis from '../config/redis.js';
 import { normalizeWhatsappNumber } from '../utils/waHelper.js';
+import { normalizeUserId } from '../utils/utilsHelper.js';
 
 const OTP_TTL_SEC = 5 * 60;
 const VERIFY_TTL_SEC = 10 * 60;
 
 export async function generateOtp(nrp, whatsapp) {
-  const key = String(nrp);
+  const key = normalizeUserId(nrp);
   const wa = normalizeWhatsappNumber(whatsapp);
   const otp = String(Math.floor(100000 + Math.random() * 900000));
   const value = JSON.stringify({ otp, whatsapp: wa });
@@ -14,7 +15,7 @@ export async function generateOtp(nrp, whatsapp) {
 }
 
 export async function verifyOtp(nrp, whatsapp, code) {
-  const key = String(nrp);
+  const key = normalizeUserId(nrp);
   const wa = normalizeWhatsappNumber(whatsapp);
   const data = await redis.get(`otp:${key}`);
   if (!data) return false;
@@ -26,7 +27,7 @@ export async function verifyOtp(nrp, whatsapp, code) {
 }
 
 export async function isVerified(nrp, whatsapp) {
-  const key = String(nrp);
+  const key = normalizeUserId(nrp);
   const wa = normalizeWhatsappNumber(whatsapp);
   const storedWa = await redis.get(`verified:${key}`);
   if (!storedWa) return false;
@@ -35,5 +36,6 @@ export async function isVerified(nrp, whatsapp) {
 }
 
 export async function clearVerification(nrp) {
-  await redis.del(`verified:${String(nrp)}`);
+  const key = normalizeUserId(nrp);
+  await redis.del(`verified:${key}`);
 }

--- a/src/utils/utilsHelper.js
+++ b/src/utils/utilsHelper.js
@@ -9,6 +9,12 @@ export function sortDivisionKeys(keys) {
   });
 }
 
+// Normalisasi user_id/NRP menjadi hanya digit tanpa spasi atau karakter lain
+export function normalizeUserId(value) {
+  if (value === undefined || value === null) return "";
+  return String(value).trim().replace(/[^0-9]/g, "");
+}
+
 export function sortTitleKeys(keys, pangkatOrder) {
   // pangkatOrder: array urut dari DB
   return keys.slice().sort((a, b) => {

--- a/tests/claimControllerGetUserData.test.js
+++ b/tests/claimControllerGetUserData.test.js
@@ -54,3 +54,13 @@ test('rejects when OTP not verified', async () => {
   await getUserData(req, res, () => {});
   expect(res.status).toHaveBeenCalledWith(403);
 });
+
+test('normalizes nrp before fetching user', async () => {
+  userModel.findUserById.mockResolvedValue({ user_id: '00123', nama: 'Test' });
+  otpService.isVerified.mockResolvedValue(true);
+  const req = { body: { nrp: ' 00-123 ', whatsapp: '08123' } };
+  const res = createRes();
+  await getUserData(req, res, () => {});
+  expect(userModel.findUserById).toHaveBeenCalledWith('00123');
+  expect(res.status).toHaveBeenCalledWith(200);
+});

--- a/tests/claimControllerRequestOtp.test.js
+++ b/tests/claimControllerRequestOtp.test.js
@@ -51,14 +51,14 @@ test('rejects request when stored whatsapp differs', async () => {
   expect(res.status).toHaveBeenCalledWith(400);
 });
 
-test('returns 503 when enqueueOtp fails', async () => {
+test('continues request even if enqueueOtp fails', async () => {
   userModel.findUserById.mockResolvedValue({ user_id: '1', whatsapp: '08123' });
   const req = { body: { nrp: '1', whatsapp: '628123' } };
   const res = createRes();
   const { enqueueOtp } = await import('../src/service/otpQueue.js');
   enqueueOtp.mockRejectedValue(new Error('queue fail'));
   await requestOtp(req, res, () => {});
-  expect(res.status).toHaveBeenCalledWith(503);
+  expect(res.status).toHaveBeenCalledWith(202);
 });
 
 test('returns 503 when findUserById throws connection error', async () => {


### PR DESCRIPTION
## Summary
- normalize NRP input across controllers, services, and models for consistent user lookups
- send OTP messages asynchronously to reduce request latency
- add tests covering NRP normalization and resilient OTP queue handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf23d71483279f15adb8832c6f4d