### PR TITLE
Protect active Baileys sessions during cleanup

### DIFF
--- a/docs/activity_schedule.md
+++ b/docs/activity_schedule.md
@@ -15,6 +15,7 @@ This document summarizes the automated jobs ("activity") that run inside Cicero_
 | `cronRekapLink.js` | `2 15,18,21 * * *` | Daily at 15:02, 18:02 and 21:02. Sends attendance link recaps to operators and admins. |
 | `cronAbsensiUserData.js` | `0 13 * * *` | Daily at 13:00. Notifies users and operators about incomplete registration data. |
 | `cronAmplifyLinkMonthly.js` | `0 23 28-31 * *` | At 23:00 on the last day of each month. Generates monthly amplification link reports and sends an Excel file to each operator. |
+| `cronBaileysCleanup.js` | `15,45 * * * *` | Twice per hour. Deletes Baileys auth files older than 24 hours when the client is disconnected. |
 
 Each job collects data from the database, interacts with RapidAPI or WhatsApp, and updates the system accordingly. The cron files are imported in `app.js` so no additional setup is required.
 

--- a/src/cron/cronBaileysCleanup.js
+++ b/src/cron/cronBaileysCleanup.js
@@ -1,12 +1,30 @@
 import cron from 'node-cron';
 import { clearBaileysAuthFiles } from '../service/baileysSessionService.js';
+import { waClient } from '../service/waService.js';
+
+// Periodically remove stale Baileys auth files.
+// Skips cleanup while a Baileys socket is connected
+// and only deletes files older than 24 hours.
+const SAFE_AGE_MS = 24 * 60 * 60 * 1000;
 
 cron.schedule(
   '15,45 * * * *',
-  () => {
-    clearBaileysAuthFiles().catch((err) => {
+  async () => {
+    try {
+      const state = await waClient.getState?.();
+      if (state === 'open') {
+        console.log('[BAILEYS] cleanup skipped - client connected');
+        return;
+      }
+    } catch {
+      /* ignore state check errors */
+    }
+
+    try {
+      await clearBaileysAuthFiles(SAFE_AGE_MS);
+    } catch (err) {
       console.error('[BAILEYS] auth cleanup failed:', err.message);
-    });
+    }
   },
   { timezone: 'Asia/Jakarta' }
 );

--- a/tests/cronBaileysCleanup.test.js
+++ b/tests/cronBaileysCleanup.test.js
@@ -1,0 +1,67 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { jest } from '@jest/globals';
+
+let scheduledCleanup;
+const schedule = jest.fn((expr, fn) => {
+  scheduledCleanup = fn;
+});
+
+jest.unstable_mockModule('node-cron', () => ({ default: { schedule } }));
+
+const waClient = { getState: jest.fn() };
+jest.unstable_mockModule('../src/service/waService.js', () => ({ waClient }));
+
+await import('../src/cron/cronBaileysCleanup.js');
+
+const SAFE_AGE_MS = 24 * 60 * 60 * 1000;
+
+test('skips cleanup when Baileys socket is connected', async () => {
+  const sessionsDir = path.join('sessions', 'baileys');
+  await fs.mkdir(sessionsDir, { recursive: true });
+  const filePath = path.join(sessionsDir, 'session-test.json');
+  await fs.writeFile(filePath, '');
+
+  waClient.getState.mockResolvedValue('open');
+  await scheduledCleanup();
+
+  let exists = true;
+  try {
+    await fs.access(filePath);
+  } catch {
+    exists = false;
+  }
+  expect(exists).toBe(true);
+  await fs.rm('sessions', { recursive: true, force: true });
+});
+
+test('deletes only auth files older than 24 hours', async () => {
+  const sessionsDir = path.join('sessions', 'baileys');
+  await fs.mkdir(sessionsDir, { recursive: true });
+  const oldFile = path.join(sessionsDir, 'session-old.json');
+  const newFile = path.join(sessionsDir, 'session-new.json');
+  await fs.writeFile(oldFile, '');
+  await fs.writeFile(newFile, '');
+  const past = Date.now() - SAFE_AGE_MS - 3600000; // 1h older than safe age
+  const pastDate = new Date(past);
+  await fs.utimes(oldFile, pastDate, pastDate);
+
+  waClient.getState.mockResolvedValue('close');
+  await scheduledCleanup();
+
+  let existsOld = true;
+  try {
+    await fs.access(oldFile);
+  } catch {
+    existsOld = false;
+  }
+  let existsNew = true;
+  try {
+    await fs.access(newFile);
+  } catch {
+    existsNew = false;
+  }
+  expect(existsOld).toBe(false);
+  expect(existsNew).toBe(true);
+  await fs.rm('sessions', { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- Skip Baileys auth cleanup when a socket is connected and only delete files older than 24h
- Add unit tests for Baileys cleanup behavior and document the cron job

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8595b55f0832792ba9175b4a07f5d