### PR TITLE
Handle group WhatsApp IDs in cron recipients

### DIFF
--- a/src/cron/cronInstaLaphar.js
+++ b/src/cron/cronInstaLaphar.js
@@ -23,12 +23,12 @@ async function getActiveClientsIG() {
 }
 
 // Helper: format WhatsApp ID (biar aman)
-function toWAid(nomor) {
-  if (!nomor || typeof nomor !== "string") return null;
-  const no = nomor.trim();
-  if (!no) return null;
-  if (no.endsWith("@c.us")) return no;
-  return no.replace(/\D/g, "") + "@c.us";
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
 }
 function getAdminWAIds() {
   return (process.env.ADMIN_WHATSAPP || "")

--- a/src/cron/cronRekapLink.js
+++ b/src/cron/cronRekapLink.js
@@ -19,12 +19,12 @@ async function getActiveClients() {
   return rows.rows;
 }
 
-function toWAid(number) {
-  if (!number || typeof number !== "string") return null;
-  const no = number.trim();
-  if (!no) return null;
-  if (no.endsWith("@c.us")) return no;
-  return no.replace(/\D/g, "") + "@c.us";
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
 }
 
 function getAdminWAIds() {

--- a/src/cron/cronTiktokLaphar.js
+++ b/src/cron/cronTiktokLaphar.js
@@ -20,13 +20,13 @@ async function getActiveClientsTiktok() {
   return rows.rows;
 }
 
-// Format nomor WhatsApp ke @c.us
-function toWAid(nomor) {
-  if (!nomor || typeof nomor !== "string") return null;
-  const no = nomor.trim();
-  if (!no) return null;
-  if (no.endsWith("@c.us")) return no;
-  return no.replace(/\D/g, "") + "@c.us";
+// Format nomor WhatsApp ke @c.us atau @g.us
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
 }
 function getAdminWAIds() {
   return (process.env.ADMIN_WHATSAPP || "")


### PR DESCRIPTION
## Summary
- allow cron jobs to accept `@g.us` group IDs
- ensure all cron WhatsApp targets stay normalized

## Testing
- `npm run lint`
- `npm test`
- `JWT_SECRET=1 node -e "import('./src/cron/cronRekapLink.js').then(m=>{console.log(m.getRecipients({client_operator:'123',client_super:'456',client_group:'789@g.us'}));}).catch(err=>console.error(err))"`

------
https://chatgpt.com/codex/tasks/task_e_68bbe15302e48327b0d30eda54419222