### PR TITLE
chore: batch client names lookup

### DIFF
--- a/app/api/clients/names/route.ts
+++ b/app/api/clients/names/route.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { client_id: clientIds } = await req.json();
+
+    const authHeader = req.headers.get('authorization') || '';
+
+    const response = await fetch(`${process.env.API_BASE_URL}/api/clients/names`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader,
+      },
+      body: JSON.stringify({ client_id: clientIds, Authorization: authHeader }),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- replace per-client loop with a single backend request for client names
- forward client IDs and auth header

## Testing
- `npm run lint`
- `npm test` *(fails: hangs due to open handles, but tests show passing output before hang)*

------
https://chatgpt.com/codex/tasks/task_e_68c5168d81c0832790a8fd207c37c00a