### PR TITLE
Add bottom-performer note to Ditbinmas laphar

### DIFF
--- a/src/cron/cronAbsensiOprDitbinmas.js
+++ b/src/cron/cronAbsensiOprDitbinmas.js
@@ -1,0 +1,10 @@
+import waClient from "../service/waService.js";
+import { sendWAReport, getAdminWAIds } from "../utils/waHelper.js";
+import { absensiRegistrasiDashboardDitbinmas } from "../handler/fetchabsensi/dashboard/absensiRegistrasiDashboardDitbinmas.js";
+
+export async function runCron() {
+  const message = await absensiRegistrasiDashboardDitbinmas();
+  await sendWAReport(waClient, message, getAdminWAIds());
+}
+
+export default null;

--- a/src/cron/cronAbsensiUserData.js
+++ b/src/cron/cronAbsensiUserData.js
@@ -1,0 +1,33 @@
+import waClient from "../service/waService.js";
+import { sendWAReport, getAdminWAIds } from "../utils/waHelper.js";
+import { getClientsByRole, getUsersMissingDataByClient } from "../model/userModel.js";
+import { query } from "../db/index.js";
+
+export async function runCron() {
+  await getClientsByRole("ditbinmas");
+  const { rows } = await query("SELECT client_id, nama, client_type FROM client", []);
+  const filtered = rows || [];
+  filtered.sort((a, b) => {
+    if (a.client_id === "DITBINMAS") return -1;
+    if (b.client_id === "DITBINMAS") return 1;
+    if (a.client_type === b.client_type) return a.nama.localeCompare(b.nama);
+    return a.client_type === "direktorat" ? -1 : 1;
+  });
+  const lines = [];
+  for (let i = 0; i < filtered.length; i++) {
+    const c = filtered[i];
+    lines.push(`${i + 1}. ${c.nama}`);
+    const users = await getUsersMissingDataByClient(c.client_id);
+    users.forEach((u) => {
+      lines.push(
+        `- ${u.nama} (${u.user_id}): Belum Registrasi Whatsapp, Instagram ${
+          u.insta || "Kosong"
+        }, Tiktok ${u.tiktok || "Kosong"}`
+      );
+    });
+  }
+  const message = lines.join("\n");
+  await sendWAReport(waClient, message, getAdminWAIds());
+}
+
+export default null;

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -930,6 +930,11 @@ export async function lapharDitbinmas() {
   const notesLines = [];
   if (backlogBig.length)
     notesLines.push(`* *${backlogBig.join(', ')}* → backlog terbesar;`);
+  const bottomPerformerNames = bottomPerformersArr.map((p) => p.name);
+  if (bottomPerformerNames.length)
+    notesLines.push(
+      `* *${bottomPerformerNames.join(', ')}* → Input Username Ter rendah;`
+    );
   if (largestGapPos)
     notesLines.push(
       `* *${largestGapPos.name}* → Anomali TT sangat rendah; Menjadi perhatian khusus.`


### PR DESCRIPTION
## Summary
- highlight five satkers with the lowest IG/TT username input ratio in laphar Ditbinmas notes
- add cronAbsensiUserData and cronAbsensiOprDitbinmas modules for reporting utilities

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5d226db08327aca1731dfa754716