### PR TITLE
feat: add TikTok comment attendance menu option

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -9,6 +9,7 @@ import {
   lapharTiktokDitbinmas,
   collectKomentarRecap,
   absensiKomentarDitbinmasReport,
+  absensiKomentar,
 } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
@@ -233,6 +234,9 @@ async function absensiLikesDitbinmas() {
 }
 async function anbsensiKomentarTiktok() {
   return await absensiKomentarDitbinmasReport();
+}
+async function absensiKomentarDitbinmas() {
+  return await absensiKomentar("DITBINMAS", { roleFlag: "ditbinmas" });
 }
 async function formatRekapBelumLengkapDitbinmas() {
   const users = await getUsersSocialByClient("DITBINMAS", "ditbinmas");
@@ -753,6 +757,9 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       }
       return;
     }
+    case "16":
+      msg = await absensiKomentarDitbinmas();
+      break;
     default:
       msg = "Menu tidak dikenal.";
   }
@@ -866,6 +873,7 @@ export const dirRequestHandlers = {
         "1️⃣3️⃣ Laporan harian TikTok Ditbinmas\n" +
         "1️⃣4️⃣ Rekap like Instagram (Excel)\n" +
         "1️⃣5️⃣ Rekap gabungan semua sosmed\n" +
+        "1️⃣6️⃣ Absensi komentar TikTok\n" +
         "┗━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -906,6 +914,7 @@ export const dirRequestHandlers = {
       "13",
       "14",
       "15",
+      "16",
     ].includes(choice)) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
       return;
@@ -935,6 +944,7 @@ export {
   formatRekapUserData,
   absensiLikesDitbinmas,
   anbsensiKomentarTiktok,
+  absensiKomentarDitbinmas,
   formatExecutiveSummary,
   formatRekapBelumLengkapDitbinmas,
   formatRekapAllSosmed,

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -268,6 +268,19 @@ test('choose_menu option 5 absensi komentar tiktok', async () => {
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
 });
 
+test('choose_menu option 16 absensi komentar ditbinmas detail', async () => {
+  mockAbsensiKomentar.mockResolvedValue('detail komentar');
+
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '444';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
+
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', { roleFlag: 'ditbinmas' });
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'detail komentar');
+});
+
 test('choose_menu option 4 absensi likes uses ditbinmas data for all users', async () => {
   mockAbsensiLikes.mockResolvedValue('laporan');
   mockFindClientById.mockResolvedValue({ client_type: 'org', nama: 'POLRES A' });


### PR DESCRIPTION
## Summary
- add `absensiKomentarDitbinmas` helper
- handle new menu selection 16 for TikTok comment attendance
- test coverage for new menu option

## Testing
- `npm run lint`
- `npm test` *(fails: Ineffective mark-compacts near heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c593b8b3c083279d619998a6f8222d