### PR TITLE
feat(wwebjs): support document messaging

### DIFF
--- a/tests/wwebjsAdapter.test.js
+++ b/tests/wwebjsAdapter.test.js
@@ -9,17 +9,24 @@ const mockClient = {
   destroy: jest.fn().mockResolvedValue(),
   sendMessage: jest.fn().mockResolvedValue({ id: { id: 'abc' } }),
   getState: jest.fn().mockResolvedValue('CONNECTED'),
-  info: {}
+  info: {},
 };
+
+const MessageMedia = jest.fn();
 
 jest.unstable_mockModule('whatsapp-web.js', () => ({
   default: {
     Client: jest.fn(() => mockClient),
     LocalAuth: jest.fn().mockImplementation(() => ({})),
+    MessageMedia,
   },
 }));
 
 const { createWwebjsClient } = await import('../src/service/wwebjsAdapter.js');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 test('wwebjs adapter relays messages', async () => {
   const client = await createWwebjsClient();
@@ -31,6 +38,33 @@ test('wwebjs adapter relays messages', async () => {
   expect(onMessage).toHaveBeenCalledWith(incoming);
   const id = await client.sendMessage('123', 'hello');
   expect(id).toBe('abc');
+  expect(mockClient.sendMessage).toHaveBeenCalledWith('123', 'hello', {});
   await client.disconnect();
   expect(mockClient.destroy).toHaveBeenCalled();
 });
+
+test('wwebjs adapter sends documents as MessageMedia', async () => {
+  MessageMedia.mockImplementation(function (mimetype, data, filename) {
+    this.mimetype = mimetype;
+    this.data = data;
+    this.filename = filename;
+  });
+  const client = await createWwebjsClient();
+  await client.connect();
+  const buffer = Buffer.from('file');
+  await client.sendMessage('123', {
+    document: buffer,
+    mimetype: 'text/plain',
+    fileName: 'file.txt',
+  });
+  expect(MessageMedia).toHaveBeenCalledWith(
+    'text/plain',
+    buffer.toString('base64'),
+    'file.txt'
+  );
+  const mediaInstance = MessageMedia.mock.instances[0];
+  expect(mockClient.sendMessage).toHaveBeenCalledWith('123', mediaInstance, {
+    sendMediaAsDocument: true,
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow wwebjs adapter to send files by wrapping buffers in `MessageMedia`
- cover document sending in adapter tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b979860af48327b133e9d4515a3b95