### PR TITLE
Add dirrequest cron schedules

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,8 @@ const cronModules = [
   './src/cron/cronTiktokLaphar.js',
   './src/cron/cronInstaDataMining.js',
   './src/cron/cronRekapLink.js',
+  './src/cron/cronAbsensiUserData.js',
+  './src/cron/cronAbsensiOprDitbinmas.js',
   './src/cron/cronAmplifyLinkMonthly.js',
   './src/cron/cronDirRequest.js',
   './src/cron/cronDirRequestAbsensiLikes.js',

--- a/src/cron/cronAbsensiOprDitbinmas.js
+++ b/src/cron/cronAbsensiOprDitbinmas.js
@@ -1,0 +1,18 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import waClient from "../service/waService.js";
+import { absensiRegistrasiDashboardDitbinmas } from "../handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js";
+import { sendWAReport, getAdminWAIds } from "../utils/waHelper.js";
+
+export async function runCron(chatIds = null) {
+  const targets = chatIds && chatIds.length ? chatIds : getAdminWAIds();
+  const msg = await absensiRegistrasiDashboardDitbinmas();
+  await sendWAReport(waClient, msg, targets);
+}
+
+const options = { timezone: "Asia/Jakarta" };
+cron.schedule("0 7 * * *", () => runCron(), options);
+
+export default null;

--- a/src/cron/cronAbsensiUserData.js
+++ b/src/cron/cronAbsensiUserData.js
@@ -1,0 +1,74 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import waClient from "../service/waService.js";
+import { sendWAReport, getAdminWAIds } from "../utils/waHelper.js";
+import { getUsersMissingDataByClient, getClientsByRole } from "../model/userModel.js";
+import { query } from "../db/index.js";
+const dirRequestGroup = "120363419830216549@g.us";
+const dirRequestNumber = "6281234560377@c.us";
+
+function sortClients(clients) {
+  return clients.sort((a, b) => {
+    if (a.client_id === "DITBINMAS") return -1;
+    if (b.client_id === "DITBINMAS") return 1;
+    if (a.client_type !== b.client_type) {
+      if (a.client_type === "direktorat") return -1;
+      if (b.client_type === "direktorat") return 1;
+    }
+    return a.nama.localeCompare(b.nama);
+  });
+}
+
+function formatMissing(user) {
+  const parts = [];
+  if (!user.whatsapp) parts.push("Belum Registrasi Whatsapp");
+  if (!user.insta) parts.push("Instagram Kosong");
+  if (!user.tiktok) parts.push("Tiktok Kosong");
+  return parts.join(", ");
+}
+
+export async function runCron(chatIds = null) {
+  const targets = chatIds && chatIds.length ? chatIds : getAdminWAIds();
+  try {
+    const clientIds = await getClientsByRole("operator");
+    clientIds.push("DITBINMAS");
+    const { rows } = await query(
+      `SELECT client_id, nama, client_type FROM clients WHERE client_id = ANY($1::text[])`,
+      [clientIds.map((id) => id.toUpperCase())]
+    );
+    const ordered = sortClients(rows);
+    const lines = ["*Rekap User Belum Melengkapi Data*"];
+    for (let i = 0; i < ordered.length; i++) {
+      const c = ordered[i];
+      lines.push(`${i + 1}. ${c.nama}`);
+      const users = await getUsersMissingDataByClient(c.client_id);
+      for (const u of users) {
+        const miss = formatMissing(u);
+        lines.push(`- ${u.nama} (${u.user_id}): ${miss}`);
+      }
+    }
+    const message = lines.join("\n");
+    await sendWAReport(waClient, message, targets);
+  } catch {
+    // silently ignore errors
+  }
+}
+
+const options = { timezone: "Asia/Jakarta" };
+
+cron.schedule("30 15 * * *", () => runCron([dirRequestGroup]), options);
+cron.schedule("30 18 * * *", () => runCron([dirRequestGroup]), options);
+cron.schedule(
+  "30 20 * * *",
+  () => runCron([dirRequestGroup, dirRequestNumber, ...getAdminWAIds()]),
+  options
+);
+cron.schedule(
+  "12 22 * * 4",
+  () => runCron([dirRequestGroup, dirRequestNumber, ...getAdminWAIds()]),
+  options
+);
+
+export default null;

--- a/src/cron/cronDirRequestAbsensiLikes.js
+++ b/src/cron/cronDirRequestAbsensiLikes.js
@@ -8,33 +8,48 @@ import { absensiLikes } from "../handler/fetchabsensi/insta/absensiLikesInsta.js
 import { getShortcodesTodayByClient } from "../model/instaPostModel.js";
 import waClient from "../service/waService.js";
 import { sendDebug } from "../middleware/debugHandler.js";
+import { getAdminWAIds } from "../utils/waHelper.js";
 
-const groupId = "120363419830216549@g.us";
 const cronTag = "CRON DIRREQUEST ABSENSI LIKES";
+const dirRequestGroup = "120363419830216549@g.us";
+const dirRequestNumber = "6281234560377@c.us";
 
-cron.schedule(
-  "50 14,17,19 * * *",
-  async () => {
-    sendDebug({ tag: cronTag, msg: "Mulai fetch & absensi IG DITBINMAS" });
-    try {
-      const keys = ["shortcode", "caption", "like_count", "timestamp"];
-      await fetchAndStoreInstaContent(keys, null, null, "DITBINMAS");
-      const shortcodes = await getShortcodesTodayByClient("DITBINMAS");
-      if (shortcodes.length === 0) {
-        sendDebug({ tag: cronTag, msg: "Tidak ada tugas IG hari ini" });
-        return;
-      }
-      await handleFetchLikesInstagram(null, null, "DITBINMAS");
-      const msg = await absensiLikes("DITBINMAS", { mode: "all", roleFlag: "ditbinmas" });
-      if (msg) {
-        await waClient.sendMessage(groupId, msg).catch(() => {});
-        sendDebug({ tag: cronTag, msg: "Laporan absensi IG dikirim" });
-      }
-    } catch (err) {
-      sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
+async function runAbsensi(chatIds) {
+  sendDebug({ tag: cronTag, msg: "Mulai fetch & absensi IG DITBINMAS" });
+  try {
+    const keys = ["shortcode", "caption", "like_count", "timestamp"];
+    await fetchAndStoreInstaContent(keys, null, null, "DITBINMAS");
+    const shortcodes = await getShortcodesTodayByClient("DITBINMAS");
+    if (shortcodes.length === 0) {
+      sendDebug({ tag: cronTag, msg: "Tidak ada tugas IG hari ini" });
+      return;
     }
-  },
-  { timezone: "Asia/Jakarta" }
+    await handleFetchLikesInstagram(null, null, "DITBINMAS");
+    const msg = await absensiLikes("DITBINMAS", { mode: "all", roleFlag: "ditbinmas" });
+    if (msg) {
+      for (const wa of chatIds) {
+        await waClient.sendMessage(wa, msg).catch(() => {});
+      }
+      sendDebug({ tag: cronTag, msg: `Laporan absensi IG dikirim ke ${chatIds.length} target` });
+    }
+  } catch (err) {
+    sendDebug({ tag: cronTag, msg: `[ERROR] ${err.message || err}` });
+  }
+}
+
+const options = { timezone: "Asia/Jakarta" };
+
+cron.schedule("12 15 * * *", () => runAbsensi([dirRequestGroup]), options);
+cron.schedule("12 18 * * *", () => runAbsensi([dirRequestGroup]), options);
+cron.schedule(
+  "12 20 * * *",
+  () => runAbsensi([dirRequestGroup, dirRequestNumber, ...getAdminWAIds()]),
+  options
+);
+cron.schedule(
+  "12 22 * * 4",
+  () => runAbsensi([dirRequestGroup, dirRequestNumber, ...getAdminWAIds()]),
+  options
 );
 
 export default null;


### PR DESCRIPTION
## Summary
- add cron job to recap users missing data with scheduled WhatsApp reports
- update dirrequest Instagram likes attendance cron for new times and recipients
- register new cron modules in app startup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b84d9331a08327912eeba7af765022