### PR TITLE
feat: include all exception tiktok usernames

### DIFF
--- a/src/handler/fetchengagement/fetchCommentTiktok.js
+++ b/src/handler/fetchengagement/fetchCommentTiktok.js
@@ -94,8 +94,7 @@ export async function handleFetchKomentarTiktokBatch(waClient = null, chatId = n
     );
     const videoIds = rows.map((r) => r.video_id);
     const excRes = await query(
-      `SELECT tiktok FROM "user" WHERE exception = true AND LOWER(TRIM(client_id)) = $1 AND tiktok IS NOT NULL`,
-      [normalizedId]
+      `SELECT tiktok FROM "user" WHERE exception = true AND tiktok IS NOT NULL`
     );
     const exceptionUsernames = excRes.rows
       .map((r) => normalizeUsername(r.tiktok))


### PR DESCRIPTION
## Summary
- fetch all exception users regardless of client when gathering TikTok comments

## Testing
- `npm run lint`
- `npm test` *(fails: heap out of memory for absensiKomentarDitbinmasReport.test.js)*
- `NODE_OPTIONS=--max-old-space-size=4096 npm test tests/absensiKomentarDitbinmasReport.test.js` *(fails: heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c54c29569083278b260d5a875aca9e