### PR TITLE
feat: ignore status broadcasts and group chats

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -275,11 +275,11 @@ waClient.on("message", async (msg) => {
   const chatId = msg.from;
   const text = (msg.body || "").trim();
   console.log(`[WA] Incoming message from ${chatId}: ${text}`);
-  if (msg.isStatus) {
+  if (msg.isStatus || chatId === "status@broadcast") {
     console.log(`[WA] Ignored status message from ${chatId}`);
     return;
   }
-  if (chatId?.endsWith("@g.us") && !text.toLowerCase().startsWith("thisgroup#")) {
+  if (chatId?.endsWith("@g.us")) {
     console.log(`[WA] Ignored group message from ${chatId}`);
     return;
   }


### PR DESCRIPTION
## Summary
- ensure WA service ignores status broadcast messages
- ignore group messages to avoid session creation or responses

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b853e0ada08327b71c0a6e82fec36d