### PR TITLE
Handle Google contact entries missing resource name

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -733,7 +733,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       let saved = 0;
       for (const u of users) {
         const exists = await searchByNumbers(auth, [u.whatsapp]);
-        if (exists.length === 0) {
+        if (!exists[u.whatsapp]) {
           await saveGoogleContact(auth, { name: u.nama, phone: u.whatsapp });
           saved++;
         }


### PR DESCRIPTION
## Summary
- map search results to resource names and return ID when creating Google contacts
- re-save contacts whose resource_name is null using the user's registered name
- adjust save contact command for new searchByNumbers output

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3613d2448327a5d4d25f478bd5cf