### PR TITLE
Handle empty TikTok username in claim controller

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -168,7 +168,7 @@ export async function updateUserData(req, res, next) {
     }
     if (tiktok !== undefined) {
       const ttUsername = extractTiktokUsername(tiktok);
-      if (ttUsername.replace(/^@/, '') === 'cicero_devs') {
+      if (ttUsername && ttUsername.replace(/^@/, '') === 'cicero_devs') {
         return res
           .status(400)
           .json({ success: false, message: 'username tiktok tidak valid' });

--- a/tests/claimControllerUpdateUserData.test.js
+++ b/tests/claimControllerUpdateUserData.test.js
@@ -78,6 +78,22 @@ describe('updateUserData', () => {
     expect(userModel.updateUser).not.toHaveBeenCalled();
   });
 
+  test('allows empty tiktok without error', async () => {
+    const req = {
+      body: {
+        nrp: '1',
+        whatsapp: '08123',
+        tiktok: ''
+      }
+    };
+    const res = createRes();
+    await updateUserData(req, res, () => {});
+    const [, data] = userModel.updateUser.mock.calls[0];
+    expect(data.tiktok).toBeUndefined();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
   test('verifies otp when provided', async () => {
     jest.resetModules();
     jest.unstable_mockModule('../src/model/userModel.js', () => ({


### PR DESCRIPTION
## Summary
- avoid TypeError when TikTok username is missing by guarding before `.replace`
- add test to ensure empty TikTok field is processed without error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba145647c83279d369ee50f6056ec