### PR TITLE
Secure OTP handling with attempt limits

### DIFF
--- a/src/service/otpService.js
+++ b/src/service/otpService.js
@@ -1,15 +1,21 @@
+import crypto from 'crypto';
 import redis from '../config/redis.js';
 import { normalizeWhatsappNumber } from '../utils/waHelper.js';
 import { normalizeUserId } from '../utils/utilsHelper.js';
 
 const OTP_TTL_SEC = 5 * 60;
 const VERIFY_TTL_SEC = 10 * 60;
+const MAX_ATTEMPTS = 3;
+
+function hashOtp(code) {
+  return crypto.createHash('sha256').update(String(code)).digest('hex');
+}
 
 export async function generateOtp(nrp, whatsapp) {
   const key = normalizeUserId(nrp);
   const wa = normalizeWhatsappNumber(whatsapp);
   const otp = String(Math.floor(100000 + Math.random() * 900000));
-  const value = JSON.stringify({ otp, whatsapp: wa });
+  const value = JSON.stringify({ hash: hashOtp(otp), whatsapp: wa, attempts: 0 });
   await redis.set(`otp:${key}`, value, { EX: OTP_TTL_SEC });
   return otp;
 }
@@ -19,8 +25,18 @@ export async function verifyOtp(nrp, whatsapp, code) {
   const wa = normalizeWhatsappNumber(whatsapp);
   const data = await redis.get(`otp:${key}`);
   if (!data) return false;
-  const { otp, whatsapp: storedWa } = JSON.parse(data);
-  if (storedWa !== wa || otp !== code) return false;
+  const { hash, whatsapp: storedWa, attempts = 0 } = JSON.parse(data);
+  if (storedWa !== wa) return false;
+  if (attempts >= MAX_ATTEMPTS) {
+    await redis.del(`otp:${key}`);
+    return false;
+  }
+  if (hash !== hashOtp(code)) {
+    const ttl = await redis.ttl(`otp:${key}`);
+    const updated = JSON.stringify({ hash, whatsapp: storedWa, attempts: attempts + 1 });
+    await redis.set(`otp:${key}`, updated, { EX: ttl });
+    return false;
+  }
   await redis.del(`otp:${key}`);
   await redis.set(`verified:${key}`, wa, { EX: VERIFY_TTL_SEC });
   return true;

--- a/tests/otpService.test.js
+++ b/tests/otpService.test.js
@@ -1,48 +1,62 @@
 import { jest } from '@jest/globals';
 
-let generateOtp;
-let verifyOtp;
-let isVerified;
-let clearVerification;
+const store = new Map();
+const mockRedis = {
+  set: jest.fn(async (key, value, opts) => {
+    const expiresAt = opts?.EX ? Date.now() + opts.EX * 1000 : null;
+    store.set(key, { value, expiresAt });
+  }),
+  get: jest.fn(async (key) => {
+    const entry = store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }),
+  del: jest.fn(async (key) => {
+    store.delete(key);
+  }),
+  ttl: jest.fn(async () => 300),
+};
 
-beforeAll(async () => {
-  const store = new Map();
-  jest.unstable_mockModule('../src/config/redis.js', () => ({
-    default: {
-      set: jest.fn(async (key, value, opts) => {
-        const expiresAt = opts?.EX ? Date.now() + opts.EX * 1000 : null;
-        store.set(key, { value, expiresAt });
-      }),
-      get: jest.fn(async (key) => {
-        const entry = store.get(key);
-        if (!entry) return null;
-        if (entry.expiresAt && entry.expiresAt < Date.now()) {
-          store.delete(key);
-          return null;
-        }
-        return entry.value;
-      }),
-      del: jest.fn(async (key) => {
-        store.delete(key);
-      }),
-    },
-  }));
-  ({ generateOtp, verifyOtp, isVerified, clearVerification } = await import('../src/service/otpService.js'));
-});
+jest.unstable_mockModule('../src/config/redis.js', () => ({
+  default: mockRedis,
+}));
 
-test('generateOtp and verifyOtp flow', async () => {
-  const otp = await generateOtp('u1', '0812');
-  expect(otp).toHaveLength(6);
-  expect(await verifyOtp('u1', '0812', '000000')).toBe(false);
-  expect(await verifyOtp('u1', '0812', otp)).toBe(true);
-  expect(await isVerified('u1', '0812')).toBe(true);
-  await clearVerification('u1');
-  expect(await isVerified('u1', '0812')).toBe(false);
-});
+const { generateOtp, verifyOtp, isVerified, clearVerification } = await import('../src/service/otpService.js');
 
-test('nrp handled consistently for strings and numbers', async () => {
-  const otp = await generateOtp(1, '0812');
-  expect(await verifyOtp('1', '0812', otp)).toBe(true);
-  expect(await isVerified(1, '0812')).toBe(true);
-  await clearVerification('1');
+describe('otpService', () => {
+  beforeEach(() => {
+    store.clear();
+    jest.clearAllMocks();
+  });
+
+  test('generateOtp and verifyOtp flow', async () => {
+    const otp = await generateOtp('u1', '0812');
+    expect(otp).toHaveLength(6);
+    expect(await verifyOtp('u1', '0812', '000000')).toBe(false);
+    expect(await verifyOtp('u1', '0812', otp)).toBe(true);
+    expect(await isVerified('u1', '0812')).toBe(true);
+    await clearVerification('u1');
+    expect(await isVerified('u1', '0812')).toBe(false);
+  });
+
+  test('nrp handled consistently for strings and numbers', async () => {
+    const otp = await generateOtp(1, '0812');
+    expect(await verifyOtp('1', '0812', otp)).toBe(true);
+    expect(await isVerified(1, '0812')).toBe(true);
+    await clearVerification('1');
+  });
+
+  test('blocks after max attempts', async () => {
+    const otp = await generateOtp('2', '08123');
+    for (let i = 0; i < 3; i++) {
+      const res = await verifyOtp('2', '08123', '000000');
+      expect(res).toBe(false);
+    }
+    const blocked = await verifyOtp('2', '08123', otp);
+    expect(blocked).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Hash OTP codes in Redis and enforce a three-attempt limit before invalidating
- Add unit tests covering OTP flow and repeated failure lockout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d35cd944832794a981f6853069a2