### PR TITLE
feat: rekap komentar tiktok ditbinmas

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -6,9 +6,9 @@ import {
   collectLikesRecap,
 } from "../fetchabsensi/insta/absensiLikesInsta.js";
 import {
-  absensiKomentar,
   lapharTiktokDitbinmas,
   collectKomentarRecap,
+  absensiKomentarDitbinmasReport,
 } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
@@ -501,11 +501,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "5":
-      msg = await absensiKomentar("DITBINMAS", {
-        clientFilter: "DITBINMAS",
-        mode: "all",
-        roleFlag,
-      });
+      msg = await absensiKomentarDitbinmasReport();
       break;
     case "6": {
       const { fetchAndStoreInstaContent } = await import(
@@ -552,11 +548,9 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       );
       await fetchAndStoreTiktokContent("DITBINMAS", waClient, chatId);
       await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
-      const rekapTiktok = await absensiKomentar("DITBINMAS", {
-        ...(userType === "org" ? { clientFilter: userClientId } : {}),
-        mode: "all",
-        roleFlag,
-      });
+      const rekapTiktok = await absensiKomentarDitbinmasReport(
+        userType === "org" ? { clientFilter: userClientId } : {}
+      );
       msg =
         rekapTiktok ||
         "Tidak ada konten TikTok untuk DIREKTORAT BINMAS hari ini.";

--- a/tests/clientRequestHandlersAbsensiOprDitbinmas.test.js
+++ b/tests/clientRequestHandlersAbsensiOprDitbinmas.test.js
@@ -26,6 +26,7 @@ jest.unstable_mockModule('../src/handler/fetchengagement/fetchLikesInstagram.js'
 jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js', () => ({
   absensiKomentar: jest.fn(),
   absensiKomentarTiktokPerKonten: jest.fn(),
+  absensiKomentarDitbinmasReport: jest.fn(),
 }));
 
 process.env.JWT_SECRET = 'test';

--- a/tests/dashRequestHandlers.test.js
+++ b/tests/dashRequestHandlers.test.js
@@ -30,7 +30,10 @@ jest.unstable_mockModule(
 
 jest.unstable_mockModule(
   '../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js',
-  () => ({ absensiKomentar: mockAbsensiKomentar })
+  () => ({
+    absensiKomentar: mockAbsensiKomentar,
+    absensiKomentarDitbinmasReport: jest.fn(),
+  })
 );
 
 jest.unstable_mockModule('../src/service/clientService.js', () => ({

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -8,6 +8,7 @@ const mockGetClientsByRole = jest.fn();
 const mockAbsensiLikes = jest.fn();
 const mockAbsensiLikesDitbinmasReport = jest.fn();
 const mockAbsensiKomentar = jest.fn();
+const mockAbsensiKomentarDitbinmasReport = jest.fn();
 const mockFindClientById = jest.fn();
 const mockFetchAndStoreInstaContent = jest.fn();
 const mockHandleFetchLikesInstagram = jest.fn();
@@ -43,6 +44,7 @@ jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTikt
   absensiKomentar: mockAbsensiKomentar,
   lapharTiktokDitbinmas: mockLapharTiktokDitbinmas,
   collectKomentarRecap: mockCollectKomentarRecap,
+  absensiKomentarDitbinmasReport: mockAbsensiKomentarDitbinmasReport,
 }));
 jest.unstable_mockModule('../src/service/clientService.js', () => ({
   findClientById: mockFindClientById,
@@ -293,9 +295,8 @@ test('choose_menu option 4 skips ketika client bukan ditbinmas', async () => {
   );
 });
 
-test('choose_menu option 5 absensi komentar filters users to ditbinmas', async () => {
-  mockAbsensiKomentar.mockResolvedValue('laporan komentar');
-  mockFindClientById.mockResolvedValue({ client_type: 'org', nama: 'POLRES A' });
+test('choose_menu option 5 absensi komentar uses ditbinmas report', async () => {
+  mockAbsensiKomentarDitbinmasReport.mockResolvedValue('laporan komentar');
 
   const session = {
     role: 'ditbinmas',
@@ -308,14 +309,7 @@ test('choose_menu option 5 absensi komentar filters users to ditbinmas', async (
 
   await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
 
-  expect(mockAbsensiKomentar).toHaveBeenCalledWith(
-    'DITBINMAS',
-    expect.objectContaining({
-      mode: 'all',
-      roleFlag: 'ditbinmas',
-      clientFilter: 'DITBINMAS',
-    })
-  );
+  expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
 });
 
@@ -355,7 +349,7 @@ test('choose_menu option 6 fetch insta returns rekap likes report', async () => 
 test('choose_menu option 8 fetch tiktok returns komentar report', async () => {
   mockFetchAndStoreTiktokContent.mockResolvedValue();
   mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
-  mockAbsensiKomentar.mockResolvedValue('laporan tiktok');
+  mockAbsensiKomentarDitbinmasReport.mockResolvedValue('laporan tiktok');
   mockSafeSendMessage.mockResolvedValue(true);
   mockFindClientById.mockResolvedValue({ client_type: 'direktorat', nama: 'DITBINMAS' });
 
@@ -380,10 +374,7 @@ test('choose_menu option 8 fetch tiktok returns komentar report', async () => {
     chatId,
     'DITBINMAS'
   );
-  expect(mockAbsensiKomentar).toHaveBeenCalledWith(
-    'DITBINMAS',
-    expect.objectContaining({ mode: 'all', roleFlag: 'ditbinmas' })
-  );
+  expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan tiktok');
   expect(mockSafeSendMessage).toHaveBeenCalledWith(
     waClient,


### PR DESCRIPTION
## Summary
- add `absensiKomentarDitbinmasReport` to compile TikTok comment engagement for Ditbinmas
- route dirrequest menu options 5 and 8 through the new recap workflow
- align tests with updated TikTok comment attendance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8d3105083279712ef0cf1bb0ac7