### PR TITLE
Restrict TikTok cron to org clients

### DIFF
--- a/src/cron/cronTiktokService.js
+++ b/src/cron/cronTiktokService.js
@@ -12,7 +12,7 @@ import { absensiKomentar } from "../handler/fetchabsensi/tiktok/absensiKomentarT
 async function getActiveClientsTiktok() {
   const { query } = await import("../db/index.js");
   const rows = await query(
-    "SELECT client_id, nama FROM clients WHERE client_status = true AND client_tiktok_status = true AND client_amplify_status = true ORDER BY client_id"
+    "SELECT client_id, nama FROM clients WHERE client_status = true AND client_tiktok_status = true AND client_type = 'ORG' ORDER BY client_id"
   );
   return rows.rows;
 }


### PR DESCRIPTION
## Summary
- limit TikTok cron to active org clients

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfda4b7b3c8327872b9b551eeb0c6f