### PR TITLE
feat: consolidate sosmed recap format

### DIFF
--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -579,7 +579,8 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
     filename: 'ig.txt',
     textBelum: 'igbelum',
     filenameBelum: 'igbelum.txt',
-    narrative: 'narIG',
+    narrative:
+      'IGHEADER\nDIREKTORAT BINMAS\nIGPART\nAbsensi Update Data\nIGUPDATE',
   });
   mockCollectLikesRecap.mockResolvedValue({ shortcodes: ['sc1'] });
   mockSaveLikesRecapExcel.mockResolvedValue('/tmp/ig.xlsx');
@@ -588,7 +589,8 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
     filename: 'tt.txt',
     textBelum: 'ttbelum',
     filenameBelum: 'ttbelum.txt',
-    narrative: 'narTT',
+    narrative:
+      'TTHEADER\nDIREKTORAT BINMAS\nTTPART\nAbsensi Update Data\nTTUPDATE',
   });
   mockCollectKomentarRecap.mockResolvedValue({ videoIds: ['vid1'] });
   mockSaveCommentRecapExcel.mockResolvedValue('/tmp/tt.xlsx');
@@ -604,9 +606,11 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
   expect(mockLapharTiktokDitbinmas).toHaveBeenCalled();
   const combined = waClient.sendMessage.mock.calls[0][1];
-  expect(combined).toContain('narIG');
-  expect(combined).toContain('narTT');
-  expect(combined).toMatch(/Seluruh personil telah melengkapi data/);
+  expect(combined).toContain('IGPART');
+  expect(combined).toContain('TTPART');
+  expect(combined).toContain('ABSENSI UPDATE DATA PERSONIL');
+  expect(combined).toContain('IGUPDATE');
+  expect(combined).not.toContain('TTUPDATE');
   expect(mockSendWAFile).toHaveBeenNthCalledWith(
     1,
     waClient,


### PR DESCRIPTION
## Summary
- combine Instagram and TikTok narratives into unified report for DirRequest menu option 15
- avoid duplicate update-data sections in recap
- adjust tests for consolidated message

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a99746f88327a562e7bc20dfa8a4