### PR TITLE
fix: handle camelCase client ids in client names batch

### DIFF
--- a/src/controller/clientController.js
+++ b/src/controller/clientController.js
@@ -35,9 +35,11 @@ export const getActiveClients = async (req, res, next) => {
 // Ambil nama-nama client secara batch
 export const getClientNamesBatch = async (req, res, next) => {
   try {
-    const { client_ids: clientIds } = req.body;
+    const clientIds = req.body.clientIds || req.body.client_ids;
     if (!Array.isArray(clientIds) || clientIds.length === 0) {
-      return res.status(400).json({ error: 'client_ids must be a non-empty array' });
+      return res
+        .status(400)
+        .json({ error: 'clientIds must be a non-empty array' });
     }
     const names = await clientService.findClientNamesByIds(clientIds);
     sendSuccess(res, names);

--- a/tests/clientNamesBatch.test.js
+++ b/tests/clientNamesBatch.test.js
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals';
+
+const mockFindClientNamesByIds = jest.fn();
+
+jest.unstable_mockModule('../src/service/clientService.js', () => ({
+  findClientNamesByIds: mockFindClientNamesByIds,
+}));
+jest.unstable_mockModule('../src/model/userModel.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaPostService.js', () => ({}));
+jest.unstable_mockModule('../src/service/instaLikeService.js', () => ({}));
+jest.unstable_mockModule('../src/service/tiktokPostService.js', () => ({}));
+jest.unstable_mockModule('../src/service/tiktokCommentService.js', () => ({}));
+
+let getClientNamesBatch;
+
+beforeAll(async () => {
+  ({ getClientNamesBatch } = await import('../src/controller/clientController.js'));
+});
+
+afterEach(() => {
+  mockFindClientNamesByIds.mockReset();
+});
+
+test('accepts snake_case client_ids', async () => {
+  mockFindClientNamesByIds.mockResolvedValueOnce({ C1: 'Client 1' });
+  const req = { body: { client_ids: ['C1'] } };
+  const status = jest.fn().mockReturnThis();
+  const json = jest.fn();
+  const res = { status, json };
+
+  await getClientNamesBatch(req, res, () => {});
+
+  expect(mockFindClientNamesByIds).toHaveBeenCalledWith(['C1']);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({ success: true, data: { C1: 'Client 1' } });
+});
+
+test('accepts camelCase clientIds', async () => {
+  mockFindClientNamesByIds.mockResolvedValueOnce({ C2: 'Client 2' });
+  const req = { body: { clientIds: ['C2'] } };
+  const status = jest.fn().mockReturnThis();
+  const json = jest.fn();
+  const res = { status, json };
+
+  await getClientNamesBatch(req, res, () => {});
+
+  expect(mockFindClientNamesByIds).toHaveBeenCalledWith(['C2']);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({ success: true, data: { C2: 'Client 2' } });
+});
+
+test('returns 400 for missing ids', async () => {
+  const req = { body: {} };
+  const status = jest.fn().mockReturnThis();
+  const json = jest.fn();
+  const res = { status, json };
+
+  await getClientNamesBatch(req, res, () => {});
+
+  expect(status).toHaveBeenCalledWith(400);
+  expect(json).toHaveBeenCalledWith({ error: 'clientIds must be a non-empty array' });
+});


### PR DESCRIPTION
## Summary
- accept both `clientIds` and `client_ids` when requesting client names
- add tests for client name batch endpoint

## Testing
- `npm run lint`
- `npm test`
- `npm test -- --runTestsByPath tests/clientNamesBatch.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c51b54a1c883279214d84190416f2f