### PR TITLE
Prioritize DIREKTORAT BINMAS in absensi likes sorting

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -125,6 +125,10 @@ export async function absensiLikes(client_id, opts = {}) {
     }
 
     reportEntries.sort((a, b) => {
+      const aBinmas = a.clientName.toUpperCase() === "DIREKTORAT BINMAS";
+      const bBinmas = b.clientName.toUpperCase() === "DIREKTORAT BINMAS";
+      if (aBinmas && !bBinmas) return -1;
+      if (bBinmas && !aBinmas) return 1;
       if (a.sudahCount !== b.sudahCount) return b.sudahCount - a.sudahCount;
       if (a.usersCount !== b.usersCount) return b.usersCount - a.usersCount;
       return a.clientName.localeCompare(b.clientName);

--- a/tests/absensiLikesInsta.test.js
+++ b/tests/absensiLikesInsta.test.js
@@ -175,6 +175,39 @@ test('directorate summarizes across clients', async () => {
   );
 });
 
+test('DIREKTORAT BINMAS is placed first regardless of counts', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ nama: 'DIREKTORAT BINMAS', client_type: 'direktorat' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'DIREKTORAT BINMAS' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES A' }] });
+  mockGetClientsByRole.mockResolvedValueOnce(['ditbinmas', 'polresa']);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
+  mockGetLikesByShortcode.mockResolvedValueOnce(['user2']);
+  mockGetUsersByDirektorat.mockResolvedValueOnce([
+    {
+      user_id: 'u1',
+      nama: 'User1',
+      insta: '@user1',
+      client_id: 'DITBINMAS',
+      exception: false,
+      status: true,
+    },
+    {
+      user_id: 'u2',
+      nama: 'User2',
+      insta: '@user2',
+      client_id: 'POLRESA',
+      exception: false,
+      status: true,
+    },
+  ]);
+
+  const msg = await absensiLikes('DITBINMAS');
+
+  expect(msg).toMatch(/1\. DIREKTORAT BINMAS\n/);
+  expect(msg).toMatch(/2\. POLRES A\n/);
+});
+
 test('absensiLikesDitbinmasReport filters users by client_id DITBINMAS', async () => {
   mockGetShortcodesTodayByClient.mockResolvedValueOnce(['sc1']);
   mockGetLikesByShortcode.mockResolvedValueOnce([]);


### PR DESCRIPTION
## Summary
- Ensure DIREKTORAT BINMAS is always the first satker in the absensi likes Instagram report
- Add regression test to verify sorting behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd96f7a4b08327a83c6455b7d37b43