### PR TITLE
Restrict DirRequest Ditbinmas absensi likes to DITBINMAS users

### DIFF
--- a/src/cron/cronDirRequestAbsensiLikes.js
+++ b/src/cron/cronDirRequestAbsensiLikes.js
@@ -25,7 +25,11 @@ async function runAbsensi(chatIds) {
       return;
     }
     await handleFetchLikesInstagram(null, null, "DITBINMAS");
-    const msg = await absensiLikes("DITBINMAS", { mode: "all", roleFlag: "ditbinmas" });
+    const msg = await absensiLikes("DITBINMAS", {
+      mode: "all",
+      roleFlag: "ditbinmas",
+      clientFilter: "DITBINMAS",
+    });
     if (msg) {
       for (const wa of chatIds) {
         await waClient.sendMessage(wa, msg).catch(() => {});

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -237,7 +237,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
         break;
       }
-      const opts = { mode: "all", roleFlag: "ditbinmas" };
+      const opts = { mode: "all", roleFlag: "ditbinmas", clientFilter: "DITBINMAS" };
       msg = await absensiLikes("DITBINMAS", opts);
       break;
     }

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -92,6 +92,24 @@ test('roleFlag uses directorate logic even if client is not directorate', async 
   expect(mockGetUsersByClient).not.toHaveBeenCalled();
 });
 
+test('directorate clientFilter restricts users to specified client', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ nama: 'DITBINMAS', client_type: 'direktorat' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'DITBINMAS', client_type: 'direktorat' }] });
+  mockGetUsersByDirektorat.mockResolvedValueOnce([]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
+  mockGetLikesByShortcode.mockResolvedValueOnce([]);
+
+  await absensiLikes('DITBINMAS', {
+    roleFlag: 'ditbinmas',
+    clientFilter: 'DITBINMAS',
+  });
+
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'DITBINMAS');
+  expect(mockGetClientsByRole).not.toHaveBeenCalled();
+  expect(mockGetUsersByClient).not.toHaveBeenCalled();
+});
+
 test('filters users by role when roleFlag provided for polres', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_type: 'instansi' }] });
   mockGetUsersByClient.mockResolvedValueOnce([]);

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -184,6 +184,7 @@ test('choose_menu option 3 absensi likes uses ditbinmas data for all users', asy
   expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
     mode: 'all',
     roleFlag: 'ditbinmas',
+    clientFilter: 'DITBINMAS',
   });
 });
 


### PR DESCRIPTION
## Summary
- Limit DirRequest absensi likes for Ditbinmas to DITBINMAS client users
- Pass client filter in Ditbinmas absensi likes cron job
- Test DirRequest handler and absensi likes filtering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99e0cfb888327b010093c20bb82b6