### PR TITLE
refactor client names fetch

### DIFF
--- a/app/api/clients/names/route.ts
+++ b/app/api/clients/names/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
         'Content-Type': 'application/json',
         Authorization: authHeader,
       },
-      body: JSON.stringify({ client_id: clientIds, Authorization: authHeader }),
+      body: JSON.stringify({ client_id: clientIds }),
     });
 
     const data = await response.json();

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,0 +1,19 @@
+const API_BASE_URL = process.env.API_BASE_URL || '';
+
+export async function getClientNamesBatch(clientIds, authHeader = '') {
+  const uniqueIds = Array.from(new Set(clientIds));
+  const response = await fetch(`${API_BASE_URL}/api/clients/names`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: authHeader,
+    },
+    body: JSON.stringify({ client_id: uniqueIds }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch client names');
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- call client names batch endpoint directly using API_BASE_URL
- simplify proxy route to forward only client ids

## Testing
- `npm run lint`
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory for tests/absensiKomentarDitbinmasReport.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c518e1b39c83279f24331b27ede2cd