### PR TITLE
Send dirrequest fetch insta report to WA group

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -7,8 +7,10 @@ import {
 import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
-import { sendWAFile } from "../../utils/waHelper.js";
+import { sendWAFile, safeSendMessage } from "../../utils/waHelper.js";
 import { writeFile } from "fs/promises";
+
+const dirRequestGroup = "120363419830216549@g.us";
 
 const pangkatOrder = [
   "KOMISARIS BESAR POLISI",
@@ -539,6 +541,9 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = "Menu tidak dikenal.";
   }
   await waClient.sendMessage(chatId, msg.trim());
+  if (action === "6") {
+    await safeSendMessage(waClient, dirRequestGroup, msg.trim());
+  }
 }
 
 export const dirRequestHandlers = {

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -14,6 +14,7 @@ const mockRekapLikesIG = jest.fn();
 const mockLapharDitbinmas = jest.fn();
 const mockWriteFile = jest.fn();
 const mockSendWAFile = jest.fn();
+const mockSafeSendMessage = jest.fn();
 
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
   getUsersSocialByClient: mockGetUsersSocialByClient,
@@ -32,7 +33,10 @@ jest.unstable_mockModule('../src/service/clientService.js', () => ({
   findClientById: mockFindClientById,
 }));
 jest.unstable_mockModule('fs/promises', () => ({ writeFile: mockWriteFile }));
-jest.unstable_mockModule('../src/utils/waHelper.js', () => ({ sendWAFile: mockSendWAFile }));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  sendWAFile: mockSendWAFile,
+  safeSendMessage: mockSafeSendMessage,
+}));
 jest.unstable_mockModule('../src/handler/fetchpost/instaFetchPost.js', () => ({
   fetchAndStoreInstaContent: mockFetchAndStoreInstaContent,
 }));
@@ -254,6 +258,7 @@ test('choose_menu option 6 fetch insta returns rekap likes report', async () => 
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();
   mockRekapLikesIG.mockResolvedValue('laporan likes');
+  mockSafeSendMessage.mockResolvedValue(true);
 
   const session = {
     role: 'ditbinmas',
@@ -275,6 +280,11 @@ test('choose_menu option 6 fetch insta returns rekap likes report', async () => 
   expect(mockHandleFetchLikesInstagram).toHaveBeenCalledWith(null, null, 'DITBINMAS');
   expect(mockRekapLikesIG).toHaveBeenCalledWith('DITBINMAS');
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan likes');
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    waClient,
+    '120363419830216549@g.us',
+    'laporan likes'
+  );
 });
 
 test('choose_menu option 10 sends laphar file and narrative', async () => {


### PR DESCRIPTION
## Summary
- forward `dirrequest` menu fetch insta report to WhatsApp group 120363419830216549@g.us
- add group messaging check in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3e79384c832787ecc28a4bfc8122