### PR TITLE
feat: store laphar reports in folder

### DIFF
--- a/src/cron/cronDirRequestRekapLaphar.js
+++ b/src/cron/cronDirRequestRekapLaphar.js
@@ -6,7 +6,8 @@ import waClient from "../service/waService.js";
 import { lapharDitbinmas, absensiLikes } from "../handler/fetchabsensi/insta/absensiLikesInsta.js";
 import { sendWAFile, safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
 import { sendDebug } from "../middleware/debugHandler.js";
-import { writeFile } from "fs/promises";
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
 
 const DIRREQUEST_GROUP = "120363419830216549@g.us";
 const REKAP_RECIPIENT = "6281234560377@c.us";
@@ -21,18 +22,22 @@ export async function runCron() {
     const recipients = getRecipients();
 
     const { text, filename, narrative, textBelum, filenameBelum } = await lapharDitbinmas();
+    const dirPath = "laphar";
+    await mkdir(dirPath, { recursive: true });
     for (const wa of recipients) {
       if (narrative) {
         await safeSendMessage(waClient, wa, narrative.trim());
       }
       if (text && filename) {
         const buffer = Buffer.from(text, "utf-8");
-        await writeFile(filename, buffer);
+        const filePath = join(dirPath, filename);
+        await writeFile(filePath, buffer);
         await sendWAFile(waClient, buffer, filename, wa, "text/plain");
       }
       if (textBelum && filenameBelum) {
         const bufferBelum = Buffer.from(textBelum, "utf-8");
-        await writeFile(filenameBelum, bufferBelum);
+        const filePathBelum = join(dirPath, filenameBelum);
+        await writeFile(filePathBelum, bufferBelum);
         await sendWAFile(waClient, bufferBelum, filenameBelum, wa, "text/plain");
       }
     }

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -8,7 +8,8 @@ import { absensiKomentar } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
 import { sendWAFile, safeSendMessage } from "../../utils/waHelper.js";
-import { writeFile } from "fs/promises";
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
 
 const dirRequestGroup = "120363419830216549@g.us";
 
@@ -515,15 +516,21 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
     case "10": {
         const { text, filename, narrative, textBelum, filenameBelum } =
           await lapharDitbinmas();
+        const dirPath = "laphar";
+        await mkdir(dirPath, { recursive: true });
         if (narrative) {
           await waClient.sendMessage(chatId, narrative.trim());
         }
-        const buffer = Buffer.from(text, "utf-8");
-        await writeFile(filename, buffer);
-        await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
+        if (text && filename) {
+          const buffer = Buffer.from(text, "utf-8");
+          const filePath = join(dirPath, filename);
+          await writeFile(filePath, buffer);
+          await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
+        }
         if (textBelum && filenameBelum) {
           const bufferBelum = Buffer.from(textBelum, "utf-8");
-          await writeFile(filenameBelum, bufferBelum);
+          const filePathBelum = join(dirPath, filenameBelum);
+          await writeFile(filePathBelum, bufferBelum);
           await sendWAFile(
             waClient,
             bufferBelum,

--- a/tests/cronDirRequestRekapLaphar.test.js
+++ b/tests/cronDirRequestRekapLaphar.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import path from 'path';
 
 const mockLapharDitbinmas = jest.fn();
 const mockAbsensiLikes = jest.fn();
@@ -6,6 +7,7 @@ const mockSendWAFile = jest.fn();
 const mockSafeSendMessage = jest.fn();
 const mockSendDebug = jest.fn();
 const mockWriteFile = jest.fn();
+const mockMkdir = jest.fn();
 const mockGetAdminWAIds = jest.fn();
 
 jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
@@ -21,7 +23,7 @@ jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
 jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
   sendDebug: mockSendDebug,
 }));
-jest.unstable_mockModule('fs/promises', () => ({ writeFile: mockWriteFile }));
+jest.unstable_mockModule('fs/promises', () => ({ writeFile: mockWriteFile, mkdir: mockMkdir }));
 
 let runCron;
 
@@ -40,11 +42,24 @@ beforeEach(() => {
     filenameBelum: 'belum.txt',
   });
   mockAbsensiLikes.mockResolvedValue('absensi');
+  mockMkdir.mockResolvedValue();
+  mockWriteFile.mockResolvedValue();
 });
 
 test('runCron sends reports to admin, group, and extra number', async () => {
   await runCron();
 
+  expect(mockMkdir).toHaveBeenCalledWith('laphar', { recursive: true });
+  expect(mockWriteFile).toHaveBeenNthCalledWith(
+    1,
+    path.join('laphar', 'file.txt'),
+    expect.any(Buffer)
+  );
+  expect(mockWriteFile).toHaveBeenNthCalledWith(
+    2,
+    path.join('laphar', 'belum.txt'),
+    expect.any(Buffer)
+  );
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'nar');
   expect(mockSafeSendMessage).toHaveBeenCalledWith(
     {},

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import path from 'path';
 
 process.env.TZ = 'Asia/Jakarta';
 
@@ -13,6 +14,7 @@ const mockHandleFetchLikesInstagram = jest.fn();
 const mockRekapLikesIG = jest.fn();
 const mockLapharDitbinmas = jest.fn();
 const mockWriteFile = jest.fn();
+const mockMkdir = jest.fn();
 const mockSendWAFile = jest.fn();
 const mockSafeSendMessage = jest.fn();
 
@@ -32,7 +34,7 @@ jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTikt
 jest.unstable_mockModule('../src/service/clientService.js', () => ({
   findClientById: mockFindClientById,
 }));
-jest.unstable_mockModule('fs/promises', () => ({ writeFile: mockWriteFile }));
+jest.unstable_mockModule('fs/promises', () => ({ writeFile: mockWriteFile, mkdir: mockMkdir }));
 jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
   sendWAFile: mockSendWAFile,
   safeSendMessage: mockSafeSendMessage,
@@ -57,6 +59,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockMkdir.mockResolvedValue();
+  mockWriteFile.mockResolvedValue();
 });
 
 test('main filters non-direktorat client IDs', async () => {
@@ -302,9 +306,10 @@ test('choose_menu option 10 sends laphar file and narrative', async () => {
   await dirRequestHandlers.choose_menu(session, chatId, '10', waClient);
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
+  expect(mockMkdir).toHaveBeenCalledWith('laphar', { recursive: true });
   expect(mockWriteFile).toHaveBeenNthCalledWith(
     1,
-    'lap.txt',
+    path.join('laphar', 'lap.txt'),
     expect.any(Buffer)
   );
   expect(mockSendWAFile).toHaveBeenNthCalledWith(
@@ -317,7 +322,7 @@ test('choose_menu option 10 sends laphar file and narrative', async () => {
   );
   expect(mockWriteFile).toHaveBeenNthCalledWith(
     2,
-    'belum.txt',
+    path.join('laphar', 'belum.txt'),
     expect.any(Buffer)
   );
   expect(mockSendWAFile).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## Summary
- save laphar report files to `laphar` directory
- adjust cron to write reports to the same directory
- update tests for new file paths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd827bab488327948bae237f27d73e