### PR TITLE
feat: cache dashboard post counts in redis

### DIFF
--- a/src/controller/dashboardController.js
+++ b/src/controller/dashboardController.js
@@ -1,8 +1,7 @@
 // src/controller/dashboardController.js
 import { getAllClients } from "../model/clientModel.js";
 import { getAllUsers } from "../model/userModel.js";
-import { countPostsByClient as countInstaPostsByClient } from "../model/instaPostModel.js";
-import { countPostsByClient as countTiktokPostsByClient } from "../model/tiktokPostModel.js";
+import { getInstaPostCount, getTiktokPostCount } from "../service/postCountService.js";
 import { sendConsoleDebug } from "../middleware/debugHandler.js";
 
 
@@ -20,8 +19,8 @@ export async function getDashboardStats(req, res) {
     const [clients, users, igPostCount, ttPostCount] = await Promise.all([
       getAllClients(),
       getAllUsers(client_id), // <- ini
-      countInstaPostsByClient(client_id, periode, tanggal, start_date, end_date),
-      countTiktokPostsByClient(client_id, periode, tanggal, start_date, end_date),
+      getInstaPostCount(client_id, periode, tanggal, start_date, end_date),
+      getTiktokPostCount(client_id, periode, tanggal, start_date, end_date),
     ]);
 
     // === FILTER HANYA USER AKTIF

--- a/src/service/postCountService.js
+++ b/src/service/postCountService.js
@@ -1,0 +1,27 @@
+import redis from '../config/redis.js';
+import { countPostsByClient as countInstaPostsByClient } from '../model/instaPostModel.js';
+import { countPostsByClient as countTiktokPostsByClient } from '../model/tiktokPostModel.js';
+
+const TTL_SEC = 60; // cache 1 minute
+
+function buildKey(platform, clientId, periode, tanggal, startDate, endDate) {
+  return `${platform}:post_count:${clientId}:${periode}:${tanggal || ''}:${startDate || ''}:${endDate || ''}`;
+}
+
+async function getCachedCount(platform, clientId, periode, tanggal, startDate, endDate, fetchFn) {
+  const key = buildKey(platform, clientId, periode, tanggal, startDate, endDate);
+  const cached = await redis.get(key);
+  if (cached !== null) return parseInt(cached, 10);
+  const count = await fetchFn(clientId, periode, tanggal, startDate, endDate);
+  await redis.set(key, String(count), { EX: TTL_SEC });
+  return count;
+}
+
+export function getInstaPostCount(clientId, periode, tanggal, startDate, endDate) {
+  return getCachedCount('instagram', clientId, periode, tanggal, startDate, endDate, countInstaPostsByClient);
+}
+
+export function getTiktokPostCount(clientId, periode, tanggal, startDate, endDate) {
+  return getCachedCount('tiktok', clientId, periode, tanggal, startDate, endDate, countTiktokPostsByClient);
+}
+


### PR DESCRIPTION
## Summary
- cache Instagram and TikTok post count queries in Redis for 1 minute
- wire dashboard stats controller to use cached counts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e570135c832786456f60890c4052