### PR TITLE
Add batch client name lookup

### DIFF
--- a/src/controller/clientController.js
+++ b/src/controller/clientController.js
@@ -32,6 +32,20 @@ export const getActiveClients = async (req, res, next) => {
   }
 };
 
+// Ambil nama-nama client secara batch
+export const getClientNamesBatch = async (req, res, next) => {
+  try {
+    const { client_ids: clientIds } = req.body;
+    if (!Array.isArray(clientIds) || clientIds.length === 0) {
+      return res.status(400).json({ error: 'client_ids must be a non-empty array' });
+    }
+    const names = await clientService.findClientNamesByIds(clientIds);
+    sendSuccess(res, names);
+  } catch (err) {
+    next(err);
+  }
+};
+
 // Detail client
 export const getClientById = async (req, res, next) => {
   try {

--- a/src/model/clientModel.js
+++ b/src/model/clientModel.js
@@ -158,3 +158,15 @@ export async function getAllClientIds() {
     status: r.client_status,
   }));
 }
+
+export async function findNamesByIds(clientIds) {
+  const res = await query(
+    'SELECT client_id, nama FROM clients WHERE client_id = ANY($1)',
+    [clientIds]
+  );
+  const map = {};
+  for (const row of res.rows) {
+    map[row.client_id] = row.nama;
+  }
+  return map;
+}

--- a/src/routes/clientRoutes.js
+++ b/src/routes/clientRoutes.js
@@ -6,6 +6,7 @@ import { authRequired } from "../middleware/authMiddleware.js"; // pastikan puny
 const router = express.Router();
 // Routes untuk client
 router.get("/", clientController.getAllClients);
+router.post("/names", clientController.getClientNamesBatch);
 // routes profile client
 router.get("/profile", clientController.getClientProfile);
 router.get("/active", clientController.getActiveClients);

--- a/src/service/clientService.js
+++ b/src/service/clientService.js
@@ -14,6 +14,9 @@ export const findAllClients = async () => await clientModel.findAll();
 
 export const findClientById = async (client_id) => await clientModel.findById(client_id);
 
+export const findClientNamesByIds = async (clientIds) =>
+  await clientModel.findNamesByIds(clientIds);
+
 export const createClient = async (data) => await clientModel.create(data);
 
 export const updateClient = async (client_id, data) => await clientModel.update(client_id, data);


### PR DESCRIPTION
## Summary
- allow posting client IDs to /clients/names to fetch name map
- implement getClientNamesBatch controller and service/model helpers

## Testing
- `npm run lint`
- `npm test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c51547b2e8832790c6fdc499d35fd3