### PR TITLE
feat: highlight satker with lowest username input

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -923,6 +923,7 @@ export async function lapharDitbinmas() {
       (a, b) => (b.tiktokPercent - b.igPercent) - (a.tiktokPercent - a.igPercent)
     )[0];
   const mentorList = topPerformers.map((p) => p.name);
+  const lowestInput = bottomPerformersArr.map((p) => p.name);
   const bestSatkerNames = bestSatkers.map((p) => p.name);
   const strongSatkerList = strongSatkers.map(
     (p) => `${p.name} (${p.igPercent.toFixed(1)}% / ${p.tiktokPercent.toFixed(1)}%)`
@@ -930,6 +931,10 @@ export async function lapharDitbinmas() {
   const notesLines = [];
   if (backlogBig.length)
     notesLines.push(`* *${backlogBig.join(', ')}* → backlog terbesar;`);
+  if (lowestInput.length)
+    notesLines.push(
+      `* *${lowestInput.join(', ')}* → Input Username Ter rendah`
+    );
   if (largestGapPos)
     notesLines.push(
       `* *${largestGapPos.name}* → Anomali TT sangat rendah; Menjadi perhatian khusus.`

--- a/tests/lapharDitbinmas.test.js
+++ b/tests/lapharDitbinmas.test.js
@@ -64,6 +64,7 @@ test('orders clients by likes with ditbinmas first and returns narrative', async
   expect(result.narrative).toMatch(/Absensi Update Data/);
   expect(result.narrative).toMatch(/Highlight Pencapaian/);
   expect(result.narrative).toMatch(/Konsentrasi Backlog/);
+  expect(result.narrative).toMatch(/Input Username Ter rendah/);
   expect(result.filename).toMatch(/^Absensi_All_Likes_IG_Ditbinmas_/);
   expect(result.filenameBelum).toMatch(/^Absensi_Belum_Likes_IG_Ditbinmas_/);
   expect(result.textBelum).toMatch(/Belum Input Sosial media/);


### PR DESCRIPTION
## Summary
- include bottom-five satker list in Ditbinmas laphar notes
- test for presence of lowest username input note

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '../src/cron/cronAbsensiUserData.js' and '../src/cron/cronAbsensiOprDitbinmas.js')*


------
https://chatgpt.com/codex/tasks/task_e_68ba5e6987f88327b4ac044425816d18