### PR TITLE
Add DirRequest rekap update cron job

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ const cronModules = [
   './src/cron/cronRekapLink.js',
   './src/cron/cronAmplifyLinkMonthly.js',
   './src/cron/cronDirRequestFetchInsta.js',
+  './src/cron/cronDirRequestRekapUpdate.js',
   './src/cron/cronDbBackup.js',
 ];
 

--- a/src/cron/cronDirRequestRekapUpdate.js
+++ b/src/cron/cronDirRequestRekapUpdate.js
@@ -1,0 +1,56 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import waClient from "../service/waService.js";
+import { formatRekapUserData, formatExecutiveSummary } from "../handler/menu/dirRequestHandlers.js";
+import { safeSendMessage } from "../utils/waHelper.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+
+const DIRREQUEST_GROUP = "120363419830216549@g.us";
+
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
+}
+
+function getAdminWAIds() {
+  return (process.env.ADMIN_WHATSAPP || "")
+    .split(",")
+    .map((n) => n.trim())
+    .filter(Boolean)
+    .map(toWAid)
+    .filter(Boolean);
+}
+
+export async function runCron() {
+  sendDebug({ tag: "CRON DIRREQ REKAP", msg: "Mulai cron dirrequest rekap update" });
+  try {
+    const executive = await formatExecutiveSummary("DITBINMAS", "ditbinmas");
+    const rekap = await formatRekapUserData("DITBINMAS", "ditbinmas");
+
+    const recipients = new Set([...getAdminWAIds(), DIRREQUEST_GROUP]);
+    for (const wa of recipients) {
+      await safeSendMessage(waClient, wa, executive.trim());
+      await safeSendMessage(waClient, wa, rekap.trim());
+    }
+
+    sendDebug({
+      tag: "CRON DIRREQ REKAP",
+      msg: `Laporan dikirim ke ${recipients.size} penerima`,
+    });
+  } catch (err) {
+    sendDebug({
+      tag: "CRON DIRREQ REKAP",
+      msg: `[ERROR] ${err.message || err}`,
+    });
+  }
+}
+
+cron.schedule("0 8-18/3 * * *", runCron, { timezone: "Asia/Jakarta" });
+
+export default null;
+

--- a/tests/cronDirRequestRekapUpdate.test.js
+++ b/tests/cronDirRequestRekapUpdate.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+
+const mockExecSummary = jest.fn();
+const mockRekapUser = jest.fn();
+const mockSafeSend = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/handler/menu/dirRequestHandlers.js', () => ({
+  formatExecutiveSummary: mockExecSummary,
+  formatRekapUserData: mockRekapUser,
+}));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  safeSendMessage: mockSafeSend,
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let runCron;
+
+beforeAll(async () => {
+  ({ runCron } = await import('../src/cron/cronDirRequestRekapUpdate.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.ADMIN_WHATSAPP = '123';
+  mockExecSummary.mockResolvedValue('exec');
+  mockRekapUser.mockResolvedValue('rekap');
+});
+
+test('runCron sends exec summary and rekap to admin and group', async () => {
+  await runCron();
+
+  expect(mockExecSummary).toHaveBeenCalledWith('DITBINMAS', 'ditbinmas');
+  expect(mockRekapUser).toHaveBeenCalledWith('DITBINMAS', 'ditbinmas');
+
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'exec');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'exec');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledTimes(4);
+});
+


### PR DESCRIPTION
## Summary
- add cron job to send executive summary and missing data recap to admins and group every 3 hours
- include cron module in app startup
- cover cron behaviour with unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4625bb8883279ad75aef205dca32