### PR TITLE
Limit dirrequest client selection to directorates

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -583,7 +583,20 @@ export const dirRequestHandlers = {
   },
 
   async main(session, chatId, _text, waClient) {
-    const ids = session.client_ids || [];
+    const originalIds = session.client_ids || [];
+    const ids = [];
+    for (const id of originalIds) {
+      try {
+        const client = await findClientById(id);
+        if (client?.client_type?.toLowerCase() === "direktorat") {
+          ids.push(id);
+        }
+      } catch {
+        // ignore lookup errors
+      }
+    }
+    session.client_ids = ids;
+
     if (!session.selectedClientId) {
       if (ids.length === 1) {
         session.selectedClientId = ids[0];


### PR DESCRIPTION
## Summary
- filter dirrequest client list to show only directorate-type clients
- cover filtering behavior with unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab899e3e88327867fd7789f044422