### PR TITLE
Strip link fields for OTP user data

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -124,6 +124,13 @@ export async function getUserData(req, res, next) {
         .status(404)
         .json({ success: false, message: 'User tidak ditemukan' });
     }
+    // Permintaan berbasis OTP hanya membutuhkan data user dasar.
+    // Jangan sertakan atau ambil informasi link agar respons tetap ringan.
+    if (user) {
+      Object.keys(user).forEach((k) => {
+        if (k.toLowerCase().includes('link')) delete user[k];
+      });
+    }
     sendSuccess(res, user);
   } catch (err) {
     next(err);

--- a/tests/claimControllerGetUserData.test.js
+++ b/tests/claimControllerGetUserData.test.js
@@ -47,6 +47,24 @@ test('returns user data when verified', async () => {
   expect(res.json).toHaveBeenCalledWith({ success: true, data: { user_id: '1', nama: 'Test' } });
 });
 
+test('strips link fields from user data', async () => {
+  userModel.findUserById.mockResolvedValue({
+    user_id: '1',
+    nama: 'Test',
+    link: 'should-remove',
+    instagram_link: 'should-remove-too',
+  });
+  otpService.isVerified.mockResolvedValue(true);
+  const req = { body: { nrp: '1', whatsapp: '08123' } };
+  const res = createRes();
+  await getUserData(req, res, () => {});
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({
+    success: true,
+    data: { user_id: '1', nama: 'Test' },
+  });
+});
+
 test('rejects when OTP not verified', async () => {
   otpService.isVerified.mockResolvedValue(false);
   const req = { body: { nrp: '1', whatsapp: '08123' } };

--- a/tests/userRoutesAuth.test.js
+++ b/tests/userRoutesAuth.test.js
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+
+let app;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  jest.unstable_mockModule('../src/controller/userController.js', () => ({
+    getAllUsers: (req, res) => res.json({ success: true }),
+    getUserList: (req, res) => res.json({ success: true }),
+    getUsersByClient: (req, res) => res.json({ success: true }),
+    getUsersByClientFull: (req, res) => res.json({ success: true }),
+    createUser: (req, res) => res.json({ success: true }),
+    updateUserRoles: (req, res) => res.json({ success: true }),
+    getUserById: (req, res) => res.status(200).json({ success: true }),
+    updateUser: (req, res) => res.json({ success: true }),
+    deleteUser: (req, res) => res.json({ success: true }),
+  }));
+  const userRoutesMod = await import('../src/routes/userRoutes.js');
+  const userRoutes = userRoutesMod.default;
+  const { authRequired } = await import('../src/middleware/authMiddleware.js');
+  app = express();
+  app.use(express.json());
+  const router = express.Router();
+  router.use('/users', userRoutes);
+  app.use('/api', authRequired, router);
+});
+
+test('GET /api/users/:id requires Authorization header', async () => {
+  await request(app).get('/api/users/u1').expect(401);
+  const token = jwt.sign({ user_id: 'u1', role: 'user' }, process.env.JWT_SECRET);
+  await request(app)
+    .get('/api/users/u1')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200);
+});
+


### PR DESCRIPTION
## Summary
- remove link-related fields from OTP-based user data responses
- add tests ensuring link fields are stripped and user routes demand a bearer token

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7d982866c832797a10ec4ecc78c77