### PR TITLE
feat: include missing social data counts

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -109,7 +109,8 @@ async function formatRekapUserData(clientId, roleFlag = null) {
         `Jumlah Total Personil : ${e.stat.total}\n` +
         `Jumlah Total Personil Sudah Mengisi Instagram : ${e.stat.insta}\n` +
         `Jumlah Total Personil Sudah Mengisi Tiktok : ${e.stat.tiktok}\n` +
-        `Jumlah Total User Belum Update Data : ${e.stat.total - e.stat.complete}`
+        `Jumlah Total Personil Belum Mengisi Instagram : ${e.stat.total - e.stat.insta}\n` +
+        `Jumlah Total Personil Belum Mengisi Tiktok : ${e.stat.total - e.stat.tiktok}`
     );
     const noDataLines = noData.map((e, idx) => `${idx + 1}. ${e.name}`);
 
@@ -134,7 +135,8 @@ async function formatRekapUserData(clientId, roleFlag = null) {
       `Jumlah Total Personil : ${totals.total}\n` +
         `Jumlah Total Personil Sudah Mengisi Instagram : ${totals.insta}\n` +
         `Jumlah Total Personil Sudah Mengisi Tiktok : ${totals.tiktok}\n` +
-        `Jumlah Total User Belum Update Data : ${totals.total - totals.complete}`,
+        `Jumlah Total Personil Belum Mengisi Instagram : ${totals.total - totals.insta}\n` +
+        `Jumlah Total Personil Belum Mengisi Tiktok : ${totals.total - totals.tiktok}`,
     ];
     if (withDataLines.length)
       sections.push(`Sudah Input Data:\n\n${withDataLines.join("\n\n")}`);

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -94,7 +94,8 @@ test('choose_menu aggregates directorate data by client_id', async () => {
   expect(msg).toMatch(/Jumlah Total Personil : 2/);
   expect(msg).toMatch(/Jumlah Total Personil Sudah Mengisi Instagram : 1/);
   expect(msg).toMatch(/Jumlah Total Personil Sudah Mengisi Tiktok : 1/);
-  expect(msg).toMatch(/Jumlah Total User Belum Update Data : 1/);
+  expect(msg).toMatch(/Jumlah Total Personil Belum Mengisi Instagram : 1/);
+  expect(msg).toMatch(/Jumlah Total Personil Belum Mengisi Tiktok : 1/);
   const idxBinmas = msg.indexOf('DIT BINMAS');
   const idxPasuruan = msg.indexOf('POLRES PASURUAN KOTA');
   expect(idxBinmas).toBeLessThan(idxPasuruan);


### PR DESCRIPTION
## Summary
- show counts of personnel missing Instagram and TikTok data in dirrequest recap
- adjust report tests for new recap format

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba2967292c832785ba643a815978df