### PR TITLE
feat: add dirrequest direktorat cron job

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ const cronModules = [
     './src/cron/cronDirRequestFetchInsta.js',
     './src/cron/cronDirRequestRekapUpdate.js',
     './src/cron/cronDirRequestRekapLaphar.js',
+    './src/cron/cronDirRequestDirektorat.js',
     './src/cron/cronDbBackup.js',
   ];
 

--- a/src/cron/cronDirRequestDirektorat.js
+++ b/src/cron/cronDirRequestDirektorat.js
@@ -1,0 +1,53 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import waClient from "../service/waService.js";
+import {
+  absensiLikesDitbinmas,
+  formatRekapBelumLengkapDitbinmas,
+} from "../handler/menu/dirRequestHandlers.js";
+import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+
+const DIRREQUEST_GROUP = "120363419830216549@g.us";
+const EXTRA_WA = "081234560377";
+
+function toWAid(id) {
+  if (!id || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
+  return trimmed.replace(/\D/g, "") + "@c.us";
+}
+
+function getRecipients() {
+  const extra = toWAid(EXTRA_WA);
+  return new Set([...getAdminWAIds(), DIRREQUEST_GROUP, extra].filter(Boolean));
+}
+
+export async function runCron() {
+  sendDebug({ tag: "CRON DIRREQ DIREKTORAT", msg: "Mulai cron dirrequest direktorat" });
+  try {
+    const likesMsg = await absensiLikesDitbinmas();
+    const rekapMsg = await formatRekapBelumLengkapDitbinmas();
+    const recipients = getRecipients();
+    for (const wa of recipients) {
+      await safeSendMessage(waClient, wa, likesMsg.trim());
+      await safeSendMessage(waClient, wa, rekapMsg.trim());
+    }
+    sendDebug({
+      tag: "CRON DIRREQ DIREKTORAT",
+      msg: `Laporan dikirim ke ${recipients.size} penerima`,
+    });
+  } catch (err) {
+    sendDebug({
+      tag: "CRON DIRREQ DIREKTORAT",
+      msg: `[ERROR] ${err.message || err}`,
+    });
+  }
+}
+
+cron.schedule("0 21 * * *", runCron, { timezone: "Asia/Jakarta" });
+
+export default null;

--- a/tests/cronDirRequestDirektorat.test.js
+++ b/tests/cronDirRequestDirektorat.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+
+const mockAbsensi = jest.fn();
+const mockRekap = jest.fn();
+const mockSafeSend = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/handler/menu/dirRequestHandlers.js', () => ({
+  absensiLikesDitbinmas: mockAbsensi,
+  formatRekapBelumLengkapDitbinmas: mockRekap,
+}));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  safeSendMessage: mockSafeSend,
+  getAdminWAIds: () => ['123@c.us'],
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let runCron;
+
+beforeAll(async () => {
+  ({ runCron } = await import('../src/cron/cronDirRequestDirektorat.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAbsensi.mockResolvedValue('absensi');
+  mockRekap.mockResolvedValue('rekap');
+});
+
+test('runCron sends absensi and rekap to admin, group, and extra number', async () => {
+  await runCron();
+
+  expect(mockAbsensi).toHaveBeenCalled();
+  expect(mockRekap).toHaveBeenCalled();
+
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'absensi');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'absensi');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '081234560377@c.us', 'absensi');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '081234560377@c.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledTimes(6);
+});
+


### PR DESCRIPTION
## Summary
- schedule nightly dirrequest report cron
- send absensi likes and incomplete user data summaries to admins and 081234560377

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc50dc204883278a11d910ce91f1cd