### PR TITLE
Bold division names in DITBINMAS incomplete data recap

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -256,7 +256,7 @@ async function formatRekapBelumLengkapDitbinmas() {
       )
       .map((u) => `${formatNama(u)}, ${u.missing}`)
       .join("\n\n");
-    return `${d.toUpperCase()} (${incomplete[d].length})\n\n${list}`;
+    return `*${d.toUpperCase()}* (${incomplete[d].length})\n\n${list}`;
   });
   const body = lines.length
     ? lines.join("\n\n")

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -319,13 +319,13 @@ test('choose_menu option 11 reports ditbinmas incomplete users by division', asy
 
   expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('DITBINMAS', 'ditbinmas');
   const msg = waClient.sendMessage.mock.calls[0][1];
-  expect(msg).toMatch(/DIV A \(2\)/);
+  expect(msg).toMatch(/\*DIV A\* \(2\)/);
   expect(msg).toMatch(/AKP Budi, Instagram kosong/);
   expect(msg).toMatch(/IPTU Adi, TikTok kosong/);
   const idxBudi = msg.indexOf('AKP Budi');
   const idxAdi = msg.indexOf('IPTU Adi');
   expect(idxBudi).toBeLessThan(idxAdi);
-  expect(msg).toMatch(/DIV B \(1\)/);
+  expect(msg).toMatch(/\*DIV B\* \(1\)/);
   expect(msg).toMatch(/KOMPOL Cici, Instagram kosong, TikTok kosong/);
   expect(msg).not.toMatch(/Edi/);
 });


### PR DESCRIPTION
## Summary
- highlight division names in `dirrequest` menu 11 by wrapping them in bold
- align tests with updated bold formatting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6e3c5ab483278dfe132f793b57da