### PR TITLE
Scope Ditbinmas comment recap to client ID

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -104,7 +104,6 @@ export async function absensiKomentar(client_id, opts = {}) {
   const clientInfo = await getClientInfo(client_id);
   const clientNama = clientInfo.nama;
   const tiktokUsername = clientInfo.tiktok;
-  const clientType = clientInfo.clientType;
   const allowedRoles = ["ditbinmas", "ditlantas", "bidhumas"];
   let users;
   if (
@@ -113,7 +112,7 @@ export async function absensiKomentar(client_id, opts = {}) {
     roleFlag.toUpperCase() === client_id.toUpperCase()
   ) {
     users = (
-      await getUsersByDirektorat(roleFlag.toLowerCase())
+      await getUsersByDirektorat(roleFlag.toLowerCase(), clientFilter || client_id)
     ).filter((u) => u.status === true);
   } else {
     users = await getUsersByClient(clientFilter || client_id, roleFlag);
@@ -161,7 +160,7 @@ export async function absensiKomentar(client_id, opts = {}) {
 
   const totalKonten = posts.length;
 
-  if (clientType === "direktorat") {
+  if (client_id.toUpperCase() === "DITBINMAS") {
     const groups = {};
     Object.values(userStats).forEach((u) => {
       const cid = u.client_id?.toUpperCase() || "";

--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -43,7 +43,7 @@ test('aggregates directorate data per client', async () => {
 
   const msg = await absensiKomentar('ditbinmas', { roleFlag: 'ditbinmas' });
 
-  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
 
   expect(msg).toContain('POLRES A');
   expect(msg).toContain('✅ *Sudah melaksanakan* : *1 user*');


### PR DESCRIPTION
## Summary
- Filter directorate user retrieval by explicit Ditbinmas client ID
- Trigger per-Polres recap only when requesting Ditbinmas

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c507b6bc8327b2e702b83ef5e2b1