### PR TITLE
Expand Instagram likes pagination limit

### DIFF
--- a/src/handler/datamining/fetchDmLikes.js
+++ b/src/handler/datamining/fetchDmLikes.js
@@ -7,6 +7,7 @@ import { getPostIdShortcodePairsTodayByUsername } from '../../model/instaPostExt
 import { sendDebug } from '../../middleware/debugHandler.js';
 
 const limit = pLimit(3);
+const MAX_LIKE_PAGES = 100;
 
 export async function handleFetchLikesInstagramDM(username) {
   try {
@@ -19,7 +20,7 @@ export async function handleFetchLikesInstagramDM(username) {
     for (const p of posts) {
       await limit(async () => {
         try {
-          const likes = await fetchAllInstagramLikesItems(p.post_id);
+          const likes = await fetchAllInstagramLikesItems(p.post_id, MAX_LIKE_PAGES);
           const usernames = likes.map(l => l?.username).filter(Boolean);
           await upsertInstaLike(p.shortcode, usernames);
           for (const u of likes) {

--- a/src/service/instaRapidService.js
+++ b/src/service/instaRapidService.js
@@ -300,7 +300,7 @@ export async function fetchAllInstagramLikes(shortcode, maxPage = 20) {
   return all;
 }
 
-export async function fetchAllInstagramLikesItems(shortcode, maxPage = 20) {
+export async function fetchAllInstagramLikesItems(shortcode, maxPage = 100) {
   const all = [];
   let cursor = null;
   let page = 0;
@@ -310,7 +310,7 @@ export async function fetchAllInstagramLikesItems(shortcode, maxPage = 20) {
     all.push(...items);
     cursor = next_cursor;
     page++;
-    if (!has_more || !cursor || page >= maxPage) break;
+    if (!has_more || !cursor || (maxPage && page >= maxPage)) break;
   } while (true);
   return all;
 }


### PR DESCRIPTION
## Summary
- increase max page limit for Instagram like retrieval to 100
- request more like pages during DM fetch

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbdc649bac8327afee842d48d5dc5d