### PR TITLE
Remove exception flag from Instagram like attendance

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -21,7 +21,7 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
 }
 ```
 
-- **sudahUsers** – usernames that liked at least 50% of posts or are marked as exception.
+- **sudahUsers** – usernames that liked at least 50% of posts.
 - **kurangUsers** – usernames that liked some posts but less than 50%.
 - **belumUsers** – usernames that did not like any posts.
 - **belumUsersCount** – users who did not like any posts **or** have no Instagram username.

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -78,9 +78,7 @@ export async function getInstaRekapLikes(req, res) {
     const noUsernameUsers = [];
 
     rows.forEach((u) => {
-      if (u.exception === true) {
-        sudahUsers.push(u.username);
-      } else if (!u.username || u.username.trim() === "") {
+      if (!u.username || u.username.trim() === "") {
         noUsernameUsers.push(u.username);
       } else if (u.jumlah_like >= threshold) {
         sudahUsers.push(u.username);

--- a/src/controller/likesController.js
+++ b/src/controller/likesController.js
@@ -27,9 +27,7 @@ export async function getDitbinmasLikes(req, res) {
     const noUsernameUsers = [];
 
     rows.forEach((u) => {
-      if (u.exception === true) {
-        sudahUsers.push(u.username);
-      } else if (!u.username || u.username.trim() === "") {
+      if (!u.username || u.username.trim() === "") {
         noUsernameUsers.push(u.username);
       } else if (u.jumlah_like >= threshold) {
         sudahUsers.push(u.username);

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -81,17 +81,6 @@ export async function absensiLikes(client_id, opts = {}) {
       usersByClient[cid].push(u);
     });
 
-    const exceptionUsernames = allUsers
-      .filter(
-        (u) =>
-          u.exception === true &&
-          u.insta &&
-          u.insta.trim() !== ""
-      )
-      .map((u) => normalizeUsername(u.insta));
-    likesSets.forEach((set) => {
-      exceptionUsernames.forEach((uname) => set.add(uname));
-    });
 
     const totalKonten = shortcodes.length;
     const reportEntries = [];
@@ -105,10 +94,6 @@ export async function absensiLikes(client_id, opts = {}) {
       const belum = [];
       const tanpaUsername = [];
       users.forEach((u) => {
-        if (u.exception === true) {
-          sudah.push(u);
-          return;
-        }
         if (!u.insta || u.insta.trim() === "") {
           tanpaUsername.push(u);
           return;
@@ -202,9 +187,7 @@ export async function absensiLikes(client_id, opts = {}) {
   let sudah = [], belum = [];
 
   Object.values(userStats).forEach((u) => {
-    if (u.exception === true) {
-      sudah.push(u); // selalu masuk ke sudah!
-    } else if (
+    if (
       u.insta &&
       u.insta.trim() !== "" &&
       u.count >= threshold
@@ -214,9 +197,6 @@ export async function absensiLikes(client_id, opts = {}) {
       belum.push(u);
     }
   });
-
-  // Hapus user exception dari list belum!
-  belum = belum.filter((u) => !u.exception);
 
   const kontenLinks = shortcodes.map(
     (sc) => `https://www.instagram.com/p/${sc}`
@@ -315,32 +295,18 @@ export async function absensiLikesPerKonten(client_id, opts = {}) {
     `📋 *Rekap Per Konten Likes Instagram*\n*Polres*: *${clientNama}*\n${hari}, ${tanggal}\nJam: ${jam}\n\n` +
     `*Jumlah Konten:* ${shortcodes.length}\n`;
 
-  const exceptionUsernames = users
-    .filter(
-      (u) =>
-        u.exception === true &&
-        u.insta &&
-        u.insta.trim() !== ""
-    )
-    .map((u) => normalizeUsername(u.insta));
-
   for (const sc of shortcodes) {
     const likes = await getLikesByShortcode(sc);
     const likesSet = new Set((likes || []).map(normalizeUsername));
-    exceptionUsernames.forEach((uname) => likesSet.add(uname));
     let userSudah = [];
     let userBelum = [];
     users.forEach((u) => {
-      if (u.exception === true) {
-        userSudah.push(u); // Selalu ke sudah!
-      } else if (u.insta && u.insta.trim() !== "" && likesSet.has(normalizeUsername(u.insta))) {
+      if (u.insta && u.insta.trim() !== "" && likesSet.has(normalizeUsername(u.insta))) {
         userSudah.push(u);
       } else {
         userBelum.push(u);
       }
     });
-    // Hilangkan user exception dari belum!
-    userBelum = userBelum.filter(u => !u.exception);
 
     // Header per konten
     msg += `\nKonten: https://www.instagram.com/p/${sc}\n`;
@@ -464,10 +430,6 @@ export async function absensiLikesDitbinmasReport() {
   const noUsername = [];
 
   allUsers.forEach((u) => {
-    if (u.exception === true) {
-      already.push({ ...u, count: shortcodes.length });
-      return;
-    }
     if (!u.insta || u.insta.trim() === "") {
       noUsername.push(u);
       return;
@@ -605,16 +567,7 @@ export async function lapharDitbinmas() {
     usersByClient[cid].push(u);
   });
 
-  const exceptionUsernames = allUsers
-    .filter(
-      (u) =>
-        u.exception === true &&
-        u.insta &&
-        u.insta.trim() !== ""
-    )
-    .map((u) => normalizeUsername(u.insta));
   likesSets.forEach((set, idx) => {
-    exceptionUsernames.forEach((uname) => set.add(uname));
     likesCounts[idx] = set.size;
   });
   const kontenLinkLikes = kontenLinks.map(

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -185,7 +185,7 @@ test('absensiLikesDitbinmasReport filters users by client_id DITBINMAS', async (
   expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'DITBINMAS');
 });
 
-test('lapharDitbinmas counts exception usernames as likes', async () => {
+test('lapharDitbinmas does not count exception usernames as likes', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'DITBINMAS', client_type: 'direktorat' }] });
   mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
   mockGetLikesByShortcode.mockResolvedValueOnce([]);
@@ -203,6 +203,6 @@ test('lapharDitbinmas counts exception usernames as likes', async () => {
 
   const result = await lapharDitbinmas();
 
-  expect(result.narrative).toMatch(/https:\/\/www.instagram.com\/p\/sc1 : 1/);
+  expect(result.narrative).toMatch(/https:\/\/www.instagram.com\/p\/sc1 : 0/);
 });
 


### PR DESCRIPTION
## Summary
- drop automatic inclusion of `exception` users from Instagram like attendance reports
- update controllers and docs to reflect new behavior
- adjust tests for exception handling removal

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7c9b9f38832793a018b02ce3b710