### PR TITLE
chore: remove belum engagement files from rekap

### DIFF
--- a/src/cron/cronDirRequestRekapAllSocmed.js
+++ b/src/cron/cronDirRequestRekapAllSocmed.js
@@ -51,15 +51,7 @@ export async function runCron(includeRekap = false) {
     const narrative = formatRekapAllSosmed(ig.narrative, tt.narrative);
 
     const igBuffer = ig.text && ig.filename ? Buffer.from(ig.text, "utf-8") : null;
-    const igBelumBuffer =
-      ig.textBelum && ig.filenameBelum
-        ? Buffer.from(ig.textBelum, "utf-8")
-        : null;
     const ttBuffer = tt.text && tt.filename ? Buffer.from(tt.text, "utf-8") : null;
-    const ttBelumBuffer =
-      tt.textBelum && tt.filenameBelum
-        ? Buffer.from(tt.textBelum, "utf-8")
-        : null;
 
     let igRecapPath = null;
     let igRecapBuffer = null;
@@ -83,17 +75,9 @@ export async function runCron(includeRekap = false) {
       const filePath = join(dirPath, ig.filename);
       await writeFile(filePath, igBuffer);
     }
-    if (igBelumBuffer) {
-      const filePathBelum = join(dirPath, ig.filenameBelum);
-      await writeFile(filePathBelum, igBelumBuffer);
-    }
     if (ttBuffer) {
       const filePath = join(dirPath, tt.filename);
       await writeFile(filePath, ttBuffer);
-    }
-    if (ttBelumBuffer) {
-      const filePathBelum = join(dirPath, tt.filenameBelum);
-      await writeFile(filePathBelum, ttBelumBuffer);
     }
 
     for (const wa of recipients) {
@@ -103,26 +87,8 @@ export async function runCron(includeRekap = false) {
       if (igBuffer) {
         await sendWAFile(waClient, igBuffer, ig.filename, wa, "text/plain");
       }
-      if (igBelumBuffer) {
-        await sendWAFile(
-          waClient,
-          igBelumBuffer,
-          ig.filenameBelum,
-          wa,
-          "text/plain"
-        );
-      }
       if (ttBuffer) {
         await sendWAFile(waClient, ttBuffer, tt.filename, wa, "text/plain");
-      }
-      if (ttBelumBuffer) {
-        await sendWAFile(
-          waClient,
-          ttBelumBuffer,
-          tt.filenameBelum,
-          wa,
-          "text/plain"
-        );
       }
       if (igRecapBuffer) {
         await sendWAFile(

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -721,18 +721,6 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         await writeFile(filePath, buffer);
         await sendWAFile(waClient, buffer, ig.filename, chatId, "text/plain");
       }
-      if (ig.textBelum && ig.filenameBelum) {
-        const bufferBelum = Buffer.from(ig.textBelum, "utf-8");
-        const filePathBelum = join(dirPath, ig.filenameBelum);
-        await writeFile(filePathBelum, bufferBelum);
-        await sendWAFile(
-          waClient,
-          bufferBelum,
-          ig.filenameBelum,
-          chatId,
-          "text/plain"
-        );
-      }
       const igRecap = await collectLikesRecap(clientId);
       if (igRecap.shortcodes.length) {
         const excelPath = await saveLikesRecapExcel(igRecap, clientId);
@@ -752,18 +740,6 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         const filePath = join(dirPath, tt.filename);
         await writeFile(filePath, buffer);
         await sendWAFile(waClient, buffer, tt.filename, chatId, "text/plain");
-      }
-      if (tt.textBelum && tt.filenameBelum) {
-        const bufferBelum = Buffer.from(tt.textBelum, "utf-8");
-        const filePathBelum = join(dirPath, tt.filenameBelum);
-        await writeFile(filePathBelum, bufferBelum);
-        await sendWAFile(
-          waClient,
-          bufferBelum,
-          tt.filenameBelum,
-          chatId,
-          "text/plain"
-        );
       }
       const ttRecap = await collectKomentarRecap(clientId);
       if (ttRecap.videoIds.length) {

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -577,8 +577,6 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
   mockLapharDitbinmas.mockResolvedValue({
     text: 'ig',
     filename: 'ig.txt',
-    textBelum: 'igbelum',
-    filenameBelum: 'igbelum.txt',
     narrative:
       'IGHEADER\nDIREKTORAT BINMAS\nIGPART\nAbsensi Update Data\nIGUPDATE',
   });
@@ -587,8 +585,6 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
   mockLapharTiktokDitbinmas.mockResolvedValue({
     text: 'tt',
     filename: 'tt.txt',
-    textBelum: 'ttbelum',
-    filenameBelum: 'ttbelum.txt',
     narrative:
       'TTHEADER\nDIREKTORAT BINMAS\nTTPART\nAbsensi Update Data\nTTUPDATE',
   });
@@ -623,20 +619,12 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
     2,
     waClient,
     expect.any(Buffer),
-    'igbelum.txt',
-    chatId,
-    'text/plain'
-  );
-  expect(mockSendWAFile).toHaveBeenNthCalledWith(
-    3,
-    waClient,
-    expect.any(Buffer),
     path.basename('/tmp/ig.xlsx'),
     chatId,
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
   );
   expect(mockSendWAFile).toHaveBeenNthCalledWith(
-    4,
+    3,
     waClient,
     expect.any(Buffer),
     'tt.txt',
@@ -644,15 +632,7 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
     'text/plain'
   );
   expect(mockSendWAFile).toHaveBeenNthCalledWith(
-    5,
-    waClient,
-    expect.any(Buffer),
-    'ttbelum.txt',
-    chatId,
-    'text/plain'
-  );
-  expect(mockSendWAFile).toHaveBeenNthCalledWith(
-    6,
+    4,
     waClient,
     expect.any(Buffer),
     path.basename('/tmp/tt.xlsx'),


### PR DESCRIPTION
## Summary
- stop sending `absensi_belum_engagement` text files in Rekap All Sosmed (dirrequest menu 15)
- drop `belum` file handling in cron rekap all sosmed
- update menu 15 tests for new file send order

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b4acbeb08327a9e7999be9bfb31e