### PR TITLE
Rename function for TikTok comment attendance

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -231,7 +231,7 @@ async function formatRekapUserData(clientId, roleFlag = null) {
 async function absensiLikesDitbinmas() {
   return await absensiLikesDitbinmasReport();
 }
-async function absensiKomentarDitbinmas() {
+async function anbsensiKomentarTiktok() {
   return await absensiKomentarDitbinmasReport();
 }
 async function formatRekapBelumLengkapDitbinmas() {
@@ -504,7 +504,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "5":
-      msg = await absensiKomentarDitbinmas();
+      msg = await anbsensiKomentarTiktok();
       break;
     case "6": { 
       const { fetchAndStoreInstaContent } = await import(
@@ -934,7 +934,7 @@ export const dirRequestHandlers = {
 export {
   formatRekapUserData,
   absensiLikesDitbinmas,
-  absensiKomentarDitbinmas,
+  anbsensiKomentarTiktok,
   formatExecutiveSummary,
   formatRekapBelumLengkapDitbinmas,
   formatRekapAllSosmed,


### PR DESCRIPTION
## Summary
- rename handler to `anbsensiKomentarTiktok`
- update performAction and exports to use new name

## Testing
- `npm run lint`
- `npm test` *(fails: A jest worker process (pid=4696) was terminated: JavaScript heap out of memory)*
- `npm test tests/absensiKomentarDitbinmasReport.test.js` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c58e8b21188327a99a090cf6e4f62e