### PR TITLE
Remove client filter when fetching directorate users

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
+++ b/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
@@ -49,7 +49,7 @@ export async function absensiKomentarInstagram(client_id, opts = {}) {
     allowedRoles.includes(roleFlag.toLowerCase()) &&
     roleFlag.toUpperCase() === targetClient.toUpperCase()
   ) {
-    users = (await getUsersByDirektorat(roleFlag.toLowerCase(), targetClient)).filter(
+    users = (await getUsersByDirektorat(roleFlag.toLowerCase())).filter(
       (u) => u.status === true
     );
   } else {

--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -57,7 +57,7 @@ export async function absensiKomentar(client_id, opts = {}) {
     roleFlag.toUpperCase() === client_id.toUpperCase()
   ) {
     users = (
-      await getUsersByDirektorat(roleFlag.toLowerCase(), clientFilter || client_id)
+      await getUsersByDirektorat(roleFlag.toLowerCase())
     ).filter((u) => u.status === true);
   } else {
     users = await getUsersByClient(clientFilter || client_id, roleFlag);

--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -42,6 +42,8 @@ test('aggregates directorate data per client', async () => {
 
   const msg = await absensiKomentar('ditbinmas', { roleFlag: 'ditbinmas' });
 
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
+
   expect(msg).toContain('POLRES A');
   expect(msg).toContain('✅ *Sudah melaksanakan* : *1 user*');
   expect(msg).toContain('POLRES B');

--- a/tests/absensiKomentarInstagramDirektorat.test.js
+++ b/tests/absensiKomentarInstagramDirektorat.test.js
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+
+jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersByClient: jest.fn(),
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+}));
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+
+let absensiKomentarInstagram;
+beforeAll(async () => {
+  ({ absensiKomentarInstagram } = await import('../src/handler/fetchabsensi/insta/absensiKomentarInstagram.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('uses getUsersByDirektorat without client filter', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'DIT BINMAS' }] });
+  mockGetUsersByDirektorat.mockResolvedValueOnce([]);
+  mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
+
+  await absensiKomentarInstagram('ditbinmas', { roleFlag: 'ditbinmas' });
+
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
+});
+


### PR DESCRIPTION
## Summary
- Avoid filtering users by client ID for directorate roles in TikTok and Instagram comment attendance handlers
- Cover directorate lookups with dedicated tests for TikTok and Instagram paths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c15454c60083278185011e420ab7b1