### PR TITLE
Ensure WA gateway waits for readiness before sending files

### DIFF
--- a/src/utils/waHelper.js
+++ b/src/utils/waHelper.js
@@ -61,6 +61,19 @@ export async function sendWAFile(
       ? chatIds
       : [chatIds]
     : getAdminWhatsAppList();
+  if (typeof waClient?.waitForWaReady === 'function') {
+    await waClient.waitForWaReady();
+  } else if (
+    typeof waClient?.isReady === 'function' ||
+    typeof waClient?.getState === 'function' ||
+    typeof waClient?.once === 'function'
+  ) {
+    const ready = await waitUntilReady(waClient);
+    if (!ready) {
+      console.warn(`[WA] Client not ready, cannot send file: ${filename}`);
+      return;
+    }
+  }
   const ext = path.extname(filename).toLowerCase();
   const resolvedMimeType =
     mimeType || spreadsheetMimeTypes[ext] || mime.lookup(filename) || defaultMimeType;


### PR DESCRIPTION
## Summary
- wait for WhatsApp client readiness in `sendWAFile` to ensure gateway reports send

## Testing
- `npm run lint`
- `npm test` *(fails: absensiKomentarDitbinmasReport.test.js - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5497f960c8327a3a9e4f06a870fc2