### PR TITLE
feat: schedule baileys auth cleanup

### DIFF
--- a/src/cron/cronBaileysCleanup.js
+++ b/src/cron/cronBaileysCleanup.js
@@ -1,11 +1,21 @@
 import cron from 'node-cron';
-import { clearAllBaileysSessions } from '../service/baileysSessionService.js';
+import { clearAllBaileysSessions, clearBaileysAuthFiles } from '../service/baileysSessionService.js';
 
 cron.schedule(
   '0 2 * * *',
   () => {
     clearAllBaileysSessions().catch((err) => {
       console.error('[BAILEYS] cleanup failed:', err.message);
+    });
+  },
+  { timezone: 'Asia/Jakarta' }
+);
+
+cron.schedule(
+  '*/15 * * * *',
+  () => {
+    clearBaileysAuthFiles().catch((err) => {
+      console.error('[BAILEYS] auth cleanup failed:', err.message);
     });
   },
   { timezone: 'Asia/Jakarta' }

--- a/src/service/baileysSessionService.js
+++ b/src/service/baileysSessionService.js
@@ -32,9 +32,40 @@ async function deleteFilesByNumber(dir, number) {
   return deleted;
 }
 
+async function deleteFilesByPatterns(dir, patterns) {
+  let deleted = 0;
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        deleted += await deleteFilesByPatterns(fullPath, patterns);
+        const remaining = await fs.readdir(fullPath).catch(() => []);
+        if (!remaining.length) {
+          await fs.rmdir(fullPath).catch(() => {});
+        }
+      } else if (entry.isFile()) {
+        if (patterns.some(p => entry.name.includes(p))) {
+          await fs.unlink(fullPath).catch(() => {});
+          deleted++;
+        }
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+  return deleted;
+}
+
 export async function deleteBaileysFilesByNumber(number) {
   const sessionsDir = path.join('sessions', 'baileys');
   return deleteFilesByNumber(sessionsDir, number);
+}
+
+export async function clearBaileysAuthFiles() {
+  const sessionsDir = path.join('sessions', 'baileys');
+  const patterns = ['sender-key', 'session', 'pre-key'];
+  return deleteFilesByPatterns(sessionsDir, patterns);
 }
 
 export async function clearAllBaileysSessions() {


### PR DESCRIPTION
## Summary
- add utility to remove Baileys auth/session key files
- run Baileys auth cleanup every 15 minutes via cron

## Testing
- `npm run lint`
- `npm test` *(fails: authRequired middleware allows operator role tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b801f11f108327b28ad7bf168fee4a