### PR TITLE
Normalize TikTok username extraction

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -24,7 +24,7 @@ function extractTiktokUsername(value) {
     /^https?:\/\/(www\.)?tiktok\.com\/@([A-Za-z0-9._]+)\/?(\?.*)?$/i
   );
   const username = match ? match[2] : value.replace(/^@/, '');
-  return `@${username.toLowerCase()}`;
+  return username.toLowerCase();
 }
 
 export async function requestOtp(req, res, next) {
@@ -166,15 +166,15 @@ export async function updateUserData(req, res, next) {
       }
       data.insta = igUsername;
     }
-    if (tiktok !== undefined) {
-      const ttUsername = extractTiktokUsername(tiktok);
-      if (ttUsername && ttUsername.replace(/^@/, '') === 'cicero_devs') {
-        return res
-          .status(400)
-          .json({ success: false, message: 'username tiktok tidak valid' });
-      }
-      data.tiktok = ttUsername;
+  if (tiktok !== undefined) {
+    const ttUsername = extractTiktokUsername(tiktok);
+    if (ttUsername && ttUsername === 'cicero_devs') {
+      return res
+        .status(400)
+        .json({ success: false, message: 'username tiktok tidak valid' });
     }
+    data.tiktok = ttUsername;
+  }
     Object.keys(data).forEach((k) => data[k] === undefined && delete data[k]);
     const updated = await userModel.updateUser(nrp, data);
     await clearVerification(nrp);

--- a/tests/claimControllerUpdateUserData.test.js
+++ b/tests/claimControllerUpdateUserData.test.js
@@ -36,15 +36,15 @@ describe('updateUserData', () => {
       body: {
         nrp: '1',
         whatsapp: '08123',
-        insta: 'https://www.instagram.com/TestUser?igsh=abc',
-        tiktok: 'https://www.tiktok.com/@TikUser?lang=id'
+        insta: 'https://www.instagram.com/de_saputra88?igsh=MWJxMnY1YmtnZ3Rmeg==',
+        tiktok: 'https://www.tiktok.com/@sidik.prayitno37?_t=ZS-8zPPyl5Q4SO&_r=1'
       }
     };
     const res = createRes();
     await updateUserData(req, res, () => {});
     expect(userModel.updateUser).toHaveBeenCalledWith('1', expect.objectContaining({
-      insta: 'testuser',
-      tiktok: '@tikuser'
+      insta: 'de_saputra88',
+      tiktok: 'sidik.prayitno37'
     }));
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));


### PR DESCRIPTION
## Summary
- strip link and leading `@` from TikTok handle when updating claim data
- test Instagram and TikTok link inputs with query params

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcf3d2347c8327b15f85649c7756b3