### PR TITLE
Rename rekap recipient flag in cron and update docs

### DIFF
--- a/docs/activity_schedule.md
+++ b/docs/activity_schedule.md
@@ -12,6 +12,7 @@ This document summarizes the automated jobs ("activity") that run inside Cicero_
 | `cronRekapLink.js` | `2 15,18,21 * * *` | Daily at 15:02, 18:02 and 21:02. Sends attendance link recaps to operators and admins. |
 | `cronAbsensiUserData.js` | `0 13 * * *` | Daily at 13:00. Notifies users and operators about incomplete registration data. |
 | `cronAmplifyLinkMonthly.js` | `0 23 28-31 * *` | At 23:00 on the last day of each month. Generates monthly amplification link reports and sends an Excel file to each operator. |
+| `cronDirRequestRekapAllSocmed.js` | `0 0 15,18 * * *` & `0 30 20 * * *` | 15:00 & 18:00 send recaps to admins and group; 20:30 also sends to the rekap recipient. |
 
 Each job collects data from the database, interacts with RapidAPI or WhatsApp, and updates the system accordingly. The cron files are imported in `app.js` so no additional setup is required.
 

--- a/src/cron/cronDirRequestRekapAllSocmed.js
+++ b/src/cron/cronDirRequestRekapAllSocmed.js
@@ -23,15 +23,15 @@ const DIRREQUEST_GROUP = "120363419830216549@g.us";
 const REKAP_RECIPIENT = "6281234560377@c.us";
 const CLIENT_ID = "DITBINMAS";
 
-function getRecipients(includeRekap = false) {
+function getRecipients(sendToRekapRecipient = false) {
   const recipients = new Set([...getAdminWAIds(), DIRREQUEST_GROUP]);
-  if (includeRekap) {
+  if (sendToRekapRecipient) {
     recipients.add(REKAP_RECIPIENT);
   }
   return recipients;
 }
 
-export async function runCron(includeRekap = false) {
+export async function runCron(sendToRekapRecipient = false) {
   const shouldArchive = process.env.LAPHAR_ARCHIVE === "true";
   sendDebug({
     tag: "CRON DIRREQ ALL SOCMED",
@@ -43,7 +43,7 @@ export async function runCron(includeRekap = false) {
   let ttPath = null;
   try {
     try {
-      const recipients = getRecipients(includeRekap);
+      const recipients = getRecipients(sendToRekapRecipient);
       const dirPath = "laphar";
       if (shouldArchive) {
         await mkdir(dirPath, { recursive: true });
@@ -147,6 +147,7 @@ export async function runCron(includeRekap = false) {
 cron.schedule(
   "0 0 15,18 * * *",
   async () => {
+    // Send recap to admin and group only
     await runCron(false);
   },
   { timezone: "Asia/Jakarta" }
@@ -154,6 +155,7 @@ cron.schedule(
 cron.schedule(
   "0 30 20 * * *",
   async () => {
+    // Send recap to admin, group, and rekap recipient
     await runCron(true);
   },
   { timezone: "Asia/Jakarta" }


### PR DESCRIPTION
## Summary
- rename includeRekap parameter to sendToRekapRecipient in cron job
- document cron behavior in schedule and docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4036d650c83279465535bbcdab299