### PR TITLE
Prioritize wwebjs for incoming WA messages

### DIFF
--- a/src/service/waEventAggregator.js
+++ b/src/service/waEventAggregator.js
@@ -2,6 +2,8 @@ const seen = new Set();
 
 /**
  * Deduplicate incoming messages from multiple adapters.
+ * Messages received via wwebjs are preferred; baileys messages are delayed
+ * briefly to allow wwebjs to handle the message first.
  * @param {'baileys'|'wwebjs'} fromAdapter
  * @param {object} msg
  * @param {(msg: object) => void} handler
@@ -11,6 +13,16 @@ export function handleIncoming(fromAdapter, msg, handler) {
   const id = msg.key?.id || msg.id?.id || msg.id?._serialized;
   const key = `${jid}:${id}`;
   if (seen.has(key)) return;
+
+  if (fromAdapter === "baileys") {
+    setTimeout(() => {
+      if (seen.has(key)) return;
+      seen.add(key);
+      handler(msg);
+    }, 200);
+    return;
+  }
+
   seen.add(key);
   handler(msg);
 }

--- a/tests/waEventAggregator.test.js
+++ b/tests/waEventAggregator.test.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+import { handleIncoming } from '../src/service/waEventAggregator.js';
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('wwebjs takes precedence over baileys', () => {
+  jest.useFakeTimers();
+  const handler = jest.fn();
+  const msg = { from: '123', id: { id: 'abc', _serialized: 'abc' } };
+
+  handleIncoming('baileys', msg, handler);
+  jest.advanceTimersByTime(100);
+  handleIncoming('wwebjs', msg, handler);
+  jest.runAllTimers();
+
+  expect(handler).toHaveBeenCalledTimes(1);
+  expect(handler).toHaveBeenCalledWith(msg);
+});
+
+test('baileys processed if wwebjs absent', () => {
+  jest.useFakeTimers();
+  const handler = jest.fn();
+  const msg = { from: '456', id: { id: 'def', _serialized: 'def' } };
+
+  handleIncoming('baileys', msg, handler);
+  jest.advanceTimersByTime(250);
+  jest.runAllTimers();
+
+  expect(handler).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary
- favor wwebjs over Baileys when handling incoming WhatsApp messages
- add unit tests to ensure wwebjs events are processed before Baileys fallback

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d88ba1448327bb7f70c1ed7a76f6