### PR TITLE
Improve error handling for DirRequest absensi likes cron

### DIFF
--- a/src/cron/cronDirRequestAbsensiLikes.js
+++ b/src/cron/cronDirRequestAbsensiLikes.js
@@ -21,14 +21,22 @@ async function runAbsensi(chatIds) {
     await fetchAndStoreInstaContent(keys, null, null, "DITBINMAS");
     const shortcodes = await getShortcodesTodayByClient("DITBINMAS");
     if (shortcodes.length === 0) {
-      sendDebug({ tag: cronTag, msg: "Tidak ada tugas IG hari ini" });
+      const infoMsg = "Tidak ada tugas IG hari ini";
+      sendDebug({ tag: cronTag, msg: infoMsg });
+      for (const wa of chatIds) {
+        await waClient.sendMessage(wa, infoMsg).catch((err) => {
+          sendDebug({ tag: cronTag, msg: `[ERROR SEND] ${err.message || err}` });
+        });
+      }
       return;
     }
     await handleFetchLikesInstagram(null, null, "DITBINMAS");
     const msg = await absensiLikes("DITBINMAS", { mode: "all", roleFlag: "ditbinmas" });
     if (msg) {
       for (const wa of chatIds) {
-        await waClient.sendMessage(wa, msg).catch(() => {});
+        await waClient.sendMessage(wa, msg).catch((err) => {
+          sendDebug({ tag: cronTag, msg: `[ERROR SEND] ${err.message || err}` });
+        });
       }
       sendDebug({ tag: cronTag, msg: `Laporan absensi IG dikirim ke ${chatIds.length} target` });
     }


### PR DESCRIPTION
## Summary
- Send "Tidak ada tugas IG hari ini" to configured chats when no Instagram task is found
- Log errors when sending WhatsApp messages in the DirRequest absensi likes cron

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2cb5f1a883278a33806492630793