### PR TITLE
Limit dirrequest rekap cron to DITBINMAS only

### DIFF
--- a/src/cron/cronDirRequestRekapAllSocmed.js
+++ b/src/cron/cronDirRequestRekapAllSocmed.js
@@ -52,8 +52,8 @@ export async function runCron(sendToRekapRecipient = false) {
       const [ig, tt, igRecap, ttRecap] = await Promise.all([
         lapharDitbinmas(),
         lapharTiktokDitbinmas(),
-        collectLikesRecap(CLIENT_ID),
-        collectKomentarRecap(CLIENT_ID),
+        collectLikesRecap(CLIENT_ID, { selfOnly: true }),
+        collectKomentarRecap(CLIENT_ID, { selfOnly: true }),
       ]);
 
       const narrative = formatRekapAllSosmed(ig.narrative, tt.narrative);

--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -29,14 +29,19 @@ async function getClientInfo(client_id) {
   };
 }
 
-export async function collectLikesRecap(clientId) {
+export async function collectLikesRecap(clientId, opts = {}) {
   const shortcodes = await getShortcodesTodayByClient(clientId);
   const likesSets = [];
   for (const sc of shortcodes) {
     const likes = await getLikesByShortcode(sc);
     likesSets.push(new Set((likes || []).map(normalizeUsername)));
   }
-  const polresIds = (await getClientsByRole(clientId)).map((c) => c.toUpperCase());
+  let polresIds;
+  if (opts.selfOnly) {
+    polresIds = [clientId.toUpperCase()];
+  } else {
+    polresIds = (await getClientsByRole(clientId)).map((c) => c.toUpperCase());
+  }
   const allUsers = (
     await getUsersByDirektorat(clientId, polresIds)
   ).filter((u) => u.status === true);

--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -48,7 +48,7 @@ function normalizeUsername(username) {
     .toLowerCase();
 }
 
-export async function collectKomentarRecap(clientId) {
+export async function collectKomentarRecap(clientId, opts = {}) {
   const posts = await getPostsTodayByClient(clientId);
   const videoIds = posts.map((p) => p.video_id);
   const commentSets = [];
@@ -56,7 +56,12 @@ export async function collectKomentarRecap(clientId) {
     const { comments } = await getCommentsByVideoId(vid);
     commentSets.push(new Set(extractUsernamesFromComments(comments)));
   }
-  const polresIds = (await getClientsByRole(clientId)).map((c) => c.toUpperCase());
+  let polresIds;
+  if (opts.selfOnly) {
+    polresIds = [clientId.toUpperCase()];
+  } else {
+    polresIds = (await getClientsByRole(clientId)).map((c) => c.toUpperCase());
+  }
   const allUsers = (
     await getUsersByDirektorat(clientId, polresIds)
   ).filter((u) => u.status === true);

--- a/tests/collectLikesRecap.test.js
+++ b/tests/collectLikesRecap.test.js
@@ -59,3 +59,32 @@ test('collectLikesRecap normalizes client IDs', async () => {
     },
   ]);
 });
+
+test('collectLikesRecap selfOnly limits to given client', async () => {
+  mockGetShortcodesTodayByClient.mockResolvedValue(['SC1']);
+  mockGetLikesByShortcode.mockResolvedValue(['user1']);
+  mockGetUsersByDirektorat.mockResolvedValue([
+    {
+      client_id: 'DITBINMAS',
+      divisi: 'Sat A',
+      title: 'AKP',
+      nama: 'Budi',
+      insta: 'user1',
+      status: true,
+    },
+  ]);
+  mockQuery.mockResolvedValue({ rows: [{ nama: 'DITBINMAS' }] });
+
+  const result = await collectLikesRecap('DITBINMAS', { selfOnly: true });
+
+  expect(mockGetClientsByRole).not.toHaveBeenCalled();
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('DITBINMAS', ['DITBINMAS']);
+  expect(result.recap['DITBINMAS']).toEqual([
+    {
+      pangkat: 'AKP',
+      nama: 'Budi',
+      satfung: 'Sat A',
+      SC1: 1,
+    },
+  ]);
+});

--- a/tests/cronDirRequestRekapAllSocmed.test.js
+++ b/tests/cronDirRequestRekapAllSocmed.test.js
@@ -86,6 +86,9 @@ beforeEach(() => {
 test('runCron without rekap sends to admin and group only', async () => {
   await runCron(false);
 
+  expect(mockCollectLikesRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
+  expect(mockCollectKomentarRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
+
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'nar ig + nar tt');
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'nar ig + nar tt');
   expect(mockSafeSendMessage).not.toHaveBeenCalledWith({}, '6281234560377@c.us', 'nar ig + nar tt');
@@ -101,6 +104,9 @@ test('runCron without rekap sends to admin and group only', async () => {
 
 test('runCron with rekap sends to all recipients', async () => {
   await runCron(true);
+
+  expect(mockCollectLikesRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
+  expect(mockCollectKomentarRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
 
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'nar ig + nar tt');
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'nar ig + nar tt');


### PR DESCRIPTION
## Summary
- restrict `collectLikesRecap` and `collectKomentarRecap` to support self-only processing
- run `cronDirRequestRekapAllSocmed` using the self-only option so only client_id DITBINMAS is processed
- add tests for the new option

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c408899d78832783beac8c018e71bc