### PR TITLE
fix: align user roles update route with frontend

### DIFF
--- a/src/routes/userRolesRoutes.js
+++ b/src/routes/userRolesRoutes.js
@@ -3,6 +3,6 @@ import * as userController from '../controller/userController.js';
 
 const router = express.Router();
 
-router.put('/', userController.updateUserRoleIds);
+router.put('/update', userController.updateUserRoleIds);
 
 export default router;

--- a/tests/userRolesRoutes.test.js
+++ b/tests/userRolesRoutes.test.js
@@ -1,0 +1,34 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const mockUpdateUserRoleIds = jest.fn((req, res) => {
+  res.status(200).json({ success: true });
+});
+
+jest.unstable_mockModule('../src/controller/userController.js', () => ({
+  updateUserRoleIds: mockUpdateUserRoleIds
+}));
+
+let userRolesRoutes;
+
+beforeAll(async () => {
+  ({ default: userRolesRoutes } = await import('../src/routes/userRolesRoutes.js'));
+});
+
+beforeEach(() => {
+  mockUpdateUserRoleIds.mockClear();
+});
+
+test('PUT /user_roles/update forwards to controller', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/user_roles', userRolesRoutes);
+
+  const res = await request(app)
+    .put('/api/user_roles/update')
+    .send({ old_user_id: '1', new_user_id: '2' });
+
+  expect(res.status).toBe(200);
+  expect(mockUpdateUserRoleIds).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- update user roles router to expose `PUT /api/user_roles/update`
- add test verifying user roles update endpoint routes correctly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d5e9e148327b1901bc33f9d6874