### PR TITLE
refactor: batch DM likes fetch with p-limit

### DIFF
--- a/src/handler/datamining/fetchDmLikes.js
+++ b/src/handler/datamining/fetchDmLikes.js
@@ -16,8 +16,9 @@ export async function handleFetchLikesInstagramDM(username) {
       return;
     }
     let sukses = 0, gagal = 0;
+    const tasks = [];
     for (const p of posts) {
-      await limit(async () => {
+      const task = limit(async () => {
         try {
           const likes = await fetchAllInstagramLikesItems(p.post_id);
           const usernames = likes.map(l => l?.username).filter(Boolean);
@@ -32,7 +33,9 @@ export async function handleFetchLikesInstagramDM(username) {
           sendDebug({ tag: 'IG DM LIKES ERROR', msg: `[${p.shortcode}] ${err.message}` });
         }
       });
+      tasks.push(task);
     }
+    await Promise.all(tasks);
     sendDebug({ tag: 'IG DM LIKES', msg: `Selesai likes @${username}. Berhasil: ${sukses}, Gagal: ${gagal}` });
   } catch (err) {
     sendDebug({ tag: 'IG DM LIKES ERROR', msg: err.message });


### PR DESCRIPTION
## Summary
- process DM likes fetches concurrently using p-limit
- preserve sendDebug error reporting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbde5beb208327a8f9c551a6e2dee3