### PR TITLE
feat: add client filter for tiktok comment recap

### DIFF
--- a/tests/absensiKomentarDitbinmasReport.test.js
+++ b/tests/absensiKomentarDitbinmasReport.test.js
@@ -57,7 +57,7 @@ test('aggregates komentar report per satker with Direktorat Binmas on top', asyn
 
   const msg = await absensiKomentarDitbinmasReport();
 
-  expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas');
+  expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas', undefined);
   expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', ['DITBINMAS', 'POLRESA']);
   expect(msg).toContain('*Jumlah Total Personil:* 4 pers');
   expect(msg).toContain('✅ *Sudah melaksanakan* : *1 pers*');
@@ -80,4 +80,23 @@ test('aggregates komentar report per satker with Direktorat Binmas on top', asyn
     "❌ *Belum melaksanakan* : 1 pers\n" +
     "⚠️ *Belum Update Username TikTok* : 0 pers";
   expect(msg).toContain(expectedPolres);
+});
+
+test('filters polres and users when clientFilter is provided', async () => {
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ nama: 'DIREKTORAT BINMAS', client_tiktok: 'ditbinmastiktok' }] })
+    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES A' }] });
+
+  mockGetClientsByRole.mockResolvedValueOnce(['polresa']);
+  mockGetPostsTodayByClient.mockResolvedValueOnce([{ video_id: 'vid1' }]);
+  mockGetCommentsByVideoId.mockResolvedValueOnce({ comments: [] });
+  mockGetUsersByDirektorat.mockResolvedValueOnce([
+    { user_id: 'u1', nama: 'User1', tiktok: '', client_id: 'POLRESA', status: true },
+  ]);
+
+  const msg = await absensiKomentarDitbinmasReport({ clientFilter: 'POLRESA' });
+
+  expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas', 'POLRESA');
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'POLRESA');
+  expect(msg).toContain('POLRES A');
 });

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -319,3 +319,12 @@ test('getClientsByRole returns lowercase client ids', async () => {
     ['operator']
   );
 });
+
+test('getClientsByRole filters by client id', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ client_id: 'c1' }] });
+  const clients = await getClientsByRole('operator', 'c1');
+  expect(clients).toEqual(['c1']);
+  const [sql, params] = mockQuery.mock.calls[0];
+  expect(sql).toContain('LOWER(duc.client_id) = LOWER($2)');
+  expect(params).toEqual(['operator', 'c1']);
+});


### PR DESCRIPTION
## Summary
- support optional clientId filtering when retrieving polres and users for TikTok comment recap
- allow filtering clients by id in `getClientsByRole`
- cover new filtering behavior with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a199d3188327ae45d839248d9fcd