### PR TITLE
Handle exception users when Instagram likes exceed 50

### DIFF
--- a/src/handler/fetchengagement/fetchLikesInstagram.js
+++ b/src/handler/fetchengagement/fetchLikesInstagram.js
@@ -42,19 +42,27 @@ async function getExistingLikes(shortcode) {
  */
 async function fetchAndStoreLikes(shortcode, client_id = null) {
   const allLikes = await fetchAllInstagramLikes(shortcode);
-
   const uniqueLikes = [...new Set(allLikes.map(normalizeUsername))];
-  const existingLikes = await getExistingLikes(shortcode);
-  const mergedSet = new Set([...existingLikes, ...uniqueLikes]);
 
-  if (mergedSet.size > 50 && client_id) {
-    const exceptionUsers = await getExceptionUsersByClient(client_id);
-    for (const u of exceptionUsers) {
-      const uname = normalizeUsername(u.insta);
-      if (uname) mergedSet.add(uname);
+  let limitedLikes = uniqueLikes;
+  if (uniqueLikes.length > 50) {
+    limitedLikes = uniqueLikes.slice(0, 50);
+    if (client_id) {
+      const exceptionUsers = await getExceptionUsersByClient(client_id);
+      const exceptionSet = new Set(
+        exceptionUsers.map((u) => normalizeUsername(u.insta))
+      );
+      for (const uname of uniqueLikes) {
+        if (exceptionSet.has(uname)) {
+          limitedLikes.push(uname);
+        }
+      }
+      limitedLikes = [...new Set(limitedLikes)];
     }
   }
 
+  const existingLikes = await getExistingLikes(shortcode);
+  const mergedSet = new Set([...existingLikes, ...limitedLikes]);
   const mergedLikes = [...mergedSet];
   sendDebug({
     tag: "IG LIKES FINAL",


### PR DESCRIPTION
## Summary
- Limit stored Instagram likes to the first 50 usernames
- Append exception users' Instagram usernames when likes exceed 50

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba803ac9c48327aef2953624016e78