### PR TITLE
feat: adjust dirreq rekap recipients by schedule

### DIFF
--- a/src/cron/cronDirRequestRekapLaphar.js
+++ b/src/cron/cronDirRequestRekapLaphar.js
@@ -12,14 +12,18 @@ import { join } from "path";
 const DIRREQUEST_GROUP = "120363419830216549@g.us";
 const REKAP_RECIPIENT = "6281234560377@c.us";
 
-function getRecipients() {
-  return new Set([...getAdminWAIds(), DIRREQUEST_GROUP, REKAP_RECIPIENT]);
+function getRecipients(includeRekap = false) {
+  const recipients = new Set([...getAdminWAIds(), DIRREQUEST_GROUP]);
+  if (includeRekap) {
+    recipients.add(REKAP_RECIPIENT);
+  }
+  return recipients;
 }
 
-export async function runCron() {
+export async function runCron(includeRekap = false) {
   sendDebug({ tag: "CRON DIRREQ LAPHAR", msg: "Mulai cron dirrequest laphar" });
   try {
-    const recipients = getRecipients();
+    const recipients = getRecipients(includeRekap);
 
     const { text, filename, narrative, textBelum, filenameBelum } = await lapharDitbinmas();
     const dirPath = "laphar";
@@ -53,7 +57,7 @@ export async function runCron() {
   }
 }
 
-cron.schedule("0 15,18 * * *", runCron, { timezone: "Asia/Jakarta" });
-cron.schedule("30 20 * * *", runCron, { timezone: "Asia/Jakarta" });
+cron.schedule("0 15,18 * * *", () => runCron(false), { timezone: "Asia/Jakarta" });
+cron.schedule("30 20 * * *", () => runCron(true), { timezone: "Asia/Jakarta" });
 
 export default null;

--- a/tests/cronDirRequestRekapLaphar.test.js
+++ b/tests/cronDirRequestRekapLaphar.test.js
@@ -46,8 +46,8 @@ beforeEach(() => {
   mockWriteFile.mockResolvedValue();
 });
 
-test('runCron sends reports to admin, group, and extra number', async () => {
-  await runCron();
+test('runCron without rekap sends reports to admin and group only', async () => {
+  await runCron(false);
 
   expect(mockMkdir).toHaveBeenCalledWith('laphar', { recursive: true });
   expect(mockWriteFile).toHaveBeenNthCalledWith(
@@ -60,6 +60,49 @@ test('runCron sends reports to admin, group, and extra number', async () => {
     path.join('laphar', 'belum.txt'),
     expect.any(Buffer)
   );
+  expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'nar');
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    {},
+    '120363419830216549@g.us',
+    'nar'
+  );
+  expect(mockSafeSendMessage).not.toHaveBeenCalledWith(
+    {},
+    '6281234560377@c.us',
+    'nar'
+  );
+
+  expect(mockSendWAFile).not.toHaveBeenCalledWith(
+    {},
+    expect.any(Buffer),
+    'file.txt',
+    '6281234560377@c.us',
+    'text/plain'
+  );
+  expect(mockSendWAFile).not.toHaveBeenCalledWith(
+    {},
+    expect.any(Buffer),
+    'belum.txt',
+    '6281234560377@c.us',
+    'text/plain'
+  );
+
+  expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'absensi');
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    {},
+    '120363419830216549@g.us',
+    'absensi'
+  );
+  expect(mockSafeSendMessage).not.toHaveBeenCalledWith(
+    {},
+    '6281234560377@c.us',
+    'absensi'
+  );
+});
+
+test('runCron with rekap sends reports to admin, group, and extra number', async () => {
+  await runCron(true);
+
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'nar');
   expect(mockSafeSendMessage).toHaveBeenCalledWith(
     {},


### PR DESCRIPTION
## Summary
- control dirrequest rekap recipients so 15:00/18:00 run sends only to admins and group
- include rekap recipient for 20:30 run and add tests for both scenarios

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17221451c8327a68d688bb661e687