### PR TITLE
Reset Baileys socket on PreKeyError

### DIFF
--- a/src/service/waAdapter.js
+++ b/src/service/waAdapter.js
@@ -85,7 +85,19 @@ export async function createBaileysClient({ refreshAuth = false } = {}) {
     });
     if (sock.logger) sock.logger.level = 'warn';
     sock.ev.on('creds.update', saveCreds);
-    sock.ev.on('messages.upsert', handleMessages);
+    sock.ev.on('messages.upsert', (m) => {
+      try {
+        handleMessages(m);
+      } catch (err) {
+        if (err?.name === 'PreKeyError') {
+          refreshAuthState();
+          startSock();
+          handleMessages(m);
+        } else {
+          throw err;
+        }
+      }
+    });
     sock.ev.on('connection.update', onConnectionUpdate);
   };
 

--- a/tests/waAdapter.test.js
+++ b/tests/waAdapter.test.js
@@ -1,0 +1,74 @@
+import { jest } from '@jest/globals';
+
+const listeners = {};
+const mockSock = {
+  ev: {
+    on: jest.fn((event, handler) => {
+      listeners[event] = handler;
+    }),
+  },
+  end: jest.fn(),
+};
+
+const makeWASocket = jest.fn(() => mockSock);
+
+jest.unstable_mockModule('@whiskeysockets/baileys', () => ({
+  __esModule: true,
+  default: makeWASocket,
+  useMultiFileAuthState: jest
+    .fn()
+    .mockResolvedValue({ state: {}, saveCreds: jest.fn() }),
+  fetchLatestBaileysVersion: jest
+    .fn()
+    .mockResolvedValue({ version: [0, 0, 0] }),
+}));
+
+const fsMock = {
+  existsSync: jest.fn().mockReturnValue(true),
+  rmSync: jest.fn(),
+  mkdirSync: jest.fn(),
+};
+
+jest.unstable_mockModule('fs', () => ({ __esModule: true, default: fsMock }));
+
+const { createBaileysClient } = await import(
+  '../src/service/waAdapter.js'
+);
+
+test('adapter resets and resumes on PreKeyError', async () => {
+  const client = await createBaileysClient();
+  const onMessage = jest.fn();
+  client.onMessage(onMessage);
+
+  const upsertHandler = listeners['messages.upsert'];
+
+  const originalEmit = client.emit.bind(client);
+  const preKeyError = new Error('prekey');
+  preKeyError.name = 'PreKeyError';
+  jest
+    .spyOn(client, 'emit')
+    .mockImplementationOnce(() => {
+      throw preKeyError;
+    })
+    .mockImplementation((...args) => originalEmit(...args));
+
+  const message = {
+    type: 'notify',
+    messages: [
+      {
+        key: { remoteJid: '123@s.whatsapp.net' },
+        message: { conversation: 'hi' },
+      },
+    ],
+  };
+
+  upsertHandler(message);
+
+  expect(fsMock.rmSync).toHaveBeenCalledTimes(1);
+  expect(makeWASocket).toHaveBeenCalledTimes(2);
+  expect(onMessage).toHaveBeenCalledWith({
+    from: '123@s.whatsapp.net',
+    body: 'hi',
+  });
+});
+


### PR DESCRIPTION
## Summary
- restart WhatsApp socket and refresh auth state when `messages.upsert` throws `PreKeyError`
- add regression test to ensure client resets and continues processing messages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85b3cc180832783ab151181f9fc7c