### PR TITLE
Ignore group and status messages for user request client

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -2217,6 +2217,10 @@ const handleUserMessage = createHandleMessage(waUserClient);
 waClient.on('message', (msg) => handleIncoming('wwebjs', msg, handleMessage));
 
 waUserClient.on('message', (msg) => {
+  const from = msg.from || '';
+  if (from.endsWith('@g.us') || from === 'status@broadcast') {
+    return;
+  }
   const text = (msg.body || '').trim().toLowerCase();
   if (text === 'userrequest' || userMenuContext[msg.from]) {
     handleIncoming('wwebjs-user', msg, handleUserMessage);


### PR DESCRIPTION
## Summary
- prevent user request WA client from responding to group chats or status updates

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c35d386bbc8327b83eeb9ebcc6c9c5