### PR TITLE
Filter TikTok cron to ORG clients

### DIFF
--- a/src/cron/cronTiktokLaphar.js
+++ b/src/cron/cronTiktokLaphar.js
@@ -14,7 +14,10 @@ async function getActiveClientsTiktok() {
   const rows = await query(
     `SELECT client_id, nama, client_operator, client_super, client_group
      FROM clients
-     WHERE client_status = true AND client_tiktok_status = true AND client_amplify_status = true
+     WHERE client_status = true
+       AND client_tiktok_status = true
+       AND client_amplify_status = true
+       AND client_type = 'ORG'
      ORDER BY client_id`
   );
   return rows.rows;


### PR DESCRIPTION
## Summary
- restrict TikTok Laphar cron job to process only clients with type ORG

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0acbc12348327addc93762ae1b5db