### PR TITLE
Improve Laphar Ditbinmas narrative and analytics

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -298,6 +298,9 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       case "9": {
         const { text, filename, narrative, textBelum, filenameBelum } =
           await lapharDitbinmas();
+        if (narrative) {
+          await waClient.sendMessage(chatId, narrative.trim());
+        }
         const buffer = Buffer.from(text, "utf-8");
         await writeFile(filename, buffer);
         await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
@@ -312,8 +315,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
             "text/plain"
           );
         }
-        msg = narrative || "✅ Laphar Ditbinmas dikirim.";
-        break;
+        return;
       }
     default:
       msg = "Menu tidak dikenal.";

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -276,5 +276,9 @@ test('choose_menu option 9 sends laphar file and narrative', async () => {
     chatId,
     'text/plain'
   );
+  expect(waClient.sendMessage.mock.calls[0][0]).toBe(chatId);
   expect(waClient.sendMessage.mock.calls[0][1]).toBe('narasi');
+  expect(waClient.sendMessage.mock.invocationCallOrder[0]).toBeLessThan(
+    mockWriteFile.mock.invocationCallOrder[0],
+  );
 });

--- a/tests/lapharDitbinmas.test.js
+++ b/tests/lapharDitbinmas.test.js
@@ -61,8 +61,9 @@ test('orders clients by likes with ditbinmas first and returns narrative', async
   expect(idxA).toBeLessThan(idxB);
   expect(result.narrative).toMatch(/POLRES A 1/);
   expect(result.narrative).toMatch(/Kontributor likes terbesar/);
-  expect(result.narrative).toMatch(/Anomali/);
-  expect(result.narrative).toMatch(/nihil/);
+  expect(result.narrative).toMatch(/Absensi Update Data/);
+  expect(result.narrative).toMatch(/Highlight Pencapaian/);
+  expect(result.narrative).toMatch(/Konsentrasi Backlog/);
   expect(result.filename).toMatch(/^Absensi_All_Likes_IG_Ditbinmas_/);
   expect(result.filenameBelum).toMatch(/^Absensi_Belum_Likes_IG_Ditbinmas_/);
   expect(result.textBelum).toMatch(/Belum Input Sosial media/);


### PR DESCRIPTION
## Summary
- Send Laphar Ditbinmas narrative before attaching report files
- Expand absensi analysis to calculate coverage, averages, top/bottom performers, and backlog projections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b5a16bcc8327a2a76d0b64f6c4dd