### PR TITLE
Avoid client filter for directorate user lookup

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
+++ b/src/handler/fetchabsensi/insta/absensiKomentarInstagram.js
@@ -44,11 +44,7 @@ export async function absensiKomentarInstagram(client_id, opts = {}) {
   const clientNama = await getClientNama(targetClient);
   const allowedRoles = ["ditbinmas", "ditlantas", "bidhumas"];
   let users;
-  if (
-    roleFlag &&
-    allowedRoles.includes(roleFlag.toLowerCase()) &&
-    roleFlag.toUpperCase() === targetClient.toUpperCase()
-  ) {
+  if (roleFlag && allowedRoles.includes(roleFlag.toLowerCase())) {
     users = (await getUsersByDirektorat(roleFlag.toLowerCase())).filter(
       (u) => u.status === true
     );

--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -112,13 +112,9 @@ export async function absensiKomentar(client_id, opts = {}) {
   const tiktokUsername = clientInfo.tiktok;
   const allowedRoles = ["ditbinmas", "ditlantas", "bidhumas"];
   let users;
-  if (
-    roleFlag &&
-    allowedRoles.includes(roleFlag.toLowerCase()) &&
-    roleFlag.toUpperCase() === client_id.toUpperCase()
-  ) {
+  if (roleFlag && allowedRoles.includes(roleFlag.toLowerCase())) {
     users = (
-      await getUsersByDirektorat(roleFlag.toLowerCase(), clientFilter || client_id)
+      await getUsersByDirektorat(roleFlag.toLowerCase())
     ).filter((u) => u.status === true);
   } else {
     users = await getUsersByClient(clientFilter || client_id, roleFlag);

--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -43,7 +43,7 @@ test('aggregates directorate data per client', async () => {
 
   const msg = await absensiKomentar('ditbinmas', { roleFlag: 'ditbinmas' });
 
-  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'ditbinmas');
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
 
   expect(msg).toContain('POLRES A');
   expect(msg).toContain('✅ *Sudah melaksanakan* : *1 user*');

--- a/tests/absensiKomentarInstagramRoleFlag.test.js
+++ b/tests/absensiKomentarInstagramRoleFlag.test.js
@@ -24,13 +24,13 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-test('filters users by roleFlag when provided', async () => {
+test('uses getUsersByDirektorat when roleFlag is a directorate', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC' }] });
-  mockGetUsersByClient.mockResolvedValueOnce([]);
+  mockGetUsersByDirektorat.mockResolvedValueOnce([]);
   mockGetShortcodesTodayByClient.mockResolvedValueOnce([]);
 
   await absensiKomentarInstagram('POLRES', { roleFlag: 'ditbinmas' });
 
-  expect(mockGetUsersByClient).toHaveBeenCalledWith('POLRES', 'ditbinmas');
-  expect(mockGetUsersByDirektorat).not.toHaveBeenCalled();
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
+  expect(mockGetUsersByClient).not.toHaveBeenCalled();
 });

--- a/tests/absensiKomentarTiktokRoleFlag.test.js
+++ b/tests/absensiKomentarTiktokRoleFlag.test.js
@@ -33,13 +33,13 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-test('filters users by roleFlag when provided', async () => {
+test('uses getUsersByDirektorat when roleFlag is a directorate', async () => {
   mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'POLRES ABC', client_tiktok: '@abc', client_type: 'org' }] });
-  mockGetUsersByClient.mockResolvedValueOnce([]);
+  mockGetUsersByDirektorat.mockResolvedValueOnce([]);
   mockGetPostsTodayByClient.mockResolvedValueOnce([]);
 
   await absensiKomentar('POLRES', { roleFlag: 'ditbinmas' });
 
-  expect(mockGetUsersByClient).toHaveBeenCalledWith('POLRES', 'ditbinmas');
-  expect(mockGetUsersByDirektorat).not.toHaveBeenCalled();
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
+  expect(mockGetUsersByClient).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- Fetch users by directorate role without filtering by `client_id` in TikTok and Instagram comment attendance handlers
- Update unit tests to match new behavior

## Testing
- `npm run lint`
- `npm test` *(fails: A jest worker process was terminated due to out-of-memory, specifically in tests/absensiKomentarDitbinmasReport.test.js)*
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- tests/absensiKomentarDitbinmasReport.test.js` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ae2806f8832789fcf55f998f68a6