### PR TITLE
feat: refine tiktok comment recap

### DIFF
--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -47,6 +47,7 @@ test('aggregates directorate data per client', async () => {
 
   expect(msg).toContain('POLRES A');
   expect(msg).toContain('✅ *Sudah melaksanakan* : *1 user*');
+  expect(msg).toContain('⚠️ *Melaksanakan kurang lengkap* : *0 user*');
   expect(msg).toContain('POLRES B');
   expect(msg).toContain('❌ *Belum melaksanakan* : *1 user*');
   expect(msg).not.toMatch(/usera/i);


### PR DESCRIPTION
## Summary
- track TikTok comment attendance per polres with full status buckets
- note partial participation in TikTok comment recap test

## Testing
- `npm run lint`
- `npm test tests/absensiKomentarDirektorat.test.js -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c43e9217bc8327b73bf0c1abb05171