### PR TITLE
Filter IG cron clients by org type

### DIFF
--- a/src/cron/cronInstaDataMining.js
+++ b/src/cron/cronInstaDataMining.js
@@ -16,7 +16,7 @@ async function getActiveClientsIG() {
      FROM clients
      WHERE client_status = true
        AND client_insta_status = true
-       AND LOWER(client_type) = 'org'`
+       AND client_type = 'ORG'`
   );
   return res.rows;
 }

--- a/src/cron/cronInstaLaphar.js
+++ b/src/cron/cronInstaLaphar.js
@@ -17,7 +17,7 @@ async function getActiveClientsIG() {
      FROM clients
      WHERE client_status = true
        AND (client_insta_status = true OR client_amplify_status = true)
-       AND LOWER(client_type) = 'org'
+       AND client_type = 'ORG'
      ORDER BY client_id`
   );
   return rows.rows;

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -362,7 +362,7 @@ export async function getActiveClientsIG() {
      WHERE client_status = true
        AND client_insta_status = true
        AND client_insta IS NOT NULL
-       AND LOWER(client_type) = 'org'`
+       AND client_type = 'ORG'`
   );
   return res.rows;
 }


### PR DESCRIPTION
## Summary
- limit active Instagram client queries to clients with type ORG

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1033deed483279c6a84758abf5a2d