### PR TITLE
Remove client filter for exception user fetch in IG likes

### DIFF
--- a/src/handler/fetchengagement/fetchLikesInstagram.js
+++ b/src/handler/fetchengagement/fetchLikesInstagram.js
@@ -3,7 +3,7 @@
 import { query } from "../../db/index.js";
 import { sendDebug } from "../../middleware/debugHandler.js";
 import { fetchAllInstagramLikes } from "../../service/instagramApi.js";
-import { getExceptionUsersByClient } from "../../model/userModel.js";
+import { getExceptionUsers } from "../../model/userModel.js";
 
 function normalizeUsername(username) {
   return (username || "")
@@ -47,18 +47,16 @@ async function fetchAndStoreLikes(shortcode, client_id = null) {
   let limitedLikes = uniqueLikes;
   if (uniqueLikes.length > 50) {
     limitedLikes = uniqueLikes.slice(0, 50);
-    if (client_id) {
-      const exceptionUsers = await getExceptionUsersByClient(client_id);
-      const exceptionSet = new Set(
-        exceptionUsers.map((u) => normalizeUsername(u.insta))
-      );
-      for (const uname of uniqueLikes) {
-        if (exceptionSet.has(uname)) {
-          limitedLikes.push(uname);
-        }
+    const exceptionUsers = await getExceptionUsers();
+    const exceptionSet = new Set(
+      exceptionUsers.map((u) => normalizeUsername(u.insta))
+    );
+    for (const uname of uniqueLikes) {
+      if (exceptionSet.has(uname)) {
+        limitedLikes.push(uname);
       }
-      limitedLikes = [...new Set(limitedLikes)];
     }
+    limitedLikes = [...new Set(limitedLikes)];
   }
 
   const existingLikes = await getExistingLikes(shortcode);

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -359,6 +359,14 @@ export async function getExceptionUsersByClient(client_id, roleFilter = null) {
   return rows;
 }
 
+// Ambil semua user dengan exception tanpa filter client
+export async function getExceptionUsers() {
+  const { rows } = await query(
+    'SELECT * FROM "user" u WHERE exception = true'
+  );
+  return rows;
+}
+
 // Ambil user dengan flag direktorat binmas atau lantas
 export async function getDirektoratUsers(clientId = null) {
   let sql = `SELECT u.*,\n    bool_or(r.role_name='ditbinmas') AS ditbinmas,\n    bool_or(r.role_name='ditlantas') AS ditlantas,\n    bool_or(r.role_name='bidhumas') AS bidhumas\n  FROM "user" u\n  JOIN user_roles ur ON u.user_id = ur.user_id\n  JOIN roles r ON ur.role_id = r.role_id\n  WHERE r.role_name IN ('ditbinmas','ditlantas','bidhumas')`;


### PR DESCRIPTION
## Summary
- Add `getExceptionUsers` to retrieve all exception-marked users without client filter
- Update Instagram likes fetch to use `getExceptionUsers` so exceptions are honored globally

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba85c40c3483278a339015f463a080