### PR TITLE
Allow cron jobs to send messages to WA groups

### DIFF
--- a/src/cron/cronInstaLaphar.js
+++ b/src/cron/cronInstaLaphar.js
@@ -23,12 +23,12 @@ async function getActiveClientsIG() {
 }
 
 // Helper: format WhatsApp ID (biar aman)
-function toWAid(nomor) {
-  if (!nomor || typeof nomor !== "string") return null;
-  const no = nomor.trim();
-  if (!no) return null;
-  if (no.endsWith("@c.us")) return no;
-  return no.replace(/\D/g, "") + "@c.us";
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
 }
 function getAdminWAIds() {
   return (process.env.ADMIN_WHATSAPP || "")

--- a/src/cron/cronRekapLink.js
+++ b/src/cron/cronRekapLink.js
@@ -19,12 +19,12 @@ async function getActiveClients() {
   return rows.rows;
 }
 
-function toWAid(number) {
-  if (!number || typeof number !== "string") return null;
-  const no = number.trim();
-  if (!no) return null;
-  if (no.endsWith("@c.us")) return no;
-  return no.replace(/\D/g, "") + "@c.us";
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
 }
 
 function getAdminWAIds() {

--- a/src/cron/cronTiktokLaphar.js
+++ b/src/cron/cronTiktokLaphar.js
@@ -20,13 +20,13 @@ async function getActiveClientsTiktok() {
   return rows.rows;
 }
 
-// Format nomor WhatsApp ke @c.us
-function toWAid(nomor) {
-  if (!nomor || typeof nomor !== "string") return null;
-  const no = nomor.trim();
-  if (!no) return null;
-  if (no.endsWith("@c.us")) return no;
-  return no.replace(/\D/g, "") + "@c.us";
+// Format nomor WhatsApp ke @c.us/@g.us
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
 }
 function getAdminWAIds() {
   return (process.env.ADMIN_WHATSAPP || "")


### PR DESCRIPTION
## Summary
- support WhatsApp group IDs in toWAid
- enable cron jobs to send reports to groups and individuals

## Testing
- `npm run lint`
- `npm test`
- `node -e "process.env.JWT_SECRET='x';process.env.ADMIN_WHATSAPP='111,222@c.us';(async()=>{const m=await import('./src/cron/cronRekapLink.js');const r=m.getRecipients({client_operator:'628123',client_super:'1234567890@c.us',client_group:'9876543210@g.us'});console.log(r);})();"`


------
https://chatgpt.com/codex/tasks/task_e_68bbe153669883279199bae721744ec6