### PR TITLE
feat: add instagram likes recap excel

### DIFF
--- a/src/service/likesRecapExcelService.js
+++ b/src/service/likesRecapExcelService.js
@@ -1,0 +1,31 @@
+import { mkdir } from 'fs/promises';
+import path from 'path';
+import XLSX from 'xlsx';
+
+export async function saveLikesRecapExcel(data) {
+  const { shortcodes, recap } = data;
+  const wb = XLSX.utils.book_new();
+  Object.entries(recap).forEach(([polres, users]) => {
+    const header = ['Pangkat Nama', 'Satfung', ...shortcodes];
+    const rows = users.map((u) => {
+      const row = {
+        'Pangkat Nama': `${u.pangkat ? u.pangkat + ' ' : ''}${u.nama}`.trim(),
+        Satfung: u.satfung || '',
+      };
+      shortcodes.forEach((sc) => {
+        row[sc] = u[sc] ?? 0;
+      });
+      return row;
+    });
+    const ws = XLSX.utils.json_to_sheet(rows, { header });
+    XLSX.utils.book_append_sheet(wb, ws, polres);
+  });
+  const exportDir = path.resolve('export_data/likes_recap');
+  await mkdir(exportDir, { recursive: true });
+  const filePath = path.join(
+    exportDir,
+    `likes_recap_${Date.now()}.xlsx`
+  );
+  XLSX.writeFile(wb, filePath);
+  return filePath;
+}


### PR DESCRIPTION
## Summary
- collect daily Instagram likes per polres and return recap data
- export recap data to Excel workbook with sheet per polres
- add DirRequest menu option to generate and send likes recap Excel
- cover new menu option in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c20e45d2748327b9377e5229b9e890