### PR TITLE
fix: include message id in wwebjs adapter

### DIFF
--- a/src/service/wwebjsAdapter.js
+++ b/src/service/wwebjsAdapter.js
@@ -19,7 +19,12 @@ export async function createWwebjsClient() {
   client.on('ready', () => emitter.emit('ready'));
   client.on('disconnected', (reason) => emitter.emit('disconnected', reason));
   client.on('message', (msg) => {
-    emitter.emit('message', { from: msg.from, body: msg.body });
+    emitter.emit('message', {
+      from: msg.from,
+      body: msg.body,
+      id: msg.id,
+      author: msg.author,
+    });
   });
 
   emitter.connect = async () => {

--- a/tests/wwebjsAdapter.test.js
+++ b/tests/wwebjsAdapter.test.js
@@ -26,8 +26,9 @@ test('wwebjs adapter relays messages', async () => {
   const onMessage = jest.fn();
   client.onMessage(onMessage);
   await client.connect();
-  listeners['message']({ from: '123', body: 'hi' });
-  expect(onMessage).toHaveBeenCalledWith({ from: '123', body: 'hi' });
+  const incoming = { from: '123', body: 'hi', id: { id: 'm1', _serialized: 'm1' } };
+  listeners['message'](incoming);
+  expect(onMessage).toHaveBeenCalledWith(incoming);
   const id = await client.sendMessage('123', 'hello');
   expect(id).toBe('abc');
   await client.disconnect();


### PR DESCRIPTION
## Summary
- include message id and author in wwebjs adapter messages to avoid duplicate suppression
- update wwebjs adapter test to expect message id propagation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ece1b1588327a5dd1530bb77e029