### PR TITLE
Rename Ditbinmas data menu to absensi likes

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -211,47 +211,9 @@ async function formatRekapUserData(clientId, roleFlag = null) {
   ).trim();
 }
 
-async function rekapUserDataDitbinmas() {
-  const clientId = "ditbinmas";
-  const users = (await getUsersSocialByClient(clientId, clientId)).filter(
-    (u) => (u.client_id || "").toLowerCase() === clientId
-  );
-  const salam = getGreeting();
-  const now = new Date();
-  const hari = now.toLocaleDateString("id-ID", { weekday: "long" });
-  const tanggal = now.toLocaleDateString("id-ID", {
-    day: "2-digit",
-    month: "long",
-    year: "numeric",
-  });
-  const jam = now.toLocaleTimeString("id-ID", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  const groups = {};
-  users.forEach((u) => {
-    const div = u.divisi || "-";
-    if (!groups[div]) groups[div] = [];
-    groups[div].push(u);
-  });
-
-  const lines = sortDivisionKeys(Object.keys(groups)).map((div) => {
-    const list = groups[div]
-      .sort((a, b) => rankIdx(a.title) - rankIdx(b.title) || formatNama(a).localeCompare(formatNama(b)))
-      .map((u) => formatNama(u))
-      .join("\n");
-    return `${div.toUpperCase()} (${groups[div].length})\n${list}`;
-  });
-
-  const client = await findClientById(clientId);
-  const header =
-    `${salam},\n\n` +
-    `Mohon ijin Komandan, melaporkan rekap data personil ${
-      (client?.nama || clientId).toUpperCase()
-    } pada hari ${hari}, ${tanggal}, pukul ${jam} WIB, sebagai berikut:\n\n`;
-  const body = lines.join("\n\n");
-  return `${header}${body}`.trim();
+async function absensiLikesDitbinmas() {
+  const opts = { mode: "all", roleFlag: "ditbinmas", clientFilter: "ditbinmas" };
+  return await absensiLikes("DITBINMAS", opts);
 }
 
 async function performAction(action, clientId, waClient, chatId, roleFlag, userClientId) {
@@ -264,7 +226,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "2":
-      msg = await rekapUserDataDitbinmas();
+      msg = await absensiLikesDitbinmas();
       break;
     case "3": {
       const normalizedId = (clientId || "").toUpperCase();
@@ -429,7 +391,7 @@ export const dirRequestHandlers = {
       `Client: *${clientName}*\n` +
       "┏━━━ *MENU DIRREQUEST* ━━━\n" +
       "1️⃣ Rekap user belum lengkapi data\n" +
-      "2️⃣ Rekap user data Ditbinmas\n" +
+      "2️⃣ Absensi Likes Ditbinmas\n" +
       "3️⃣ Absensi Likes Instagram\n" +
       "4️⃣ Absensi Komentar TikTok\n" +
       "5️⃣ Fetch Insta\n" +
@@ -486,7 +448,7 @@ export const dirRequestHandlers = {
   },
 };
 
-export { formatRekapUserData, rekapUserDataDitbinmas };
+export { formatRekapUserData, absensiLikesDitbinmas };
 
 export default dirRequestHandlers;
 

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -151,19 +151,8 @@ test('formatRekapUserData orders users by rank', async () => {
   expect(idxAkp).toBeLessThan(idxIpda);
 });
 
-test('choose_menu option 2 rekap user data ditbinmas', async () => {
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date('2025-08-27T16:06:00Z'));
-
-  mockGetUsersSocialByClient.mockResolvedValue([
-    { client_id: 'ditbinmas', divisi: 'Sat A', title: 'AKP', nama: 'Budi' },
-    { client_id: 'ditbinmas', divisi: 'Sat A', title: 'Bripka', nama: 'Agus' },
-    { client_id: 'ditbinmas', divisi: 'Sat B', title: 'Kompol', nama: 'Charlie' },
-    { client_id: 'other', divisi: 'Sat C', title: 'Aiptu', nama: 'Dodi' },
-  ]);
-  mockFindClientById.mockImplementation(async (cid) => ({
-    ditbinmas: { nama: 'DIT BINMAS' },
-  })[cid]);
+test('choose_menu option 2 absensi likes ditbinmas', async () => {
+  mockAbsensiLikes.mockResolvedValue('laporan');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '321';
@@ -171,18 +160,12 @@ test('choose_menu option 2 rekap user data ditbinmas', async () => {
 
   await dirRequestHandlers.choose_menu(session, chatId, '2', waClient);
 
-  expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
-  const msg = waClient.sendMessage.mock.calls[0][1];
-  expect(msg).toContain('SAT A (2)');
-  expect(msg).toContain('AKP Budi');
-  expect(msg).toContain('Bripka Agus');
-  const idxAkp = msg.indexOf('AKP Budi');
-  const idxBripka = msg.indexOf('Bripka Agus');
-  expect(idxAkp).toBeLessThan(idxBripka);
-  expect(msg).toContain('SAT B (1)');
-  expect(msg).toContain('Kompol Charlie');
-  expect(msg).not.toMatch(/Aiptu Dodi/);
-  jest.useRealTimers();
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
+    mode: 'all',
+    roleFlag: 'ditbinmas',
+    clientFilter: 'ditbinmas',
+  });
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan');
 });
 
 test('choose_menu option 3 absensi likes uses ditbinmas data for all users', async () => {


### PR DESCRIPTION
## Summary
- rename dirrequest option from "Rekap user data Ditbinmas" to "Absensi Likes Ditbinmas"
- use `absensiLikes` to recap likes for Ditbinmas users only

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b994fcff648327a05f20b2677eedbb