### PR TITLE
feat: update user role mapping on NRP changes

### DIFF
--- a/src/controller/userController.js
+++ b/src/controller/userController.js
@@ -132,6 +132,16 @@ export const updateUserRoles = async (req, res, next) => {
   }
 };
 
+export const updateUserRoleIds = async (req, res, next) => {
+  try {
+    const { old_user_id, new_user_id } = req.body;
+    await userModel.updateUserRolesUserId(old_user_id, new_user_id);
+    sendSuccess(res, { old_user_id, new_user_id });
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const deleteUser = async (req, res, next) => {
   try {
     const user = await userModel.deleteUser(req.params.id);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,6 +18,7 @@ import approvalRequestRoutes from './approvalRequestRoutes.js';
 import pressReleaseDetailRoutes from './pressReleaseDetailRoutes.js';
 import premiumRequestRoutes from './premiumRequestRoutes.js';
 import likesRoutes from './likesRoutes.js';
+import userRolesRoutes from './userRolesRoutes.js';
 
 const router = express.Router();
 
@@ -40,6 +41,7 @@ router.use('/press-release-details', pressReleaseDetailRoutes);
 router.use('/amplify', amplifyRoutes);
 router.use('/amplify-khusus', amplifyKhususRoutes);
 router.use('/premium-requests', premiumRequestRoutes);
+router.use('/user_roles', userRolesRoutes);
 export default router;
 
 

--- a/src/routes/userRolesRoutes.js
+++ b/src/routes/userRolesRoutes.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as userController from '../controller/userController.js';
+
+const router = express.Router();
+
+router.put('/', userController.updateUserRoleIds);
+
+export default router;

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -7,6 +7,7 @@ const mockUpdateUser = jest.fn();
 const mockGetUsersByClient = jest.fn();
 const mockGetUsersByDirektorat = jest.fn();
 const mockFindClientById = jest.fn();
+const mockUpdateUserRolesUserId = jest.fn();
 
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
   createUser: mockCreateUser,
@@ -14,7 +15,8 @@ jest.unstable_mockModule('../src/model/userModel.js', () => ({
   updateUserField: mockUpdateUserField,
   updateUser: mockUpdateUser,
   getUsersByClient: mockGetUsersByClient,
-  getUsersByDirektorat: mockGetUsersByDirektorat
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+  updateUserRolesUserId: mockUpdateUserRolesUserId
 }));
 
 jest.unstable_mockModule('../src/service/clientService.js', () => ({
@@ -25,6 +27,7 @@ let createUser;
 let getUserList;
 let getUsersByClientCtrl;
 let updateUserRolesCtrl;
+let updateUserRoleIdsCtrl;
 
 beforeAll(async () => {
   const mod = await import('../src/controller/userController.js');
@@ -32,6 +35,7 @@ beforeAll(async () => {
   getUserList = mod.getUserList;
   getUsersByClientCtrl = mod.getUsersByClient;
   updateUserRolesCtrl = mod.updateUserRoles;
+  updateUserRoleIdsCtrl = mod.updateUserRoleIds;
 });
 
 beforeEach(() => {
@@ -42,6 +46,7 @@ beforeEach(() => {
   mockGetUsersByClient.mockReset();
   mockGetUsersByDirektorat.mockReset();
   mockFindClientById.mockReset();
+  mockUpdateUserRolesUserId.mockReset();
 });
 
 test('operator adds user with defaults', async () => {
@@ -203,6 +208,22 @@ test('updateUserRoles updates roles based on array', async () => {
       ditlantas: false,
       bidhumas: false,
     },
+  });
+});
+
+test('updateUserRoleIds updates user_roles mapping', async () => {
+  const req = { body: { old_user_id: '1', new_user_id: '2' } };
+  const json = jest.fn();
+  const status = jest.fn().mockReturnThis();
+  const res = { status, json };
+
+  await updateUserRoleIdsCtrl(req, res, () => {});
+
+  expect(mockUpdateUserRolesUserId).toHaveBeenCalledWith('1', '2');
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({
+    success: true,
+    data: { old_user_id: '1', new_user_id: '2' }
   });
 });
 

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -15,6 +15,7 @@ let getUsersByDirektorat;
 let getClientsByRole;
 let getUsersByClient;
 let getUsersSocialByClient;
+let updateUserRolesUserId;
 
 beforeAll(async () => {
   const mod = await import('../src/model/userModel.js');
@@ -27,6 +28,7 @@ beforeAll(async () => {
   getClientsByRole = mod.getClientsByRole;
   getUsersByClient = mod.getUsersByClient;
   getUsersSocialByClient = mod.getUsersSocialByClient;
+  updateUserRolesUserId = mod.updateUserRolesUserId;
 });
 
 beforeEach(() => {
@@ -191,6 +193,13 @@ test('updateUserField updates ditbinmas field', async () => {
   const row = await updateUserField('1', 'ditbinmas', true);
   expect(row).toEqual({ user_id: '1', ditbinmas: true, ditlantas: false, bidhumas: false, operator: false });
   expect(mockQuery.mock.calls[1][0]).toContain('user_roles');
+});
+
+test('updateUserRolesUserId updates user_roles table', async () => {
+  mockQuery.mockResolvedValueOnce({});
+  await updateUserRolesUserId('1', '2');
+  expect(mockQuery.mock.calls[0][0]).toContain('UPDATE user_roles SET user_id=$1 WHERE user_id=$2');
+  expect(mockQuery.mock.calls[0][1]).toEqual(['2', '1']);
 });
 
 test('updateUserField updates desa field', async () => {


### PR DESCRIPTION
## Summary
- allow updating user_id and expose endpoint to sync user_roles
- register route for updating user role mappings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9ae7db588327a8e5ee793c583016