### PR TITLE
Avoid duplicate TikTok comment fetch in cron

### DIFF
--- a/src/cron/cronDirRequestFetchSosmed.js
+++ b/src/cron/cronDirRequestFetchSosmed.js
@@ -6,7 +6,6 @@ import waClient from "../service/waService.js";
 import { fetchAndStoreInstaContent } from "../handler/fetchpost/instaFetchPost.js";
 import { handleFetchLikesInstagram } from "../handler/fetchengagement/fetchLikesInstagram.js";
 import { fetchAndStoreTiktokContent } from "../handler/fetchpost/tiktokFetchPost.js";
-import { handleFetchKomentarTiktokBatch } from "../handler/fetchengagement/fetchCommentTiktok.js";
 import { generateSosmedTaskMessage } from "../handler/fetchabsensi/sosmedTask.js";
 import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
 import { sendDebug } from "../middleware/debugHandler.js";
@@ -28,7 +27,6 @@ export async function runCron() {
     );
     await handleFetchLikesInstagram(null, null, "DITBINMAS");
     await fetchAndStoreTiktokContent("DITBINMAS");
-    await handleFetchKomentarTiktokBatch(null, null, "DITBINMAS");
     const msg = await generateSosmedTaskMessage();
     const recipients = getRecipients();
     for (const wa of recipients) {

--- a/src/handler/fetchabsensi/sosmedTask.js
+++ b/src/handler/fetchabsensi/sosmedTask.js
@@ -6,8 +6,10 @@ import { findClientById } from "../../service/clientService.js";
 import { handleFetchLikesInstagram } from "../fetchengagement/fetchLikesInstagram.js";
 import { handleFetchKomentarTiktokBatch } from "../fetchengagement/fetchCommentTiktok.js";
 
-export async function generateSosmedTaskMessage() {
-  const clientId = "DITBINMAS";
+export async function generateSosmedTaskMessage(
+  clientId = "DITBINMAS",
+  skipTiktokFetch = false
+) {
 
   let clientName = clientId;
   let tiktokUsername = "";
@@ -44,7 +46,9 @@ export async function generateSosmedTaskMessage() {
   let tiktokPosts = [];
   try {
     tiktokPosts = await getTiktokPostsToday(clientId);
-    await handleFetchKomentarTiktokBatch(null, null, clientId);
+    if (!skipTiktokFetch) {
+      await handleFetchKomentarTiktokBatch(null, null, clientId);
+    }
   } catch {
     tiktokPosts = [];
   }

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -634,7 +634,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       await handleFetchLikesInstagram(null, null, targetId);
       await fetchAndStoreTiktokContent(targetId, waClient, chatId);
       await handleFetchKomentarTiktokBatch(null, null, targetId);
-      msg = await generateSosmedTaskMessage(targetId);
+      msg = await generateSosmedTaskMessage(targetId, true);
       break;
     }
     case "13": {

--- a/tests/cronDirRequestFetchSosmed.test.js
+++ b/tests/cronDirRequestFetchSosmed.test.js
@@ -3,7 +3,6 @@ import { jest } from '@jest/globals';
 const mockFetchInsta = jest.fn();
 const mockFetchLikes = jest.fn();
 const mockFetchTiktok = jest.fn();
-const mockFetchComments = jest.fn();
 const mockGenerateMsg = jest.fn();
 const mockSafeSend = jest.fn();
 const mockSendDebug = jest.fn();
@@ -17,9 +16,6 @@ jest.unstable_mockModule('../src/handler/fetchengagement/fetchLikesInstagram.js'
 }));
 jest.unstable_mockModule('../src/handler/fetchpost/tiktokFetchPost.js', () => ({
   fetchAndStoreTiktokContent: mockFetchTiktok,
-}));
-jest.unstable_mockModule('../src/handler/fetchengagement/fetchCommentTiktok.js', () => ({
-  handleFetchKomentarTiktokBatch: mockFetchComments,
 }));
 jest.unstable_mockModule('../src/handler/fetchabsensi/sosmedTask.js', () => ({
   generateSosmedTaskMessage: mockGenerateMsg,
@@ -54,7 +50,6 @@ test('runCron fetches sosmed and sends message to recipients', async () => {
   );
   expect(mockFetchLikes).toHaveBeenCalledWith(null, null, 'DITBINMAS');
   expect(mockFetchTiktok).toHaveBeenCalledWith('DITBINMAS');
-  expect(mockFetchComments).toHaveBeenCalledWith(null, null, 'DITBINMAS');
   expect(mockGenerateMsg).toHaveBeenCalled();
   expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'msg');
   expect(mockSafeSend).toHaveBeenCalledWith(

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -387,8 +387,8 @@ test('choose_menu option 12 fetch sosial media sends combined task', async () =>
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();
   mockFetchAndStoreTiktokContent.mockResolvedValue();
-  mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
-  mockGenerateSosmedTaskMessage.mockResolvedValue('tugas sosmed');
+      mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
+      mockGenerateSosmedTaskMessage.mockResolvedValue('tugas sosmed');
   mockSafeSendMessage.mockResolvedValue(true);
   mockFindClientById.mockResolvedValue({ client_type: 'direktorat', nama: 'DITBINMAS' });
 
@@ -416,7 +416,7 @@ test('choose_menu option 12 fetch sosial media sends combined task', async () =>
     chatId
   );
   expect(mockHandleFetchKomentarTiktokBatch).toHaveBeenCalledWith(null, null, 'DITBINMAS');
-  expect(mockGenerateSosmedTaskMessage).toHaveBeenCalledWith('DITBINMAS');
+  expect(mockGenerateSosmedTaskMessage).toHaveBeenCalledWith('DITBINMAS', true);
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'tugas sosmed');
   expect(mockSafeSendMessage).toHaveBeenCalledWith(
     waClient,

--- a/tests/sosmedTask.test.js
+++ b/tests/sosmedTask.test.js
@@ -35,6 +35,10 @@ beforeAll(async () => {
   ({ generateSosmedTaskMessage } = await import('../src/handler/fetchabsensi/sosmedTask.js'));
 });
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 test('generateSosmedTaskMessage formats message correctly', async () => {
   mockFindClientById.mockResolvedValue({ nama: 'Dit Binmas', client_tiktok: '' });
   mockGetShortcodesTodayByClient.mockResolvedValue(['abc']);
@@ -53,4 +57,15 @@ test('generateSosmedTaskMessage formats message correctly', async () => {
   expect(msg).toContain('2 likes');
   expect(mockHandleFetchLikesInstagram).toHaveBeenCalledWith(null, null, 'DITBINMAS');
   expect(mockHandleFetchKomentarTiktokBatch).toHaveBeenCalledWith(null, null, 'DITBINMAS');
+});
+
+test('generateSosmedTaskMessage can skip tiktok fetch', async () => {
+  mockFindClientById.mockResolvedValue({ nama: 'Dit Binmas', client_tiktok: '' });
+  mockGetShortcodesTodayByClient.mockResolvedValue([]);
+  mockGetTiktokPostsToday.mockResolvedValue([]);
+  mockHandleFetchLikesInstagram.mockResolvedValue();
+
+  await generateSosmedTaskMessage('DITBINMAS', true);
+
+  expect(mockHandleFetchKomentarTiktokBatch).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- prevent cronDirRequestFetchSosmed from invoking `handleFetchKomentarTiktokBatch` directly
- allow `generateSosmedTaskMessage` to skip redundant comment fetching
- update menu handler and tests for single-comment-fetch flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e624842c8327826de044e814e3f1