### PR TITLE
feat: add TikTok fetch report for DirRequest

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -498,11 +498,27 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "8": {
+      const normalizedId = (clientId || "").toUpperCase();
+      if (normalizedId !== "DITBINMAS") {
+        msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
+        break;
+      }
       const { fetchAndStoreTiktokContent } = await import(
         "../fetchpost/tiktokFetchPost.js"
       );
+      const { handleFetchKomentarTiktokBatch } = await import(
+        "../fetchengagement/fetchCommentTiktok.js"
+      );
       await fetchAndStoreTiktokContent("DITBINMAS", waClient, chatId);
-      msg = "✅ Selesai fetch TikTok DITBINMAS.";
+      await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
+      const rekapTiktok = await absensiKomentar("DITBINMAS", {
+        ...(userType === "org" ? { clientFilter: userClientId } : {}),
+        mode: "all",
+        roleFlag,
+      });
+      msg =
+        rekapTiktok ||
+        "Tidak ada konten TikTok untuk DIREKTORAT BINMAS hari ini.";
       break;
     }
     case "9": {
@@ -548,7 +564,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = "Menu tidak dikenal.";
   }
   await waClient.sendMessage(chatId, msg.trim());
-  if (action === "6") {
+  if (action === "6" || action === "8") {
     await safeSendMessage(waClient, dirRequestGroup, msg.trim());
   }
 }
@@ -645,7 +661,7 @@ export const dirRequestHandlers = {
         "5️⃣ Absensi Komentar TikTok\n" +
         "6️⃣ Fetch Insta\n" +
         "7️⃣ Fetch Likes Insta\n" +
-        "8️⃣ Fetch TikTok\n" +
+        "8️⃣ Fetch TikTok (Laporan)\n" +
         "9️⃣ Fetch Komentar TikTok\n" +
         "🔟 Laphar Ditbinmas\n" +
         "1️⃣1️⃣ Rekap user belum lengkapi data DITBINMAS\n" +

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -17,6 +17,8 @@ const mockWriteFile = jest.fn();
 const mockMkdir = jest.fn();
 const mockSendWAFile = jest.fn();
 const mockSafeSendMessage = jest.fn();
+const mockFetchAndStoreTiktokContent = jest.fn();
+const mockHandleFetchKomentarTiktokBatch = jest.fn();
 
 jest.unstable_mockModule('../src/model/userModel.js', () => ({
   getUsersSocialByClient: mockGetUsersSocialByClient,
@@ -44,6 +46,12 @@ jest.unstable_mockModule('../src/handler/fetchpost/instaFetchPost.js', () => ({
 }));
 jest.unstable_mockModule('../src/handler/fetchengagement/fetchLikesInstagram.js', () => ({
   handleFetchLikesInstagram: mockHandleFetchLikesInstagram,
+}));
+jest.unstable_mockModule('../src/handler/fetchpost/tiktokFetchPost.js', () => ({
+  fetchAndStoreTiktokContent: mockFetchAndStoreTiktokContent,
+}));
+jest.unstable_mockModule('../src/handler/fetchengagement/fetchCommentTiktok.js', () => ({
+  handleFetchKomentarTiktokBatch: mockHandleFetchKomentarTiktokBatch,
 }));
 jest.unstable_mockModule('../src/utils/utilsHelper.js', () => ({
   getGreeting: () => 'Selamat malam',
@@ -288,6 +296,46 @@ test('choose_menu option 6 fetch insta returns rekap likes report', async () => 
     waClient,
     '120363419830216549@g.us',
     'laporan likes'
+  );
+});
+
+test('choose_menu option 8 fetch tiktok returns komentar report', async () => {
+  mockFetchAndStoreTiktokContent.mockResolvedValue();
+  mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
+  mockAbsensiKomentar.mockResolvedValue('laporan tiktok');
+  mockSafeSendMessage.mockResolvedValue(true);
+  mockFindClientById.mockResolvedValue({ client_type: 'direktorat', nama: 'DITBINMAS' });
+
+  const session = {
+    role: 'ditbinmas',
+    selectedClientId: 'ditbinmas',
+    clientName: 'DITBINMAS',
+    dir_client_id: 'ditbinmas',
+  };
+  const chatId = '888';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '8', waClient);
+
+  expect(mockFetchAndStoreTiktokContent).toHaveBeenCalledWith(
+    'DITBINMAS',
+    waClient,
+    chatId
+  );
+  expect(mockHandleFetchKomentarTiktokBatch).toHaveBeenCalledWith(
+    waClient,
+    chatId,
+    'DITBINMAS'
+  );
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith(
+    'DITBINMAS',
+    expect.objectContaining({ mode: 'all', roleFlag: 'ditbinmas' })
+  );
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan tiktok');
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    waClient,
+    '120363419830216549@g.us',
+    'laporan tiktok'
   );
 });
 


### PR DESCRIPTION
## Summary
- add TikTok fetch menu that fetches posts, comments, and generates report for DITBINMAS
- send report to group and update menu label
- test DirRequest TikTok menu workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ae71e4688327bff57a7680c0ce21