### PR TITLE
chore: harmonize likes recap excel filenames

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -562,7 +562,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         }
         const recapData = await collectLikesRecap(clientId);
         if (recapData.shortcodes.length) {
-          const excelPath = await saveLikesRecapExcel(recapData);
+          const excelPath = await saveLikesRecapExcel(recapData, clientId);
           const bufferExcel = await readFile(excelPath);
           await sendWAFile(
             waClient,
@@ -641,7 +641,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         msg = `Tidak ada konten IG untuk *${clientId}* hari ini.`;
         break;
       }
-      const filePath = await saveLikesRecapExcel(data);
+      const filePath = await saveLikesRecapExcel(data, clientId);
       const buffer = await readFile(filePath);
       await sendWAFile(
         waClient,

--- a/src/service/likesRecapExcelService.js
+++ b/src/service/likesRecapExcelService.js
@@ -1,8 +1,9 @@
 import { mkdir } from 'fs/promises';
 import path from 'path';
 import XLSX from 'xlsx';
+import { hariIndo } from '../utils/constants.js';
 
-export async function saveLikesRecapExcel(data) {
+export async function saveLikesRecapExcel(data, clientId) {
   const { shortcodes, recap } = data;
   const wb = XLSX.utils.book_new();
   Object.entries(recap).forEach(([polres, users]) => {
@@ -22,9 +23,19 @@ export async function saveLikesRecapExcel(data) {
   });
   const exportDir = path.resolve('export_data/likes_recap');
   await mkdir(exportDir, { recursive: true });
+
+  const now = new Date();
+  const hari = hariIndo[now.getDay()];
+  const tanggal = now.toLocaleDateString('id-ID');
+  const jam = now.toLocaleTimeString('id-ID', { hour12: false });
+  const dateSafe = tanggal.replace(/\//g, '-');
+  const timeSafe = jam.replace(/[:.]/g, '-');
+  const formattedClient = (clientId || '')
+    .toLowerCase()
+    .replace(/^./, (c) => c.toUpperCase());
   const filePath = path.join(
     exportDir,
-    `likes_recap_${Date.now()}.xlsx`
+    `Rekap_Likes_IG_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
   );
   XLSX.writeFile(wb, filePath);
   return filePath;

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -420,7 +420,7 @@ test('choose_menu option 10 sends laphar file, narrative, and likes recap excel'
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
   expect(mockCollectLikesRecap).toHaveBeenCalledWith('ditbinmas');
-  expect(mockSaveLikesRecapExcel).toHaveBeenCalledWith({ shortcodes: ['sc1'] });
+  expect(mockSaveLikesRecapExcel).toHaveBeenCalledWith({ shortcodes: ['sc1'] }, 'ditbinmas');
   expect(mockReadFile).toHaveBeenCalledWith('/tmp/recap.xlsx');
   expect(mockUnlink).toHaveBeenCalledWith('/tmp/recap.xlsx');
   expect(mockMkdir).toHaveBeenCalledWith('laphar', { recursive: true });
@@ -528,7 +528,7 @@ test('choose_menu option 14 generates likes recap excel and sends file', async (
   expect(mockSaveLikesRecapExcel).toHaveBeenCalledWith({
     shortcodes: ['sc1'],
     recap: { POLRES_A: [{ pangkat: 'AKP', nama: 'Budi', satfung: 'SAT A', sc1: 1 }] },
-  });
+  }, 'ditbinmas');
   expect(mockReadFile).toHaveBeenCalledWith('/tmp/recap.xlsx');
   expect(mockSendWAFile).toHaveBeenCalledWith(
     waClient,


### PR DESCRIPTION
## Summary
- align likes recap Excel file names with existing text report pattern
- update dirRequest handlers to supply client ID for Excel report naming
- adjust tests for new Excel naming

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c28560594c832782780cc5f94b1991