### PR TITLE
refactor: simplify TikTok comment role filtering

### DIFF
--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -112,13 +112,9 @@ export async function getRekapKomentarByClient(
 
   let postClientFilter = "LOWER(p.client_id) = LOWER($1)";
   let userWhere = "LOWER(u.client_id) = LOWER($1)";
-  let postRoleJoin = "";
-  let postRoleFilter = "";
   if (clientType === "direktorat") {
     postClientFilter = "1=1";
     const roleIdx = params.push(roleLower || client_id);
-    postRoleJoin = "JOIN tiktok_post_roles pr ON pr.video_id = c.video_id";
-    postRoleFilter = `AND LOWER(pr.role_name) = LOWER($${roleIdx})`;
     userWhere = `EXISTS (
       SELECT 1 FROM user_roles ur
       JOIN roles r ON ur.role_id = r.role_id
@@ -126,8 +122,6 @@ export async function getRekapKomentarByClient(
     )`;
   } else if (roleLower && roleLower !== "operator") {
     const roleIdx = params.push(roleLower);
-    postRoleJoin = "JOIN tiktok_post_roles pr ON pr.video_id = c.video_id";
-    postRoleFilter = `AND LOWER(pr.role_name) = LOWER($${roleIdx})`;
     userWhere = `LOWER(u.client_id) = LOWER($1) AND EXISTS (
       SELECT 1 FROM user_roles ur
       JOIN roles r ON ur.role_id = r.role_id
@@ -142,9 +136,8 @@ export async function getRekapKomentarByClient(
              lower(replace(trim(cmt), '@', '')) AS username
       FROM tiktok_comment c
       JOIN tiktok_post p ON p.video_id = c.video_id
-      ${postRoleJoin}
       JOIN LATERAL jsonb_array_elements_text(c.comments) cmt ON TRUE
-      WHERE ${postClientFilter} ${postRoleFilter} AND ${tanggalFilter}
+      WHERE ${postClientFilter} AND ${tanggalFilter}
     ),
     comment_counts AS (
       SELECT username, COUNT(DISTINCT video_id) AS jumlah_komentar

--- a/tests/tiktokCommentModel.test.js
+++ b/tests/tiktokCommentModel.test.js
@@ -36,6 +36,6 @@ test('getRekapKomentarByClient includes directorate role filter for ditbinmas', 
   await getRekapKomentarByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   expect(mockQuery.mock.calls[0][0]).toContain('SELECT client_type FROM clients');
   const sql = mockQuery.mock.calls[1][0];
-  expect(sql).toContain('tiktok_post_roles');
+  expect(sql).not.toContain('tiktok_post_roles');
   expect(sql).toContain('user_roles');
 });


### PR DESCRIPTION
## Summary
- remove `tiktok_post_roles` join and filter from TikTok comment recap query
- rely solely on `user_roles`/`roles` to filter user roles
- adjust tests to match new role filtering logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c24a7d7ca88327a3851325bdad8f63