### PR TITLE
Fix user_roles update when changing NRP

### DIFF
--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -533,6 +533,8 @@ export async function updateUser(userId, userData) {
   if (userData.user_id) {
     const newUid = normalizeUserId(userData.user_id);
     if (newUid !== uid) {
+      // Update mapping in user_roles first to satisfy foreign key constraint
+      await updateUserRolesUserId(uid, newUid);
       await query('UPDATE "user" SET user_id=$1 WHERE user_id=$2', [newUid, uid]);
       uid = newUid;
     }

--- a/src/routes/userRolesRoutes.js
+++ b/src/routes/userRolesRoutes.js
@@ -3,6 +3,6 @@ import * as userController from '../controller/userController.js';
 
 const router = express.Router();
 
-router.put('/update', userController.updateUserRoleIds);
+router.route('/update').put(userController.updateUserRoleIds).post(userController.updateUserRoleIds);
 
 export default router;

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -16,6 +16,7 @@ let getClientsByRole;
 let getUsersByClient;
 let getUsersSocialByClient;
 let updateUserRolesUserId;
+let updateUser;
 
 beforeAll(async () => {
   const mod = await import('../src/model/userModel.js');
@@ -29,6 +30,7 @@ beforeAll(async () => {
   getUsersByClient = mod.getUsersByClient;
   getUsersSocialByClient = mod.getUsersSocialByClient;
   updateUserRolesUserId = mod.updateUserRolesUserId;
+  updateUser = mod.updateUser;
 });
 
 beforeEach(() => {
@@ -200,6 +202,31 @@ test('updateUserRolesUserId updates user_roles table', async () => {
   await updateUserRolesUserId('1', '2');
   expect(mockQuery.mock.calls[0][0]).toContain('UPDATE user_roles SET user_id=$1 WHERE user_id=$2');
   expect(mockQuery.mock.calls[0][1]).toEqual(['2', '1']);
+});
+
+test('updateUser updates user_id and user_roles', async () => {
+  mockQuery
+    .mockResolvedValueOnce({}) // update user_roles
+    .mockResolvedValueOnce({}) // update user
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          user_id: '2',
+          ditbinmas: false,
+          ditlantas: false,
+          bidhumas: false,
+          operator: false,
+        },
+      ],
+    });
+
+  const row = await updateUser('1', { user_id: '2' });
+
+  expect(mockQuery.mock.calls[0][0]).toContain('UPDATE user_roles SET user_id=$1 WHERE user_id=$2');
+  expect(mockQuery.mock.calls[0][1]).toEqual(['2', '1']);
+  expect(mockQuery.mock.calls[1][0]).toContain('UPDATE "user" SET user_id=$1 WHERE user_id=$2');
+  expect(mockQuery.mock.calls[1][1]).toEqual(['2', '1']);
+  expect(row).toEqual({ user_id: '2', ditbinmas: false, ditlantas: false, bidhumas: false, operator: false });
 });
 
 test('updateUserField updates desa field', async () => {

--- a/tests/userRolesRoutes.test.js
+++ b/tests/userRolesRoutes.test.js
@@ -32,3 +32,16 @@ test('PUT /user_roles/update forwards to controller', async () => {
   expect(res.status).toBe(200);
   expect(mockUpdateUserRoleIds).toHaveBeenCalled();
 });
+
+test('POST /user_roles/update forwards to controller', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/user_roles', userRolesRoutes);
+
+  const res = await request(app)
+    .post('/api/user_roles/update')
+    .send({ old_user_id: '1', new_user_id: '2' });
+
+  expect(res.status).toBe(200);
+  expect(mockUpdateUserRoleIds).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- Update `updateUser` to refresh `user_roles` mapping when `user_id` changes
- Accept POST requests for `/api/user_roles/update`
- Add tests covering user ID updates and new route

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9f8b422c8327885ae8dce6331cdc