### PR TITLE
Remove TikTok comment option 16

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -8,7 +8,6 @@ import {
 import {
   lapharTiktokDitbinmas,
   collectKomentarRecap,
-  absensiKomentar,
   absensiKomentarDitbinmasReport,
 } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { findClientById } from "../../service/clientService.js";
@@ -754,16 +753,6 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       }
       return;
     }
-    case "16": {
-      const normalizedId = (clientId || "").toUpperCase();
-      if (normalizedId !== "DITBINMAS") {
-        msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
-        break;
-      }
-      const opts = { mode: "all", roleFlag: "ditbinmas" };
-      msg = await absensiKomentar("DITBINMAS", opts);
-      break;
-    }
     default:
       msg = "Menu tidak dikenal.";
   }
@@ -865,8 +854,7 @@ export const dirRequestHandlers = {
         "📅 *Absensi*\n" +
         "3️⃣ Absensi like Ditbinmas\n" +
         "4️⃣ Absensi like Instagram\n" +
-        "5️⃣ Absensi komentar Ditbinmas\n" +
-        "1️⃣6️⃣ Absensi komentar TikTok\n\n" +
+        "5️⃣ Absensi komentar TikTok\n\n" +
         "📥 *Pengambilan Data*\n" +
         "6️⃣ Ambil konten & like Instagram\n" +
         "7️⃣ Ambil like Instagram saja\n" +
@@ -909,7 +897,6 @@ export const dirRequestHandlers = {
       "3",
       "4",
       "5",
-      "16",
       "6",
       "7",
       "8",

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -254,7 +254,7 @@ test('choose_menu option 3 absensi likes ditbinmas', async () => {
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan');
 });
 
-test('choose_menu option 5 absensi komentar ditbinmas', async () => {
+test('choose_menu option 5 absensi komentar tiktok', async () => {
   mockAbsensiKomentarDitbinmasReport.mockResolvedValue('laporan komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
@@ -309,50 +309,6 @@ test('choose_menu option 4 skips ketika client bukan ditbinmas', async () => {
   );
 });
 
-
-test('choose_menu option 16 absensi komentar tiktok uses ditbinmas data for all users', async () => {
-  mockAbsensiKomentar.mockResolvedValue('laporan komentar tiktok');
-
-  const session = {
-    role: 'ditbinmas',
-    selectedClientId: 'polres_a',
-    clientName: 'POLRES A',
-    dir_client_id: 'ditbinmas',
-  };
-  const chatId = '765';
-  const waClient = { sendMessage: jest.fn() };
-
-  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
-
-  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', {
-    mode: 'all',
-    roleFlag: 'ditbinmas',
-  });
-  expect(waClient.sendMessage).toHaveBeenCalledWith(
-    chatId,
-    'laporan komentar tiktok'
-  );
-});
-
-test('choose_menu option 16 skips ketika client bukan ditbinmas', async () => {
-  mockAbsensiKomentar.mockResolvedValue('laporan komentar tiktok');
-
-  const session = {
-    role: 'polres',
-    selectedClientId: 'polres_a',
-    clientName: 'POLRES A',
-  };
-  const chatId = '766';
-  const waClient = { sendMessage: jest.fn() };
-
-  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
-
-  expect(mockAbsensiKomentar).not.toHaveBeenCalled();
-  expect(waClient.sendMessage).toHaveBeenCalledWith(
-    chatId,
-    expect.stringContaining('DITBINMAS')
-  );
-});
 
 test('choose_menu option 6 fetch insta returns rekap likes report', async () => {
   mockFetchAndStoreInstaContent.mockResolvedValue();


### PR DESCRIPTION
## Summary
- rename DirRequest menu 5 to TikTok comment attendance and drop menu 16
- drop unused option 16 handler and tests

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: Reached heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c58a0a2e2483278689e37c33b1d7c1