### PR TITLE
Limit Instagram cron to active ORG clients

### DIFF
--- a/src/cron/cronInstaService.js
+++ b/src/cron/cronInstaService.js
@@ -26,13 +26,30 @@ cron.schedule(
         "taken_at",
         "comment_count",
       ];
-      const fetchSummary = await fetchAndStoreInstaContent(keys);
+      const fetchSummary = {};
+      for (const client of clients) {
+        try {
+          const res = await fetchAndStoreInstaContent(
+            keys,
+            null,
+            null,
+            client.client_id
+          );
+          const stat = res?.[client.client_id] || {};
+          fetchSummary[client.client_id] = { count: stat.count || 0 };
+        } catch (err) {
+          fetchSummary[client.client_id] = {
+            count: 0,
+            error: err.message,
+          };
+        }
+      }
 
       let debugMsg = `[CRON IG] Ringkasan fetch Instagram\n`;
       debugMsg += `Tanggal: ${new Date().toLocaleString("id-ID", {
         timeZone: "Asia/Jakarta",
       })}\n`;
-      if (fetchSummary && typeof fetchSummary === "object") {
+      if (Object.keys(fetchSummary).length) {
         Object.entries(fetchSummary).forEach(([client, stat]) => {
           debugMsg += `Client: ${client}\n  - Jumlah post hari ini: ${stat.count || 0}\n`;
           if (stat.error) debugMsg += `  - Error: ${stat.error}\n`;


### PR DESCRIPTION
## Summary
- Fetch Instagram posts only for clients with active status and type ORG in cron job
- Provide per-client fetch summary in debug logs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3f05c64c08327a9daab9af69d864d