### PR TITLE
Fix cron schedule for dirrequest recap

### DIFF
--- a/src/cron/cronDirRequestRekapAllSocmed.js
+++ b/src/cron/cronDirRequestRekapAllSocmed.js
@@ -129,7 +129,19 @@ export async function runCron(includeRekap = false) {
   }
 }
 
-cron.schedule("0 15,18 * * *", () => runCron(false), { timezone: "Asia/Jakarta" });
-cron.schedule("30 20 * * *", () => runCron(true), { timezone: "Asia/Jakarta" });
+cron.schedule(
+  "0 0 15,18 * * *",
+  async () => {
+    await runCron(false);
+  },
+  { timezone: "Asia/Jakarta" }
+);
+cron.schedule(
+  "0 30 20 * * *",
+  async () => {
+    await runCron(true);
+  },
+  { timezone: "Asia/Jakarta" }
+);
 
 export default null;


### PR DESCRIPTION
## Summary
- ensure dirrequest recap cron awaits task execution
- adjust cron expressions to include explicit seconds for correct timing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d8fe033483278cfa6938bbfe1cb6