### PR TITLE
Limit dirrequest cron to DITBINMAS client

### DIFF
--- a/src/cron/cronDirRequest.js
+++ b/src/cron/cronDirRequest.js
@@ -12,6 +12,7 @@ async function getActiveClients() {
     `SELECT client_id
      FROM clients
      WHERE client_status=true
+       AND UPPER(client_id) = 'DITBINMAS'
      ORDER BY client_id`
   );
   return rows.rows;


### PR DESCRIPTION
## Summary
- ensure cronDirRequest processes only the DITBINMAS client

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab7a1547c832789732da2e86dfdcb