### PR TITLE
fix: normalize directorate flag for recap

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -30,6 +30,7 @@ async function getClientInfo(client_id) {
 }
 
 export async function collectLikesRecap(clientId, opts = {}) {
+  const roleName = String(clientId || "").toLowerCase();
   const shortcodes = await getShortcodesTodayByClient(clientId);
   const likesSets = [];
   for (const sc of shortcodes) {
@@ -38,12 +39,12 @@ export async function collectLikesRecap(clientId, opts = {}) {
   }
   let polresIds;
   if (opts.selfOnly) {
-    polresIds = [clientId.toUpperCase()];
+    polresIds = [String(clientId).toUpperCase()];
   } else {
-    polresIds = (await getClientsByRole(clientId)).map((c) => c.toUpperCase());
+    polresIds = (await getClientsByRole(roleName)).map((c) => c.toUpperCase());
   }
   const allUsers = (
-    await getUsersByDirektorat(clientId, polresIds)
+    await getUsersByDirektorat(roleName, polresIds)
   ).filter((u) => u.status === true);
   const usersByClient = {};
   allUsers.forEach((u) => {

--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -56,14 +56,15 @@ export async function collectKomentarRecap(clientId, opts = {}) {
     const { comments } = await getCommentsByVideoId(vid);
     commentSets.push(new Set(extractUsernamesFromComments(comments)));
   }
+  const roleName = String(clientId || "").toLowerCase();
   let polresIds;
   if (opts.selfOnly) {
-    polresIds = [clientId.toUpperCase()];
+    polresIds = [String(clientId).toUpperCase()];
   } else {
-    polresIds = (await getClientsByRole(clientId)).map((c) => c.toUpperCase());
+    polresIds = (await getClientsByRole(roleName)).map((c) => c.toUpperCase());
   }
   const allUsers = (
-    await getUsersByDirektorat(clientId, polresIds)
+    await getUsersByDirektorat(roleName, polresIds)
   ).filter((u) => u.status === true);
   const usersByClient = {};
   allUsers.forEach((u) => {

--- a/tests/collectLikesRecap.test.js
+++ b/tests/collectLikesRecap.test.js
@@ -78,7 +78,7 @@ test('collectLikesRecap selfOnly limits to given client', async () => {
   const result = await collectLikesRecap('DITBINMAS', { selfOnly: true });
 
   expect(mockGetClientsByRole).not.toHaveBeenCalled();
-  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('DITBINMAS', ['DITBINMAS']);
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', ['DITBINMAS']);
   expect(result.recap['DITBINMAS']).toEqual([
     {
       pangkat: 'AKP',


### PR DESCRIPTION
## Summary
- Normalize directorate flag to lowercase when collecting Instagram and TikTok recap data
- Adjust tests for new directorate flag handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c40b1c42188327a4ce8a63b9d12412