### PR TITLE
Send directorate cron reports via WA-GATEWAY

### DIFF
--- a/src/cron/cronDirRequestDirektorat.js
+++ b/src/cron/cronDirRequestDirektorat.js
@@ -2,7 +2,7 @@ import cron from "node-cron";
 import dotenv from "dotenv";
 dotenv.config();
 
-import waClient from "../service/waService.js";
+import { waGatewayClient } from "../service/waService.js";
 import { absensiLikesDitbinmas } from "../handler/menu/dirRequestHandlers.js";
 import { absensiKomentarDitbinmasReport } from "../handler/fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
@@ -21,8 +21,8 @@ export async function runCron() {
     const komentarMsg = await absensiKomentarDitbinmasReport();
     const recipients = getRecipients();
     for (const wa of recipients) {
-      await safeSendMessage(waClient, wa, likesMsg.trim());
-      await safeSendMessage(waClient, wa, komentarMsg.trim());
+      await safeSendMessage(waGatewayClient, wa, likesMsg.trim());
+      await safeSendMessage(waGatewayClient, wa, komentarMsg.trim());
     }
     sendDebug({
       tag: "CRON DIRREQ DIREKTORAT",

--- a/src/cron/cronDirRequestFetchSosmed.js
+++ b/src/cron/cronDirRequestFetchSosmed.js
@@ -2,7 +2,7 @@ import cron from "node-cron";
 import dotenv from "dotenv";
 dotenv.config();
 
-import waClient from "../service/waService.js";
+import { waGatewayClient } from "../service/waService.js";
 import { fetchAndStoreInstaContent } from "../handler/fetchpost/instaFetchPost.js";
 import { handleFetchLikesInstagram } from "../handler/fetchengagement/fetchLikesInstagram.js";
 import { fetchAndStoreTiktokContent } from "../handler/fetchpost/tiktokFetchPost.js";
@@ -30,7 +30,7 @@ export async function runCron() {
     const msg = await generateSosmedTaskMessage();
     const recipients = getRecipients();
     for (const wa of recipients) {
-      await safeSendMessage(waClient, wa, msg.trim());
+      await safeSendMessage(waGatewayClient, wa, msg.trim());
     }
     sendDebug({
       tag: "CRON DIRFETCH SOSMED",

--- a/src/cron/cronDirRequestRekapAllSocmed.js
+++ b/src/cron/cronDirRequestRekapAllSocmed.js
@@ -2,7 +2,7 @@ import cron from "node-cron";
 import dotenv from "dotenv";
 dotenv.config();
 
-import waClient from "../service/waService.js";
+import { waGatewayClient } from "../service/waService.js";
 import {
   lapharDitbinmas,
   collectLikesRecap,
@@ -90,17 +90,17 @@ export async function runCron(sendToRekapRecipient = false) {
 
       for (const wa of recipients) {
         if (narrative) {
-          await safeSendMessage(waClient, wa, narrative.trim());
+          await safeSendMessage(waGatewayClient, wa, narrative.trim());
         }
         if (igBuffer) {
-          await sendWAFile(waClient, igBuffer, ig.filename, wa, "text/plain");
+          await sendWAFile(waGatewayClient, igBuffer, ig.filename, wa, "text/plain");
         }
         if (ttBuffer) {
-          await sendWAFile(waClient, ttBuffer, tt.filename, wa, "text/plain");
+          await sendWAFile(waGatewayClient, ttBuffer, tt.filename, wa, "text/plain");
         }
         if (igRecapBuffer) {
           await sendWAFile(
-            waClient,
+            waGatewayClient,
             igRecapBuffer,
             igRecapName,
             wa,
@@ -109,7 +109,7 @@ export async function runCron(sendToRekapRecipient = false) {
         }
         if (ttRecapBuffer) {
           await sendWAFile(
-            waClient,
+            waGatewayClient,
             ttRecapBuffer,
             ttRecapName,
             wa,

--- a/tests/cronDirRequestDirektorat.test.js
+++ b/tests/cronDirRequestDirektorat.test.js
@@ -5,7 +5,7 @@ const mockKomentar = jest.fn();
 const mockSafeSend = jest.fn();
 const mockSendDebug = jest.fn();
 
-jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/service/waService.js', () => ({ waGatewayClient: {} }));
 jest.unstable_mockModule('../src/handler/menu/dirRequestHandlers.js', () => ({
   absensiLikesDitbinmas: mockAbsensi,
 }));

--- a/tests/cronDirRequestFetchSosmed.test.js
+++ b/tests/cronDirRequestFetchSosmed.test.js
@@ -7,7 +7,7 @@ const mockGenerateMsg = jest.fn();
 const mockSafeSend = jest.fn();
 const mockSendDebug = jest.fn();
 
-jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/service/waService.js', () => ({ waGatewayClient: {} }));
 jest.unstable_mockModule('../src/handler/fetchpost/instaFetchPost.js', () => ({
   fetchAndStoreInstaContent: mockFetchInsta,
 }));

--- a/tests/cronDirRequestRekapAllSocmed.test.js
+++ b/tests/cronDirRequestRekapAllSocmed.test.js
@@ -16,7 +16,7 @@ const mockMkdir = jest.fn();
 const mockReadFile = jest.fn();
 const mockUnlink = jest.fn();
 
-jest.unstable_mockModule('../src/service/waService.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/service/waService.js', () => ({ waGatewayClient: {} }));
 jest.unstable_mockModule('../src/handler/fetchabsensi/insta/absensiLikesInsta.js', () => ({
   lapharDitbinmas: mockLapharDitbinmas,
   collectLikesRecap: mockCollectLikesRecap,


### PR DESCRIPTION
## Summary
- route WhatsApp report delivery for directorate cron jobs through waGatewayClient
- adjust tests to mock waGatewayClient

## Testing
- `npm run lint`
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `NODE_OPTIONS=--max_old_space_size=4096 npm test -- tests/absensiKomentarDitbinmasReport.test.js` *(hung, manual termination)*

------
https://chatgpt.com/codex/tasks/task_e_68c53028926c832780a1a325e12d9e21