### PR TITLE
Normalize client ID casing in likes recap

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -36,7 +36,7 @@ export async function collectLikesRecap(clientId) {
     const likes = await getLikesByShortcode(sc);
     likesSets.push(new Set((likes || []).map(normalizeUsername)));
   }
-  const polresIds = await getClientsByRole(clientId);
+  const polresIds = (await getClientsByRole(clientId)).map((c) => c.toUpperCase());
   const allUsers = (
     await getUsersByDirektorat(clientId, polresIds)
   ).filter((u) => u.status === true);

--- a/tests/collectLikesRecap.test.js
+++ b/tests/collectLikesRecap.test.js
@@ -1,0 +1,61 @@
+import { jest } from '@jest/globals';
+
+const mockGetShortcodesTodayByClient = jest.fn();
+const mockGetLikesByShortcode = jest.fn();
+const mockGetClientsByRole = jest.fn();
+const mockGetUsersByDirektorat = jest.fn();
+const mockGetUsersByClient = jest.fn();
+const mockQuery = jest.fn();
+
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({
+  getLikesByShortcode: mockGetLikesByShortcode,
+}));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getClientsByRole: mockGetClientsByRole,
+  getUsersByDirektorat: mockGetUsersByDirektorat,
+  getUsersByClient: mockGetUsersByClient,
+}));
+jest.unstable_mockModule('../src/db/index.js', () => ({
+  query: mockQuery,
+}));
+
+let collectLikesRecap;
+beforeAll(async () => {
+  ({ collectLikesRecap } = await import('../src/handler/fetchabsensi/insta/absensiLikesInsta.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('collectLikesRecap normalizes client IDs', async () => {
+  mockGetShortcodesTodayByClient.mockResolvedValue(['SC1']);
+  mockGetLikesByShortcode.mockResolvedValue(['user1']);
+  mockGetClientsByRole.mockResolvedValue(['polres_a']);
+  mockGetUsersByDirektorat.mockResolvedValue([
+    {
+      client_id: 'POLRES_A',
+      divisi: 'Sat A',
+      title: 'AKP',
+      nama: 'Budi',
+      insta: 'user1',
+      status: true,
+    },
+  ]);
+  mockQuery.mockResolvedValue({ rows: [{ nama: 'POLRES A' }] });
+
+  const result = await collectLikesRecap('ditbinmas');
+
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', ['POLRES_A']);
+  expect(result.recap['POLRES A']).toEqual([
+    {
+      pangkat: 'AKP',
+      nama: 'Budi',
+      satfung: 'Sat A',
+      SC1: 1,
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- ensure `collectLikesRecap` uppercases client IDs before grouping
- add regression test covering client ID normalization for likes recap

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c274b7a8d08327883897f4b2515cd3