### PR TITLE
fix: reduce WhatsApp response delay to 2 seconds

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -100,9 +100,8 @@ dotenv.config();
 
 const messageQueue = new PQueue({ concurrency: 1 });
 
-function randomDelay() {
-  return 2000 + Math.floor(Math.random() * 3000);
-}
+// Fixed delay to ensure consistent response timing
+const responseDelayMs = 2000;
 
 // Helper ringkas untuk menampilkan data user
 function formatUserSummary(user) {
@@ -234,7 +233,7 @@ function wrapSendMessage(client) {
   }
 
   client.sendMessage = (...args) => {
-    return messageQueue.add(() => sendWithRetry(args), { delay: randomDelay() });
+    return messageQueue.add(() => sendWithRetry(args), { delay: responseDelayMs });
   };
 }
 wrapSendMessage(waClient);


### PR DESCRIPTION
## Summary
- replace random WA message delay with fixed 2-second delay for faster replies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ebfb474c8327b93f3d527d5316e1