### PR TITLE
Polyfill WidFactory.toUserWidOrThrow for WhatsApp Web

### DIFF
--- a/src/service/wwebjsAdapter.js
+++ b/src/service/wwebjsAdapter.js
@@ -16,7 +16,18 @@ export async function createWwebjsClient() {
   });
 
   client.on('qr', (qr) => emitter.emit('qr', qr));
-  client.on('ready', () => emitter.emit('ready'));
+  client.on('ready', async () => {
+    await client.pupPage.evaluate(() => {
+      if (
+        window.Store?.WidFactory &&
+        !window.Store.WidFactory.toUserWidOrThrow
+      ) {
+        window.Store.WidFactory.toUserWidOrThrow = (jid) =>
+          window.Store.WidFactory.createWid(jid);
+      }
+    });
+    emitter.emit('ready');
+  });
   client.on('disconnected', (reason) => emitter.emit('disconnected', reason));
   client.on('message', (msg) => {
     emitter.emit('message', {


### PR DESCRIPTION
## Summary
- polyfill `WidFactory.toUserWidOrThrow` using `createWid` to restore WhatsApp sendMessage compatibility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3a243bec83278d66ae580776f4f9