### PR TITLE
Remove client-specific filtering for Instagram likes exceptions

### DIFF
--- a/src/handler/fetchengagement/fetchLikesInstagram.js
+++ b/src/handler/fetchengagement/fetchLikesInstagram.js
@@ -3,7 +3,7 @@
 import { query } from "../../db/index.js";
 import { sendDebug } from "../../middleware/debugHandler.js";
 import { fetchAllInstagramLikes } from "../../service/instagramApi.js";
-import { getExceptionUsersByClient } from "../../model/userModel.js";
+import { getAllExceptionUsers } from "../../model/userModel.js";
 
 function normalizeUsername(username) {
   return (username || "")
@@ -47,18 +47,16 @@ async function fetchAndStoreLikes(shortcode, client_id = null) {
   let limitedLikes = uniqueLikes;
   if (uniqueLikes.length > 50) {
     limitedLikes = uniqueLikes.slice(0, 50);
-    if (client_id) {
-      const exceptionUsers = await getExceptionUsersByClient(client_id);
-      const exceptionSet = new Set(
-        exceptionUsers.map((u) => normalizeUsername(u.insta))
-      );
-      for (const uname of uniqueLikes) {
-        if (exceptionSet.has(uname)) {
-          limitedLikes.push(uname);
-        }
+    const exceptionUsers = await getAllExceptionUsers();
+    const exceptionSet = new Set(
+      exceptionUsers.map((u) => normalizeUsername(u.insta))
+    );
+    for (const uname of uniqueLikes) {
+      if (exceptionSet.has(uname)) {
+        limitedLikes.push(uname);
       }
-      limitedLikes = [...new Set(limitedLikes)];
     }
+    limitedLikes = [...new Set(limitedLikes)];
   }
 
   const existingLikes = await getExistingLikes(shortcode);

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -349,6 +349,14 @@ export async function updateUserField(user_id, field, value) {
   return findUserById(uid);
 }
 
+// Ambil semua user dengan exception true
+export async function getAllExceptionUsers() {
+  const { rows } = await query(
+    'SELECT * FROM "user" u WHERE exception = true'
+  );
+  return rows;
+}
+
 // Ambil user dengan exception per client
 export async function getExceptionUsersByClient(client_id, roleFilter = null) {
   const { clause, params } = await buildClientFilter(client_id, 'u', 1, roleFilter);


### PR DESCRIPTION
## Summary
- Load all exception users for Instagram likes instead of filtering by client
- Add helper to retrieve all exception users

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8b372c7083279fbd29eaf4392f6a