### PR TITLE
Send Ditbinmas comment recap in directorate cron

### DIFF
--- a/src/cron/cronDirRequestDirektorat.js
+++ b/src/cron/cronDirRequestDirektorat.js
@@ -3,10 +3,8 @@ import dotenv from "dotenv";
 dotenv.config();
 
 import waClient from "../service/waService.js";
-import {
-  absensiLikesDitbinmas,
-  formatRekapBelumLengkapDitbinmas,
-} from "../handler/menu/dirRequestHandlers.js";
+import { absensiLikesDitbinmas } from "../handler/menu/dirRequestHandlers.js";
+import { absensiKomentarDitbinmasReport } from "../handler/fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
 import { sendDebug } from "../middleware/debugHandler.js";
 
@@ -20,11 +18,11 @@ export async function runCron() {
   sendDebug({ tag: "CRON DIRREQ DIREKTORAT", msg: "Mulai cron dirrequest direktorat" });
   try {
     const likesMsg = await absensiLikesDitbinmas();
-    const rekapMsg = await formatRekapBelumLengkapDitbinmas();
+    const komentarMsg = await absensiKomentarDitbinmasReport();
     const recipients = getRecipients();
     for (const wa of recipients) {
       await safeSendMessage(waClient, wa, likesMsg.trim());
-      await safeSendMessage(waClient, wa, rekapMsg.trim());
+      await safeSendMessage(waClient, wa, komentarMsg.trim());
     }
     sendDebug({
       tag: "CRON DIRREQ DIREKTORAT",

--- a/tests/cronDirRequestDirektorat.test.js
+++ b/tests/cronDirRequestDirektorat.test.js
@@ -1,15 +1,20 @@
 import { jest } from '@jest/globals';
 
 const mockAbsensi = jest.fn();
-const mockRekap = jest.fn();
+const mockKomentar = jest.fn();
 const mockSafeSend = jest.fn();
 const mockSendDebug = jest.fn();
 
 jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
 jest.unstable_mockModule('../src/handler/menu/dirRequestHandlers.js', () => ({
   absensiLikesDitbinmas: mockAbsensi,
-  formatRekapBelumLengkapDitbinmas: mockRekap,
 }));
+jest.unstable_mockModule(
+  '../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js',
+  () => ({
+    absensiKomentarDitbinmasReport: mockKomentar,
+  })
+);
 jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
   safeSendMessage: mockSafeSend,
   getAdminWAIds: () => ['123@c.us'],
@@ -27,19 +32,19 @@ beforeAll(async () => {
 beforeEach(() => {
   jest.clearAllMocks();
   mockAbsensi.mockResolvedValue('absensi');
-  mockRekap.mockResolvedValue('rekap');
+  mockKomentar.mockResolvedValue('komentar');
 });
 
-test('runCron sends absensi and rekap to admin and rekap recipient', async () => {
+test('runCron sends absensi and komentar to admin and rekap recipient', async () => {
   await runCron();
 
   expect(mockAbsensi).toHaveBeenCalled();
-  expect(mockRekap).toHaveBeenCalled();
+  expect(mockKomentar).toHaveBeenCalled();
 
   expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'absensi');
-  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'komentar');
   expect(mockSafeSend).toHaveBeenCalledWith({}, '6281234560377@c.us', 'absensi');
-  expect(mockSafeSend).toHaveBeenCalledWith({}, '6281234560377@c.us', 'rekap');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '6281234560377@c.us', 'komentar');
   expect(mockSafeSend).toHaveBeenCalledTimes(4);
 });
 


### PR DESCRIPTION
## Summary
- send Ditbinmas TikTok comment recap alongside likes recap in directorate cron job
- adjust cronDirRequestDirektorat test to expect comment recap

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4049db88483278241b4651a58dbde