### PR TITLE
Filter Ditbinmas users in Absensi Komentar recap

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -501,8 +501,8 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "5":
-      msg = await absensiKomentar(clientId, {
-        ...(userType === "org" ? { clientFilter: userClientId } : {}),
+      msg = await absensiKomentar("DITBINMAS", {
+        clientFilter: "DITBINMAS",
         mode: "all",
         roleFlag,
       });

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -293,6 +293,32 @@ test('choose_menu option 4 skips ketika client bukan ditbinmas', async () => {
   );
 });
 
+test('choose_menu option 5 absensi komentar filters users to ditbinmas', async () => {
+  mockAbsensiKomentar.mockResolvedValue('laporan komentar');
+  mockFindClientById.mockResolvedValue({ client_type: 'org', nama: 'POLRES A' });
+
+  const session = {
+    role: 'ditbinmas',
+    selectedClientId: 'polres_a',
+    clientName: 'POLRES A',
+    dir_client_id: 'ditbinmas',
+  };
+  const chatId = '4321';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
+
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith(
+    'DITBINMAS',
+    expect.objectContaining({
+      mode: 'all',
+      roleFlag: 'ditbinmas',
+      clientFilter: 'DITBINMAS',
+    })
+  );
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
+});
+
 test('choose_menu option 6 fetch insta returns rekap likes report', async () => {
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();


### PR DESCRIPTION
## Summary
- Restrict DirRequest menu option 5 to recap only DITBINMAS users by forcing `absensiKomentar` to use client and user filters for DITBINMAS
- Add unit test confirming the recap uses the DITBINMAS filter

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c20b0ce08327ad42f267056b5d34