### PR TITLE
Fix WhatsApp group file sending

### DIFF
--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -71,7 +71,7 @@ export async function sendWAFile(
     }
     try {
       let chatId = target;
-      if (typeof waClient.onWhatsApp === 'function') {
+      if (typeof waClient.onWhatsApp === 'function' && !target.endsWith('@g.us')) {
         const [result] = await waClient.onWhatsApp(target);
         if (!result?.exists) {
           console.warn(`[SKIP WA] Unregistered wid: ${target}`);

--- a/tests/waHelper.test.js
+++ b/tests/waHelper.test.js
@@ -78,6 +78,21 @@ test('sendWAFile accepts s.whatsapp.net wid', async () => {
   });
 });
 
+test('sendWAFile skips onWhatsApp for group ids', async () => {
+  const waClient = {
+    onWhatsApp: jest.fn(),
+    sendMessage: jest.fn().mockResolvedValue(),
+  };
+  const buffer = Buffer.from('hello');
+  await sendWAFile(waClient, buffer, 'file.txt', '123@g.us', 'text/plain');
+  expect(waClient.onWhatsApp).not.toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith('123@g.us', {
+    document: buffer,
+    mimetype: 'text/plain',
+    fileName: 'file.txt',
+  });
+});
+
 test('isUnsupportedVersionError detects update prompts', () => {
   expect(
     isUnsupportedVersionError(


### PR DESCRIPTION
## Summary
- allow `sendWAFile` to send files to group targets without failing the existence check
- add test ensuring group IDs bypass `onWhatsApp` validation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2eea086883279f10f62cf582a0e7