### PR TITLE
Fix client names batch request field

### DIFF
--- a/app/api/clients/names/route.ts
+++ b/app/api/clients/names/route.ts
@@ -3,7 +3,8 @@ import { NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
   try {
-    const { client_id: clientIds } = await req.json();
+    const { client_ids, clientIds } = await req.json();
+    const ids = client_ids || clientIds;
 
     const authHeader = req.headers.get('authorization') || '';
 
@@ -13,7 +14,7 @@ export async function POST(req: NextRequest) {
         'Content-Type': 'application/json',
         Authorization: authHeader,
       },
-      body: JSON.stringify({ client_id: clientIds }),
+      body: JSON.stringify({ client_ids: ids }),
     });
 
     const data = await response.json();

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -8,7 +8,7 @@ export async function getClientNamesBatch(clientIds, authHeader = '') {
       'Content-Type': 'application/json',
       Authorization: authHeader,
     },
-    body: JSON.stringify({ client_id: uniqueIds }),
+    body: JSON.stringify({ client_ids: uniqueIds }),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- send `client_ids` array when requesting client names to match backend expectations
- proxy client names route accepts both `clientIds` and `client_ids` and forwards `client_ids`

## Testing
- `npm run lint`
- `npm test` *(fails: A jest worker process was terminated by another process: signal=SIGTERM)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d1d6e848327ab208b16be9f8971