### PR TITLE
feat: add all sosmed recap

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -577,8 +577,8 @@ export async function lapharDitbinmas() {
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
   const dateSafe = tanggal.replace(/\//g, "-");
   const timeSafe = jam.replace(/[:.]/g, "-");
-  const filename = `Absensi_All_Likes_IG_Ditbinmas_${hari}_${dateSafe}_${timeSafe}.txt`;
-  const filenameBelum = `Absensi_Belum_Likes_IG_Ditbinmas_${hari}_${dateSafe}_${timeSafe}.txt`;
+  const filename = `Absensi_All_Engagement_Instagram_${hari}_${dateSafe}_${timeSafe}.txt`;
+  const filenameBelum = `Absensi_Belum_Engagement_Instagram_${hari}_${dateSafe}_${timeSafe}.txt`;
 
   const shortcodes = await getShortcodesTodayByClient(roleName);
   if (!shortcodes.length)

--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -307,8 +307,8 @@ export async function lapharTiktokDitbinmas() {
   const jam = now.toLocaleTimeString("id-ID", { hour12: false });
   const dateSafe = tanggal.replace(/\//g, "-");
   const timeSafe = jam.replace(/[:.]/g, "-");
-  const filename = `Absensi_All_Komentar_Tiktok_Ditbinmas_${hari}_${dateSafe}_${timeSafe}.txt`;
-  const filenameBelum = `Absensi_Belum_Komentar_Tiktok_Ditbinmas_${hari}_${dateSafe}_${timeSafe}.txt`;
+  const filename = `Absensi_All_Engagement_Tiktok_${hari}_${dateSafe}_${timeSafe}.txt`;
+  const filenameBelum = `Absensi_Belum_Engagement_Tiktok_${hari}_${dateSafe}_${timeSafe}.txt`;
 
   const posts = await getPostsTodayByClient(roleName);
   if (!posts.length)

--- a/src/service/commentRecapExcelService.js
+++ b/src/service/commentRecapExcelService.js
@@ -35,7 +35,7 @@ export async function saveCommentRecapExcel(data, clientId) {
     .replace(/^./, (c) => c.toUpperCase());
   const filePath = path.join(
     exportDir,
-    `Rekap_Komentar_TikTok_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+    `Rekap_Engagement_Tiktok_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
   );
   XLSX.writeFile(wb, filePath);
   return filePath;

--- a/src/service/likesRecapExcelService.js
+++ b/src/service/likesRecapExcelService.js
@@ -35,7 +35,7 @@ export async function saveLikesRecapExcel(data, clientId) {
     .replace(/^./, (c) => c.toUpperCase());
   const filePath = path.join(
     exportDir,
-    `Rekap_Likes_IG_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+    `Rekap_Engagement_Instagram_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
   );
   XLSX.writeFile(wb, filePath);
   return filePath;

--- a/tests/lapharDitbinmas.test.js
+++ b/tests/lapharDitbinmas.test.js
@@ -65,7 +65,7 @@ test('orders clients by likes with ditbinmas first and returns narrative', async
   expect(result.narrative).toMatch(/Highlight Pencapaian/);
   expect(result.narrative).toMatch(/Konsentrasi Backlog/);
   expect(result.narrative).toMatch(/Input Username Ter rendah/);
-  expect(result.filename).toMatch(/^Absensi_All_Likes_IG_Ditbinmas_/);
-  expect(result.filenameBelum).toMatch(/^Absensi_Belum_Likes_IG_Ditbinmas_/);
+  expect(result.filename).toMatch(/^Absensi_All_Engagement_Instagram_/);
+  expect(result.filenameBelum).toMatch(/^Absensi_Belum_Engagement_Instagram_/);
   expect(result.textBelum).toMatch(/Belum Input Sosial media/);
 });


### PR DESCRIPTION
## Summary
- add combined "Rekap All Sosmed" option to dirrequest menu
- rename engagement report filenames for Instagram and TikTok
- expand tests for unified recap flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a302c5808327904819380e0b3518