### PR TITLE
Filter Ditbinmas users in DirRequest menu 5

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -502,9 +502,9 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
     }
     case "5":
       msg = await absensiKomentar(clientId, {
-        ...(userType === "org" ? { clientFilter: userClientId } : {}),
         mode: "all",
         roleFlag,
+        clientFilter: "ditbinmas",
       });
       break;
     case "6": {

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -540,6 +540,23 @@ test('choose_menu option 13 sends tiktok laphar file narrative and recap excel',
   expect(waClient.sendMessage.mock.calls[0][1]).toBe('narasi');
 });
 
+test('choose_menu option 5 filters users to ditbinmas', async () => {
+  mockAbsensiKomentar.mockResolvedValue('ok');
+  const originalMain = dirRequestHandlers.main;
+  dirRequestHandlers.main = jest.fn();
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '555';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
+
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith(
+    'ditbinmas',
+    expect.objectContaining({ mode: 'all', clientFilter: 'ditbinmas' })
+  );
+  dirRequestHandlers.main = originalMain;
+});
+
 test('choose_menu option 14 generates likes recap excel and sends file', async () => {
   mockCollectLikesRecap.mockResolvedValue({
     shortcodes: ['sc1'],


### PR DESCRIPTION
## Summary
- filter users by `ditbinmas` client when running DirRequest menu 5 recap
- test DirRequest handler to ensure menu 5 applies the Ditbinmas filter

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2bfe388588327bc520b9d5278ddc2