### PR TITLE
fix: improve wwebjs message sending

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -199,6 +199,9 @@ export function waitForWaReady(timeout = 30000) {
   });
 }
 
+// Expose readiness helper for consumers like safeSendMessage
+waClient.waitForWaReady = waitForWaReady;
+
 // Pastikan semua pengiriman pesan menunggu hingga client siap
 function wrapSendMessage(client) {
   const original = client.sendMessage;

--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -210,14 +210,18 @@ async function waitUntilReady(waClient, timeout = 10000) {
 
 export async function safeSendMessage(waClient, chatId, message, options = {}) {
   try {
-    const ready = await waitUntilReady(waClient);
-    if (!ready) {
-      console.warn(`[WA] Client not ready, cannot send message to ${chatId}`);
-      return false;
+    if (typeof waClient?.waitForWaReady === 'function') {
+      await waClient.waitForWaReady();
+    } else {
+      const ready = await waitUntilReady(waClient);
+      if (!ready) {
+        console.warn(`[WA] Client not ready, cannot send message to ${chatId}`);
+        return false;
+      }
     }
     await waClient.sendMessage(chatId, message, options);
     console.log(
-      `[WA] Sent message to ${chatId}: ${message.substring(0, 64)}`
+      `[WA] Sent message to ${chatId}: ${String(message).substring(0, 64)}`
     );
     return true;
   } catch (err) {


### PR DESCRIPTION
## Summary
- expose `waitForWaReady` on WhatsApp client
- allow `safeSendMessage` to await client readiness using `waitForWaReady`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc355e3c6083279a9af8c8ee5cb19b