### PR TITLE
Track social task counts to prevent duplicate reports

### DIFF
--- a/src/handler/fetchabsensi/sosmedTask.js
+++ b/src/handler/fetchabsensi/sosmedTask.js
@@ -84,7 +84,11 @@ export async function generateSosmedTaskMessage(
     "Rincian:\n";
   msg += tiktokDetails.length ? tiktokDetails.join("\n") : "-";
   msg += "\n\nSilahkan Melaksanakan Likes, Komentar dan Share.";
-  return msg.trim();
+  return {
+    text: msg.trim(),
+    igCount: shortcodes.length,
+    tiktokCount: tiktokPosts.length,
+  };
 }
 
 export default generateSosmedTaskMessage;

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -633,11 +633,11 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         targetId
       );
       await handleFetchLikesInstagram(null, null, targetId);
-      await fetchAndStoreTiktokContent(targetId, waClient, chatId);
-      await handleFetchKomentarTiktokBatch(null, null, targetId);
-      msg = await generateSosmedTaskMessage(targetId, true);
-      break;
-    }
+        await fetchAndStoreTiktokContent(targetId, waClient, chatId);
+        await handleFetchKomentarTiktokBatch(null, null, targetId);
+        ({ text: msg } = await generateSosmedTaskMessage(targetId, true));
+        break;
+      }
     case "13": {
       const { text, filename, narrative, textBelum, filenameBelum } =
         await lapharTiktokDitbinmas();

--- a/tests/cronDirRequestFetchSosmed.test.js
+++ b/tests/cronDirRequestFetchSosmed.test.js
@@ -30,13 +30,11 @@ jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
 
 let runCron;
 
-beforeAll(async () => {
-  ({ runCron } = await import('../src/cron/cronDirRequestFetchSosmed.js'));
-});
-
-beforeEach(() => {
+beforeEach(async () => {
+  jest.resetModules();
   jest.clearAllMocks();
-  mockGenerateMsg.mockResolvedValue('msg');
+  mockGenerateMsg.mockResolvedValue({ text: 'msg', igCount: 1, tiktokCount: 1 });
+  ({ runCron } = await import('../src/cron/cronDirRequestFetchSosmed.js'));
 });
 
 test('runCron fetches sosmed and sends message to recipients', async () => {
@@ -57,4 +55,11 @@ test('runCron fetches sosmed and sends message to recipients', async () => {
     '120363419830216549@g.us',
     'msg'
   );
+});
+
+test('runCron skips sending when counts unchanged', async () => {
+  await runCron();
+  mockSafeSend.mockClear();
+  await runCron();
+  expect(mockSafeSend).not.toHaveBeenCalled();
 });

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -431,8 +431,12 @@ test('choose_menu option 12 fetch sosial media sends combined task', async () =>
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();
   mockFetchAndStoreTiktokContent.mockResolvedValue();
-      mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
-      mockGenerateSosmedTaskMessage.mockResolvedValue('tugas sosmed');
+        mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
+        mockGenerateSosmedTaskMessage.mockResolvedValue({
+          text: 'tugas sosmed',
+          igCount: 0,
+          tiktokCount: 0,
+        });
   mockSafeSendMessage.mockResolvedValue(true);
   mockFindClientById.mockResolvedValue({ client_type: 'direktorat', nama: 'DITBINMAS' });
 

--- a/tests/sosmedTask.test.js
+++ b/tests/sosmedTask.test.js
@@ -48,13 +48,15 @@ test('generateSosmedTaskMessage formats message correctly', async () => {
   mockHandleFetchLikesInstagram.mockResolvedValue();
   mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
 
-  const msg = await generateSosmedTaskMessage();
+  const { text, igCount, tiktokCount } = await generateSosmedTaskMessage();
 
   expect(mockFindClientById).toHaveBeenCalledWith('DITBINMAS');
-  expect(msg).toContain('Total likes semua konten: 2');
-  expect(msg).toContain('Total komentar semua konten: 1');
-  expect(msg).toContain('https://www.tiktok.com/video/123');
-  expect(msg).toContain('2 likes');
+  expect(text).toContain('Total likes semua konten: 2');
+  expect(text).toContain('Total komentar semua konten: 1');
+  expect(text).toContain('https://www.tiktok.com/video/123');
+  expect(text).toContain('2 likes');
+  expect(igCount).toBe(1);
+  expect(tiktokCount).toBe(1);
   expect(mockHandleFetchLikesInstagram).toHaveBeenCalledWith(null, null, 'DITBINMAS');
   expect(mockHandleFetchKomentarTiktokBatch).toHaveBeenCalledWith(null, null, 'DITBINMAS');
 });


### PR DESCRIPTION
## Summary
- Track last Instagram and TikTok counts to avoid sending duplicate social task reports
- Expose IG/TikTok counts from `generateSosmedTaskMessage`
- Adjust cron and handlers to use new message object and added tests for unchanged counts

## Testing
- `npm run lint`
- `npm test` *(fails: absensiKomentarDitbinmasReport.test.js – JavaScript heap out of memory)*
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/absensiKomentarDitbinmasReport.test.js` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c560fe26ec83279489a5b032e1e97b