### PR TITLE
Filter IG cron clients by ORG type

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -391,7 +391,8 @@ export async function getActiveClientsIG() {
      FROM clients
      WHERE client_status = true
        AND (client_insta_status = true OR client_amplify_status = true)
-       AND client_insta IS NOT NULL`
+       AND client_insta IS NOT NULL
+       AND LOWER(client_type) = 'org'`
   );
   return res.rows;
 }


### PR DESCRIPTION
## Summary
- restrict cronInstaService client query to `client_type` ORG

## Testing
- `npm run lint` *(fails: npm not installed in container)*
- `npm test` *(not run: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba53f8d62483279bcdc2429c24317d