### PR TITLE
chore: send dirrequest report to rekap recipient

### DIFF
--- a/src/cron/cronDirRequestDirektorat.js
+++ b/src/cron/cronDirRequestDirektorat.js
@@ -10,20 +10,10 @@ import {
 import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
 import { sendDebug } from "../middleware/debugHandler.js";
 
-const DIRREQUEST_GROUP = "120363419830216549@g.us";
-const EXTRA_WA = "081234560377";
-
-function toWAid(id) {
-  if (!id || typeof id !== "string") return null;
-  const trimmed = id.trim();
-  if (!trimmed) return null;
-  if (trimmed.endsWith("@c.us") || trimmed.endsWith("@g.us")) return trimmed;
-  return trimmed.replace(/\D/g, "") + "@c.us";
-}
+const REKAP_RECIPIENT = "6281234560377@c.us";
 
 function getRecipients() {
-  const extra = toWAid(EXTRA_WA);
-  return new Set([...getAdminWAIds(), DIRREQUEST_GROUP, extra].filter(Boolean));
+  return new Set([...getAdminWAIds(), REKAP_RECIPIENT]);
 }
 
 export async function runCron() {

--- a/tests/cronDirRequestDirektorat.test.js
+++ b/tests/cronDirRequestDirektorat.test.js
@@ -30,7 +30,7 @@ beforeEach(() => {
   mockRekap.mockResolvedValue('rekap');
 });
 
-test('runCron sends absensi and rekap to admin, group, and extra number', async () => {
+test('runCron sends absensi and rekap to admin and rekap recipient', async () => {
   await runCron();
 
   expect(mockAbsensi).toHaveBeenCalled();
@@ -38,10 +38,8 @@ test('runCron sends absensi and rekap to admin, group, and extra number', async 
 
   expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'absensi');
   expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'rekap');
-  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'absensi');
-  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'rekap');
-  expect(mockSafeSend).toHaveBeenCalledWith({}, '081234560377@c.us', 'absensi');
-  expect(mockSafeSend).toHaveBeenCalledWith({}, '081234560377@c.us', 'rekap');
-  expect(mockSafeSend).toHaveBeenCalledTimes(6);
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '6281234560377@c.us', 'absensi');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '6281234560377@c.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledTimes(4);
 });
 


### PR DESCRIPTION
## Summary
- send directorate report to dedicated REKAP_RECIPIENT WhatsApp ID
- adjust cronDirRequestDirektorat test expectations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd99d134888327a1d2ef95843760f6