### PR TITLE
fix: simplify TikTok rekap komentar

### DIFF
--- a/src/controller/tiktokController.js
+++ b/src/controller/tiktokController.js
@@ -61,20 +61,11 @@ export async function getTiktokPosts(req, res) {
 import { getRekapKomentarByClient } from '../model/tiktokCommentModel.js';
 
 export async function getTiktokRekapKomentar(req, res) {
-  const client_id = req.query.client_id;
+  const client_id = 'DITBINMAS';
   const periode = req.query.periode || 'harian';
   const tanggal = req.query.tanggal;
-  const startDate =
-    req.query.start_date || req.query.tanggal_mulai;
+  const startDate = req.query.start_date || req.query.tanggal_mulai;
   const endDate = req.query.end_date || req.query.tanggal_selesai;
-  if (!client_id) {
-    return res.status(400).json({ success: false, message: 'client_id wajib diisi' });
-  }
-  if (req.user?.client_ids && !req.user.client_ids.includes(client_id)) {
-    return res
-      .status(403)
-      .json({ success: false, message: 'client_id tidak diizinkan' });
-  }
   try {
     const role = req.user?.role;
     const data = await getRekapKomentarByClient(

--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -135,12 +135,6 @@ export async function getRekapKomentarByClient(
     )`;
   }
 
-  const { rows: postRows } = await query(
-    `SELECT COUNT(*) AS jumlah_post FROM tiktok_post p JOIN tiktok_comment c ON c.video_id = p.video_id ${postRoleJoin} WHERE ${postClientFilter} ${postRoleFilter} AND ${tanggalFilter}`,
-    params
-  );
-  const max_comment = parseInt(postRows[0]?.jumlah_post || "0", 10);
-
   const { rows } = await query(
     `WITH valid_comments AS (
       SELECT c.video_id,
@@ -164,7 +158,6 @@ export async function getRekapKomentarByClient(
       u.nama,
       u.tiktok AS username,
       u.divisi,
-      u.exception,
       COALESCE(cc.jumlah_komentar, 0) AS jumlah_komentar
     FROM "user" u
     LEFT JOIN comment_counts cc
@@ -176,17 +169,7 @@ export async function getRekapKomentarByClient(
     params
   );
   for (const user of rows) {
-    if (
-      user.exception === true ||
-      user.exception === "true" ||
-      user.exception == 1 ||
-      user.exception === "1"
-    ) {
-      user.jumlah_komentar = max_comment;
-    } else {
-      user.jumlah_komentar = parseInt(user.jumlah_komentar, 10);
-    }
-    user.display_nama = user.title ? `${user.title} ${user.nama}` : user.nama;
+    user.jumlah_komentar = parseInt(user.jumlah_komentar, 10);
   }
 
   return rows;

--- a/tests/tiktokCommentModel.test.js
+++ b/tests/tiktokCommentModel.test.js
@@ -22,27 +22,20 @@ function mockClientType(type = 'instansi') {
 
 test('getRekapKomentarByClient uses updated_at BETWEEN for date range', async () => {
   mockClientType();
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ jumlah_post: '2' }] })
-    .mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapKomentarByClient('POLRES', 'harian', null, '2024-01-01', '2024-01-31');
-  expect(mockQuery).toHaveBeenCalledTimes(3);
+  expect(mockQuery).toHaveBeenCalledTimes(2);
   expect(mockQuery.mock.calls[1][0]).toContain('c.updated_at');
   expect(mockQuery.mock.calls[1][0]).toContain('BETWEEN $2::date AND $3::date');
   expect(mockQuery.mock.calls[1][1]).toEqual(['POLRES', '2024-01-01', '2024-01-31']);
-  expect(mockQuery.mock.calls[2][0]).toContain('c.updated_at');
-  expect(mockQuery.mock.calls[2][0]).toContain('BETWEEN $2::date AND $3::date');
-  expect(mockQuery.mock.calls[2][1]).toEqual(['POLRES', '2024-01-01', '2024-01-31']);
 });
 
 test('getRekapKomentarByClient includes directorate role filter for ditbinmas', async () => {
   mockClientType('direktorat');
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ jumlah_post: '0' }] })
-    .mockResolvedValueOnce({ rows: [] });
+  mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapKomentarByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   expect(mockQuery.mock.calls[0][0]).toContain('SELECT client_type FROM clients');
-  const sql = mockQuery.mock.calls[2][0];
+  const sql = mockQuery.mock.calls[1][0];
   expect(sql).toContain('tiktok_post_roles');
   expect(sql).toContain('user_roles');
 });

--- a/tests/tiktokControllerDateRange.test.js
+++ b/tests/tiktokControllerDateRange.test.js
@@ -29,7 +29,6 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   mockGetRekap.mockResolvedValue([]);
   const req = {
     query: {
-      client_id: 'c1',
       periode: 'harian',
       tanggal_mulai: '2024-01-01',
       tanggal_selesai: '2024-01-31'
@@ -39,7 +38,7 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const res = { json, status: jest.fn().mockReturnThis() };
   await getTiktokRekapKomentar(req, res);
   expect(mockGetRekap).toHaveBeenCalledWith(
-    'c1',
+    'DITBINMAS',
     'harian',
     undefined,
     '2024-01-01',
@@ -49,40 +48,6 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
 });
 
-test('returns 403 when client_id unauthorized', async () => {
-  const req = {
-    query: { client_id: 'c2' },
-    user: { client_ids: ['c1'] }
-  };
-  const json = jest.fn();
-  const res = { json, status: jest.fn().mockReturnThis() };
-  await getTiktokRekapKomentar(req, res);
-  expect(res.status).toHaveBeenCalledWith(403);
-  expect(json).toHaveBeenCalledWith({ success: false, message: 'client_id tidak diizinkan' });
-  expect(mockGetRekap).not.toHaveBeenCalled();
-});
-
-test('allows authorized client_id', async () => {
-  mockGetRekap.mockResolvedValue([]);
-  const req = {
-    query: { client_id: 'c1' },
-    user: { client_ids: ['c1', 'c2'] }
-  };
-  const json = jest.fn();
-  const res = { json, status: jest.fn().mockReturnThis() };
-  await getTiktokRekapKomentar(req, res);
-  expect(res.status).not.toHaveBeenCalledWith(403);
-  expect(mockGetRekap).toHaveBeenCalledWith(
-    'c1',
-    'harian',
-    undefined,
-    undefined,
-    undefined,
-    undefined
-  );
-  expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
-});
-
 test('returns user comment summaries with counts', async () => {
   const rows = [
     { username: 'alice', jumlah_komentar: 2 },
@@ -90,7 +55,7 @@ test('returns user comment summaries with counts', async () => {
     { username: 'charlie', jumlah_komentar: 1 }
   ];
   mockGetRekap.mockResolvedValue(rows);
-  const req = { query: { client_id: 'c1' } };
+  const req = { query: {} };
   const json = jest.fn();
   const res = { json, status: jest.fn().mockReturnThis() };
   await getTiktokRekapKomentar(req, res);


### PR DESCRIPTION
## Summary
- always use fixed client_id DITBINMAS for TikTok comment recap
- drop exception and display name logic from TikTok comment recap model
- adjust related tests for new behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2334acfa48327931a67468953f86f