### PR TITLE
Improve Baileys socket performance

### DIFF
--- a/tests/requestPairingCode.test.js
+++ b/tests/requestPairingCode.test.js
@@ -7,7 +7,12 @@ const mockSock = { requestPairingCode: mockRequestPairingCode, ev: { on: jest.fn
 jest.unstable_mockModule('@whiskeysockets/baileys', () => ({
   __esModule: true,
   default: jest.fn(() => mockSock),
-  useMultiFileAuthState: jest.fn().mockResolvedValue({ state: {}, saveCreds: jest.fn() }),
+  useMultiFileAuthState: jest
+    .fn()
+    .mockResolvedValue({ state: {}, saveCreds: jest.fn() }),
+  fetchLatestBaileysVersion: jest
+    .fn()
+    .mockResolvedValue({ version: [0, 0, 0] }),
 }));
 
 const { requestPairingCode } = await import('../src/service/waAdapter.js');


### PR DESCRIPTION
## Summary
- fetch latest WhatsApp Web version and disable heavy history sync
- add queue with retry/backoff for controlled message sending
- apply same optimized settings to pairing code requests

## Testing
- `npm run lint`
- `npm test` *(fails: authMiddleware.test.js allows operator access; expected 200 but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd305b1083278e82b3ff6f02064b