### PR TITLE
Retain @ prefix in TikTok usernames

### DIFF
--- a/src/controller/claimController.js
+++ b/src/controller/claimController.js
@@ -24,7 +24,7 @@ function extractTiktokUsername(value) {
     /^https?:\/\/(www\.)?tiktok\.com\/@([A-Za-z0-9._]+)\/?(\?.*)?$/i
   );
   const username = match ? match[2] : value.replace(/^@/, '');
-  return username.toLowerCase();
+  return username ? `@${username.toLowerCase()}` : undefined;
 }
 
 export async function requestOtp(req, res, next) {
@@ -168,7 +168,7 @@ export async function updateUserData(req, res, next) {
     }
   if (tiktok !== undefined) {
     const ttUsername = extractTiktokUsername(tiktok);
-    if (ttUsername && ttUsername === 'cicero_devs') {
+    if (ttUsername && ttUsername.replace(/^@/, '') === 'cicero_devs') {
       return res
         .status(400)
         .json({ success: false, message: 'username tiktok tidak valid' });

--- a/tests/claimControllerUpdateUserData.test.js
+++ b/tests/claimControllerUpdateUserData.test.js
@@ -44,7 +44,7 @@ describe('updateUserData', () => {
     await updateUserData(req, res, () => {});
     expect(userModel.updateUser).toHaveBeenCalledWith('1', expect.objectContaining({
       insta: 'de_saputra88',
-      tiktok: 'sidik.prayitno37'
+      tiktok: '@sidik.prayitno37'
     }));
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));


### PR DESCRIPTION
## Summary
- Preserve the `@` when extracting TikTok usernames during claim updates
- Adjust invalid TikTok username check accordingly
- Update tests to expect the `@` prefix

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcf74fe6888327b52aa02df34e3138