### PR TITLE
feat(dirrequest): add tiktok comment attendance menu

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -8,6 +8,7 @@ import {
 import {
   lapharTiktokDitbinmas,
   collectKomentarRecap,
+  absensiKomentar,
   absensiKomentarDitbinmasReport,
 } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { findClientById } from "../../service/clientService.js";
@@ -750,6 +751,16 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       }
       return;
     }
+    case "16": {
+      const normalizedId = (clientId || "").toUpperCase();
+      if (normalizedId !== "DITBINMAS") {
+        msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
+        break;
+      }
+      const opts = { mode: "all", roleFlag: "ditbinmas" };
+      msg = await absensiKomentar("DITBINMAS", opts);
+      break;
+    }
     default:
       msg = "Menu tidak dikenal.";
   }
@@ -859,6 +870,7 @@ export const dirRequestHandlers = {
         "1️⃣3️⃣ Laphar TikTok Ditbinmas\n" +
         "1️⃣4️⃣ Rekap Likes Instagram (Excel)\n" +
         "1️⃣5️⃣ Rekap All Sosmed\n" +
+        "1️⃣6️⃣ Absensi Komentar Tiktok\n" +
         "┗━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -899,6 +911,7 @@ export const dirRequestHandlers = {
       "13",
       "14",
       "15",
+      "16",
     ].includes(choice)) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
       return;

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -313,6 +313,50 @@ test('choose_menu option 5 absensi komentar uses ditbinmas report', async () => 
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
 });
 
+test('choose_menu option 16 absensi komentar tiktok uses ditbinmas data for all users', async () => {
+  mockAbsensiKomentar.mockResolvedValue('laporan komentar tiktok');
+
+  const session = {
+    role: 'ditbinmas',
+    selectedClientId: 'polres_a',
+    clientName: 'POLRES A',
+    dir_client_id: 'ditbinmas',
+  };
+  const chatId = '765';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
+
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', {
+    mode: 'all',
+    roleFlag: 'ditbinmas',
+  });
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    'laporan komentar tiktok'
+  );
+});
+
+test('choose_menu option 16 skips ketika client bukan ditbinmas', async () => {
+  mockAbsensiKomentar.mockResolvedValue('laporan komentar tiktok');
+
+  const session = {
+    role: 'polres',
+    selectedClientId: 'polres_a',
+    clientName: 'POLRES A',
+  };
+  const chatId = '766';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
+
+  expect(mockAbsensiKomentar).not.toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('DITBINMAS')
+  );
+});
+
 test('choose_menu option 6 fetch insta returns rekap likes report', async () => {
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();


### PR DESCRIPTION
## Summary
- extend dirrequest menu with "1️⃣6️⃣ Absensi Komentar Tiktok" option
- route new menu to absensiKomentar for TikTok comment attendance
- cover new menu option with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c433bee280832782b0c23617dae055