### PR TITLE
Guard WhatsApp sendMessage when client isn't ready

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -220,12 +220,11 @@ function wrapSendMessage(client) {
   client._originalSendMessage = original;
 
   async function sendWithRetry(args, attempt = 0) {
+    await waitForWaReady().catch(() => {
+      console.warn("[WA] sendMessage called before ready");
+      throw new Error("WhatsApp client not ready");
+    });
     try {
-      try {
-        await waitForWaReady();
-      } catch {
-        console.warn("[WA] sendMessage called before ready");
-      }
       return await original.apply(client, args);
     } catch (err) {
       const isRateLimit = err?.data === 429 || err?.message === "rate-overlimit";


### PR DESCRIPTION
## Summary
- Prevent sendMessage from running when the WhatsApp client is not ready by throwing a descriptive error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ce1e2bac8327a19019c10fa3a741