### PR TITLE
Filter Instagram cron clients by ORG type

### DIFF
--- a/src/cron/cronInstaDataMining.js
+++ b/src/cron/cronInstaDataMining.js
@@ -12,7 +12,11 @@ import { sendDebug } from '../middleware/debugHandler.js';
 
 async function getActiveClientsIG() {
   const res = await query(
-    `SELECT client_id, client_insta FROM clients WHERE client_status = true AND client_insta_status = true`
+    `SELECT client_id, client_insta, client_insta_status
+     FROM clients
+     WHERE client_status = true
+       AND client_insta_status = true
+       AND LOWER(client_type) = 'org'`
   );
   return res.rows;
 }

--- a/src/cron/cronInstaLaphar.js
+++ b/src/cron/cronInstaLaphar.js
@@ -17,6 +17,7 @@ async function getActiveClientsIG() {
      FROM clients
      WHERE client_status = true
        AND (client_insta_status = true OR client_amplify_status = true)
+       AND LOWER(client_type) = 'org'
      ORDER BY client_id`
   );
   return rows.rows;

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -357,10 +357,10 @@ export async function absensiLikesPerKonten(client_id, opts = {}) {
 
 export async function getActiveClientsIG() {
   const res = await query(
-    `SELECT client_id, client_insta, client_insta_status, client_amplify_status
+    `SELECT client_id, client_insta, client_insta_status
      FROM clients
      WHERE client_status = true
-       AND (client_insta_status = true OR client_amplify_status = true)
+       AND client_insta_status = true
        AND client_insta IS NOT NULL
        AND LOWER(client_type) = 'org'`
   );


### PR DESCRIPTION
## Summary
- limit getActiveClientsIG query to ORG clients with Instagram enabled
- apply same ORG filter to data mining and laphar cron helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfcc2150ec832797e75488c418891e