### PR TITLE
Allow configurable wwebjs clientId

### DIFF
--- a/src/service/wwebjsAdapter.js
+++ b/src/service/wwebjsAdapter.js
@@ -7,11 +7,13 @@ const { Client, LocalAuth, MessageMedia } = pkg;
  * Create a whatsapp-web.js client that matches the WAAdapter contract.
  * The client stays in standby mode and does not mark messages as read
  * unless explicitly invoked.
+ *
+ * @param {string} [clientId='wa-admin'] - WhatsApp client identifier used by LocalAuth.
  */
-export async function createWwebjsClient() {
+export async function createWwebjsClient(clientId = 'wa-admin') {
   const emitter = new EventEmitter();
   const client = new Client({
-    authStrategy: new LocalAuth({ clientId: 'wa-admin' }),
+    authStrategy: new LocalAuth({ clientId }),
     puppeteer: { args: ['--no-sandbox'], headless: true },
   });
 


### PR DESCRIPTION
## Summary
- allow passing custom clientId to wwebjs LocalAuth

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2cb06a8ac832786ed3c424dd40b22