### PR TITLE
Normalize client lookup to be case-insensitive

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -9,7 +9,7 @@ import { sendDebug } from "../../../middleware/debugHandler.js";
 // Dapatkan nama dan username tiktok client
 async function getClientInfo(client_id) {
   const res = await query(
-    "SELECT nama, client_tiktok, client_type FROM clients WHERE client_id = $1 LIMIT 1",
+    "SELECT nama, client_tiktok, client_type FROM clients WHERE LOWER(client_id) = LOWER($1) LIMIT 1",
     [client_id]
   );
   return {


### PR DESCRIPTION
## Summary
- ensure TikTok comment attendance lookup uses case-insensitive client_id comparison

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c114e5509c8327b00a7490761db2dc