### PR TITLE
Apply Ditbinmas filters for dirrequest likes

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -1,9 +1,5 @@
 import { getUsersSocialByClient, getClientsByRole } from "../../model/userModel.js";
-import {
-  absensiLikes,
-  lapharDitbinmas,
-  absensiLikesDitbinmasReport,
-} from "../fetchabsensi/insta/absensiLikesInsta.js";
+import { absensiLikes, lapharDitbinmas } from "../fetchabsensi/insta/absensiLikesInsta.js";
 import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
@@ -216,7 +212,10 @@ async function formatRekapUserData(clientId, roleFlag = null) {
 }
 
 async function absensiLikesDitbinmas() {
-  return await absensiLikesDitbinmasReport();
+  return await absensiLikes("DITBINMAS", {
+    mode: "all",
+    roleFlag: "ditbinmas",
+  });
 }
 
 async function performAction(action, clientId, waClient, chatId, roleFlag, userClientId) {

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -5,7 +5,6 @@ process.env.TZ = 'Asia/Jakarta';
 const mockGetUsersSocialByClient = jest.fn();
 const mockGetClientsByRole = jest.fn();
 const mockAbsensiLikes = jest.fn();
-const mockAbsensiLikesDitbinmasReport = jest.fn();
 const mockAbsensiKomentar = jest.fn();
 const mockFindClientById = jest.fn();
 const mockFetchAndStoreInstaContent = jest.fn();
@@ -23,7 +22,6 @@ jest.unstable_mockModule('../src/handler/fetchabsensi/insta/absensiLikesInsta.js
   absensiLikes: mockAbsensiLikes,
   rekapLikesIG: mockRekapLikesIG,
   lapharDitbinmas: mockLapharDitbinmas,
-  absensiLikesDitbinmasReport: mockAbsensiLikesDitbinmasReport,
 }));
 jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js', () => ({
   absensiKomentar: mockAbsensiKomentar,
@@ -154,7 +152,7 @@ test('formatRekapUserData orders users by rank', async () => {
 });
 
 test('choose_menu option 2 absensi likes ditbinmas', async () => {
-  mockAbsensiLikesDitbinmasReport.mockResolvedValue('laporan');
+  mockAbsensiLikes.mockResolvedValue('laporan');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '321';
@@ -162,7 +160,10 @@ test('choose_menu option 2 absensi likes ditbinmas', async () => {
 
   await dirRequestHandlers.choose_menu(session, chatId, '2', waClient);
 
-  expect(mockAbsensiLikesDitbinmasReport).toHaveBeenCalled();
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
+    mode: 'all',
+    roleFlag: 'ditbinmas',
+  });
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan');
 });
 


### PR DESCRIPTION
## Summary
- Filter `Absensi Likes Ditbinmas` menu to use Ditbinmas client and role
- Adjust dirRequest handlers tests for updated filter behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9af7a09a883278ae56bc1fac86fa0