### PR TITLE
feat: allow OTP verification during user update

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -132,13 +132,28 @@ export async function getUserData(req, res, next) {
 
 export async function updateUserData(req, res, next) {
   try {
-    const { nrp: rawNrp, whatsapp, nama, title, divisi, jabatan, desa, insta, tiktok } = req.body;
+    const {
+      nrp: rawNrp,
+      whatsapp,
+      nama,
+      title,
+      divisi,
+      jabatan,
+      desa,
+      insta,
+      tiktok,
+      otp,
+    } = req.body;
     const nrp = normalizeUserId(rawNrp);
     if (!nrp || !whatsapp) {
       return res.status(400).json({ success: false, message: 'nrp dan whatsapp wajib diisi' });
     }
     const wa = normalizeWhatsappNumber(whatsapp);
-    if (!(await isVerified(nrp, wa))) {
+    let verified = await isVerified(nrp, wa);
+    if (!verified && otp) {
+      verified = await verifyOtp(nrp, wa, otp);
+    }
+    if (!verified) {
       return res.status(403).json({ success: false, message: 'OTP belum diverifikasi' });
     }
     const data = { nama, title, divisi, jabatan, desa };


### PR DESCRIPTION
## Summary
- allow `PUT /api/claim/update` to verify OTP when the code is supplied in the request
- add unit test covering OTP verification path in updateUserData

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d3f4e22c83278ec8ce305bb24537