### PR TITLE
Align dirrequest cron schedules with operational needs

### DIFF
--- a/src/cron/cronDirRequest.js
+++ b/src/cron/cronDirRequest.js
@@ -17,54 +17,37 @@ async function getActiveClients() {
   return rows.rows;
 }
 
-function toWAid(number) {
-  if (!number || typeof number !== "string") return null;
-  const no = number.trim();
-  if (!no) return null;
-  if (no.endsWith("@c.us")) return no;
-  return no.replace(/\D/g, "") + "@c.us";
-}
-
-function getAdminWAIds() {
-  return (process.env.ADMIN_WHATSAPP || "")
-    .split(",")
-    .map((n) => n.trim())
-    .filter(Boolean)
-    .map(toWAid)
-    .filter(Boolean);
-}
-
+const groupId = "120363419830216549@g.us";
 const cronTag = "CRON DIRREQUEST";
+const options = { timezone: "Asia/Jakarta" };
 
-cron.schedule(
-  "3 7-20 * * *",
-  async () => {
-    sendDebug({ tag: cronTag, msg: "Mulai rekap dirrequest" });
-    try {
-      const admins = getAdminWAIds();
-      const clients = await getActiveClients();
-      for (const client of clients) {
-        try {
-          const msg1 = await formatRekapUserData(client.client_id);
-          for (const wa of admins) {
-            await waClient.sendMessage(wa, msg1).catch(() => {});
-          }
-          sendDebug({
-            tag: cronTag,
-            msg: `[${client.client_id}] Rekap menu 1 dikirim ke ${admins.length} admin`,
-          });
-        } catch (err) {
-          sendDebug({
-            tag: cronTag,
-            msg: `[${client.client_id}] ERROR menu 1: ${err.message}`,
-          });
+async function runRekap(chatIds) {
+  sendDebug({ tag: cronTag, msg: "Mulai rekap dirrequest" });
+  try {
+    const clients = await getActiveClients();
+    for (const client of clients) {
+      try {
+        const msg1 = await formatRekapUserData(client.client_id);
+        for (const wa of chatIds) {
+          await waClient.sendMessage(wa, msg1).catch(() => {});
         }
+        sendDebug({
+          tag: cronTag,
+          msg: `[${client.client_id}] Rekap menu 1 dikirim ke ${chatIds.length} target`,
+        });
+      } catch (err) {
+        sendDebug({
+          tag: cronTag,
+          msg: `[${client.client_id}] ERROR menu 1: ${err.message}`,
+        });
       }
-    } catch (err) {
-      sendDebug({ tag: cronTag, msg: `[ERROR GLOBAL] ${err.message || err}` });
     }
-  },
-  { timezone: "Asia/Jakarta" }
-);
+  } catch (err) {
+    sendDebug({ tag: cronTag, msg: `[ERROR GLOBAL] ${err.message || err}` });
+  }
+}
+
+cron.schedule("0 15,18 * * *", () => runRekap([groupId]), options);
+cron.schedule("30 20 * * *", () => runRekap([groupId]), options);
 
 export default null;

--- a/src/cron/cronDirRequestAbsensiLikes.js
+++ b/src/cron/cronDirRequestAbsensiLikes.js
@@ -39,16 +39,12 @@ async function runAbsensi(chatIds) {
 
 const options = { timezone: "Asia/Jakarta" };
 
-cron.schedule("12 15 * * *", () => runAbsensi([dirRequestGroup]), options);
-cron.schedule("12 18 * * *", () => runAbsensi([dirRequestGroup]), options);
+cron.schedule("0 15 * * *", () => runAbsensi([dirRequestGroup]), options);
+cron.schedule("0 18 * * *", () => runAbsensi([dirRequestGroup]), options);
+cron.schedule("30 20 * * *", () => runAbsensi([dirRequestGroup]), options);
 cron.schedule(
-  "12 20 * * *",
-  () => runAbsensi([dirRequestGroup, dirRequestNumber, ...getAdminWAIds()]),
-  options
-);
-cron.schedule(
-  "12 22 * * 4",
-  () => runAbsensi([dirRequestGroup, dirRequestNumber, ...getAdminWAIds()]),
+  "30 20 * * *",
+  () => runAbsensi([dirRequestNumber, ...getAdminWAIds()]),
   options
 );
 

--- a/src/cron/cronDirRequestFetchInsta.js
+++ b/src/cron/cronDirRequestFetchInsta.js
@@ -25,7 +25,7 @@ const groupId = "120363419830216549@g.us";
 const cronTag = "CRON DIRREQUEST FETCH INSTA";
 
 cron.schedule(
-  "0,30 6-21 * * *",
+  "15,45 6-19 * * *",
   async () => {
     sendDebug({ tag: cronTag, msg: "Mulai fetch Instagram DITBINMAS" });
     try {

--- a/src/cron/cronDirRequestLaphar.js
+++ b/src/cron/cronDirRequestLaphar.js
@@ -5,7 +5,8 @@ dotenv.config();
 import waClient from "../service/waService.js";
 import { sendDebug } from "../middleware/debugHandler.js";
 import { lapharDitbinmas } from "../handler/fetchabsensi/insta/absensiLikesInsta.js";
-import { sendWAFile } from "../utils/waHelper.js";
+import { sendWAFile, getAdminWAIds } from "../utils/waHelper.js";
+import { handleFetchLikesInstagram } from "../handler/fetchengagement/fetchLikesInstagram.js";
 
 const cronTag = "CRON DIRREQUEST LAPHAR";
 const dirRequestGroup = "120363419830216549@g.us";
@@ -14,6 +15,7 @@ const dirRequestNumber = "6281234560377@c.us";
 async function sendLaphar(chatIds) {
   sendDebug({ tag: cronTag, msg: "Mulai rekap laphar dirrequest" });
   try {
+    await handleFetchLikesInstagram(null, null, "DITBINMAS");
     const {
       text,
       filename,
@@ -60,9 +62,17 @@ cron.schedule(
 );
 
 cron.schedule(
-  "0 20 * * *",
+  "30 20 * * *",
   async () => {
-    await sendLaphar([dirRequestGroup, dirRequestNumber]);
+    await sendLaphar([dirRequestGroup]);
+  },
+  options
+);
+
+cron.schedule(
+  "30 20 * * *",
+  async () => {
+    await sendLaphar([dirRequestNumber, ...getAdminWAIds()]);
   },
   options
 );


### PR DESCRIPTION
## Summary
- Run Instagram fetch & like sync for Ditbinmas at minute 15 and 45 from 06:00-19:00
- Send rekap user data to Ditbinmas group at 15:00, 18:00 and 20:30
- Deliver absensi likes and laphar Ditbinmas to group, wadir and admins per new 15:00/18:00/20:30 schedule, ensuring likes are fetched before laphar

## Testing
- ✅ `npm run lint`
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5917d1f08327a2bef9bd0ab01adf