### PR TITLE
feat: add KPI cards server component

### DIFF
--- a/cicero-dashboard/app/dashboard/KpiCards.tsx
+++ b/cicero-dashboard/app/dashboard/KpiCards.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from 'react';
+
+interface KpiItem {
+  label: string;
+  value: number;
+}
+
+// Server Component fetching KPI data
+export default async function KpiCards(): Promise<ReactElement> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/aggregator`, {
+    cache: 'force-cache',
+    next: { revalidate: 60 },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch KPI data');
+  }
+
+  const data: KpiItem[] = await res.json();
+
+  return (
+    <div className="grid gap-4 md:grid-cols-4">
+      {data.map((item) => (
+        <div key={item.label} className="rounded border p-4">
+          <p className="text-sm text-gray-500">{item.label}</p>
+          <p className="text-2xl font-bold">{item.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import type { ReactElement } from 'react';
+import KpiCards from './KpiCards';
+
+export default function DashboardPage(): ReactElement {
+  return (
+    <main className="p-4">
+      <KpiCards />
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `KpiCards` server component that fetches KPI data with caching
- render KPI cards on dashboard page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c36328e0f483278f5de3608003ce65