### PR TITLE
Add cron job for DITBINMAS social media fetch

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ const cronModules = [
   './src/cron/cronInstaDataMining.js',
   './src/cron/cronRekapLink.js',
   './src/cron/cronAmplifyLinkMonthly.js',
-    './src/cron/cronDirRequestFetchInsta.js',
+    './src/cron/cronDirRequestFetchSosmed.js',
     './src/cron/cronDirRequestRekapUpdate.js',
     './src/cron/cronDirRequestRekapLaphar.js',
     './src/cron/cronDirRequestDirektorat.js',

--- a/tests/cronDirRequestFetchSosmed.test.js
+++ b/tests/cronDirRequestFetchSosmed.test.js
@@ -1,0 +1,65 @@
+import { jest } from '@jest/globals';
+
+const mockFetchInsta = jest.fn();
+const mockFetchLikes = jest.fn();
+const mockFetchTiktok = jest.fn();
+const mockFetchComments = jest.fn();
+const mockGenerateMsg = jest.fn();
+const mockSafeSend = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/handler/fetchpost/instaFetchPost.js', () => ({
+  fetchAndStoreInstaContent: mockFetchInsta,
+}));
+jest.unstable_mockModule('../src/handler/fetchengagement/fetchLikesInstagram.js', () => ({
+  handleFetchLikesInstagram: mockFetchLikes,
+}));
+jest.unstable_mockModule('../src/handler/fetchpost/tiktokFetchPost.js', () => ({
+  fetchAndStoreTiktokContent: mockFetchTiktok,
+}));
+jest.unstable_mockModule('../src/handler/fetchengagement/fetchCommentTiktok.js', () => ({
+  handleFetchKomentarTiktokBatch: mockFetchComments,
+}));
+jest.unstable_mockModule('../src/handler/fetchabsensi/sosmedTask.js', () => ({
+  generateSosmedTaskMessage: mockGenerateMsg,
+}));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  safeSendMessage: mockSafeSend,
+  getAdminWAIds: () => ['123@c.us'],
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let runCron;
+
+beforeAll(async () => {
+  ({ runCron } = await import('../src/cron/cronDirRequestFetchSosmed.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGenerateMsg.mockResolvedValue('msg');
+});
+
+test('runCron fetches sosmed and sends message to recipients', async () => {
+  await runCron();
+
+  expect(mockFetchInsta).toHaveBeenCalledWith(
+    ['shortcode', 'caption', 'like_count', 'timestamp'],
+    null,
+    null,
+    'DITBINMAS'
+  );
+  expect(mockFetchLikes).toHaveBeenCalledWith(null, null, 'DITBINMAS');
+  expect(mockFetchTiktok).toHaveBeenCalledWith('DITBINMAS');
+  expect(mockFetchComments).toHaveBeenCalledWith(null, null, 'DITBINMAS');
+  expect(mockGenerateMsg).toHaveBeenCalled();
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'msg');
+  expect(mockSafeSend).toHaveBeenCalledWith(
+    {},
+    '120363419830216549@g.us',
+    'msg'
+  );
+});


### PR DESCRIPTION
## Summary
- replace Instagram-only cron with social media fetch cron for dirrequest menu 12
- ensure cron targets only DITBINMAS and sends report to admins and group
- add test for new cron behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0fc1c307c832799598ba78e0f4081