### PR TITLE
fix: support CJS import for whatsapp-web.js

### DIFF
--- a/src/service/wwebjsAdapter.js
+++ b/src/service/wwebjsAdapter.js
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
-import { Client, LocalAuth } from 'whatsapp-web.js';
+import pkg from 'whatsapp-web.js';
+
+const { Client, LocalAuth } = pkg;
 
 /**
  * Create a whatsapp-web.js client that matches the WAAdapter contract.

--- a/tests/wwebjsAdapter.test.js
+++ b/tests/wwebjsAdapter.test.js
@@ -13,8 +13,10 @@ const mockClient = {
 };
 
 jest.unstable_mockModule('whatsapp-web.js', () => ({
-  Client: jest.fn(() => mockClient),
-  LocalAuth: jest.fn().mockImplementation(() => ({})),
+  default: {
+    Client: jest.fn(() => mockClient),
+    LocalAuth: jest.fn().mockImplementation(() => ({})),
+  },
 }));
 
 const { createWwebjsClient } = await import('../src/service/wwebjsAdapter.js');


### PR DESCRIPTION
## Summary
- use default import for `whatsapp-web.js`
- update wwebjsAdapter tests for default mock

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c89698448327a9233a0526dcc472