### PR TITLE
Refactor Ditbinmas TikTok comment report for division grouping

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -345,9 +345,8 @@ export async function absensiKomentar(client_id, opts = {}) {
   return msg.trim();
 }
 
-export async function absensiKomentarDitbinmasReport(opts = {}) {
+export async function absensiKomentarDitbinmasReport() {
   const roleName = "ditbinmas";
-  const { clientFilter } = opts;
   const now = new Date();
   const hari = hariIndo[now.getDay()];
   const tanggal = now.toLocaleDateString("id-ID");
@@ -368,30 +367,27 @@ export async function absensiKomentarDitbinmasReport(opts = {}) {
     commentSets.push(new Set(extractUsernamesFromComments(comments)));
   }
 
-  const polresIds = (await getClientsByRole(roleName, clientFilter)).map(
-    (c) => c.toUpperCase()
+  const allUsersRaw = await getUsersByDirektorat(roleName, "DITBINMAS");
+  const allUsers = allUsersRaw.filter(
+    (u) =>
+      u.status === true && (u.client_id || "").toUpperCase() === "DITBINMAS"
   );
-  const userFilter = clientFilter || polresIds;
-  const allUsers = polresIds.length
-    ? (await getUsersByDirektorat(roleName, userFilter)).filter(
-        (u) => u.status === true
-      )
-    : [];
 
-  const usersByClient = {};
+  const usersByDiv = {};
   allUsers.forEach((u) => {
-    const cid = u.client_id?.toUpperCase() || "";
-    if (!usersByClient[cid]) usersByClient[cid] = [];
-    usersByClient[cid].push(u);
+    const div = u.divisi?.toUpperCase() || "-";
+    if (!usersByDiv[div]) usersByDiv[div] = [];
+    usersByDiv[div].push(u);
   });
 
   const totalKonten = posts.length;
   const reportEntries = [];
   const totals = { total: 0, sudah: 0, kurang: 0, belum: 0, noUsername: 0 };
 
-  for (const cid of polresIds) {
-    const users = usersByClient[cid] || [];
-    const { nama: clientName } = await getClientInfo(cid);
+  const divisions = sortDivisionKeys(Object.keys(usersByDiv));
+
+  for (const div of divisions) {
+    const users = usersByDiv[div] || [];
     const sudah = [];
     const kurang = [];
     const belum = [];
@@ -421,7 +417,7 @@ export async function absensiKomentarDitbinmasReport(opts = {}) {
     totals.noUsername += tanpaUsername.length;
 
     reportEntries.push({
-      clientName,
+      clientName: div,
       usersCount: users.length,
       sudahCount: sudah.length,
       kurangCount: kurang.length,
@@ -435,10 +431,6 @@ export async function absensiKomentarDitbinmasReport(opts = {}) {
   }
 
   reportEntries.sort((a, b) => {
-    const aBinmas = a.clientName.toUpperCase() === "DIREKTORAT BINMAS";
-    const bBinmas = b.clientName.toUpperCase() === "DIREKTORAT BINMAS";
-    if (aBinmas && !bBinmas) return -1;
-    if (bBinmas && !aBinmas) return 1;
     if (a.sudahCount !== b.sudahCount) return b.sudahCount - a.sudahCount;
     if (a.usersCount !== b.usersCount) return b.usersCount - a.usersCount;
     return a.clientName.localeCompare(b.clientName);

--- a/tests/absensiKomentarDitbinmasReport.test.js
+++ b/tests/absensiKomentarDitbinmasReport.test.js
@@ -4,7 +4,6 @@ const mockQuery = jest.fn();
 const mockGetPostsTodayByClient = jest.fn();
 const mockGetCommentsByVideoId = jest.fn();
 const mockGetUsersByDirektorat = jest.fn();
-const mockGetClientsByRole = jest.fn();
 
 jest.unstable_mockModule('../src/db/index.js', () => ({ query: mockQuery }));
 jest.unstable_mockModule('../src/model/tiktokPostModel.js', () => ({ getPostsTodayByClient: mockGetPostsTodayByClient }));
@@ -14,7 +13,6 @@ jest.unstable_mockModule('../src/model/userModel.js', async () => {
   return {
     ...actual,
     getUsersByDirektorat: mockGetUsersByDirektorat,
-    getClientsByRole: mockGetClientsByRole,
   };
 });
 
@@ -29,16 +27,11 @@ beforeEach(() => {
   mockGetPostsTodayByClient.mockReset();
   mockGetCommentsByVideoId.mockReset();
   mockGetUsersByDirektorat.mockReset();
-  mockGetClientsByRole.mockReset();
 });
 
-test('aggregates komentar report per satker with Direktorat Binmas on top', async () => {
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ nama: 'DIREKTORAT BINMAS', client_tiktok: 'ditbinmastiktok' }] })
-    .mockResolvedValueOnce({ rows: [{ nama: 'DIREKTORAT BINMAS' }] })
-    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES A' }] });
+test('aggregates komentar report per division for Ditbinmas', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [{ nama: 'DIREKTORAT BINMAS', client_tiktok: 'ditbinmastiktok' }] });
 
-  mockGetClientsByRole.mockResolvedValueOnce(['ditbinmas', 'polresa']);
   mockGetPostsTodayByClient.mockResolvedValueOnce([
     { video_id: 'vid1' },
     { video_id: 'vid2' },
@@ -49,54 +42,34 @@ test('aggregates komentar report per satker with Direktorat Binmas on top', asyn
     .mockResolvedValueOnce({ comments: [{ username: 'user1' }] })
     .mockResolvedValueOnce({ comments: [] });
   mockGetUsersByDirektorat.mockResolvedValueOnce([
-    { user_id: 'u1', nama: 'User1', tiktok: 'user1', client_id: 'DITBINMAS', status: true },
-    { user_id: 'u2', nama: 'User2', tiktok: '', client_id: 'DITBINMAS', status: true },
-    { user_id: 'u3', nama: 'User3', tiktok: 'user3', client_id: 'POLRESA', status: true },
-    { user_id: 'u4', nama: 'User4', tiktok: 'user4', client_id: 'POLRESA', status: true },
+    { user_id: 'u1', nama: 'User1', tiktok: 'user1', divisi: 'DIV A', client_id: 'DITBINMAS', status: true },
+    { user_id: 'u2', nama: 'User2', tiktok: '', divisi: 'DIV A', client_id: 'DITBINMAS', status: true },
+    { user_id: 'u3', nama: 'User3', tiktok: 'user3', divisi: 'DIV B', client_id: 'DITBINMAS', status: true },
+    { user_id: 'u4', nama: 'User4', tiktok: 'user4', divisi: 'DIV B', client_id: 'DITBINMAS', status: true },
   ]);
 
   const msg = await absensiKomentarDitbinmasReport();
 
-  expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas', undefined);
-  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', ['DITBINMAS', 'POLRESA']);
+  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'DITBINMAS');
   expect(msg).toContain('*Jumlah Total Personil:* 4 pers');
   expect(msg).toContain('✅ *Sudah melaksanakan* : *1 pers*');
   expect(msg).toContain('⚠️ *Melaksanakan kurang lengkap* : *1 pers*');
   expect(msg).toContain('❌ *Belum melaksanakan* : *2 pers*');
   expect(msg).toContain('⚠️ *Belum Update Username TikTok* : *1 pers*');
-  const expectedDir =
-    "1. DIREKTORAT BINMAS\n\n" +
+  const expectedDivA =
+    "1. DIV A\n\n" +
     "*Jumlah Personil* : 2 pers\n" +
     "✅ *Sudah melaksanakan* : 1 pers\n" +
     "⚠️ *Melaksanakan kurang lengkap* : 0 pers\n" +
     "❌ *Belum melaksanakan* : 1 pers\n" +
     "⚠️ *Belum Update Username TikTok* : 1 pers";
-  expect(msg).toContain(expectedDir);
-  const expectedPolres =
-    "2. POLRES A\n\n" +
+  expect(msg).toContain(expectedDivA);
+  const expectedDivB =
+    "2. DIV B\n\n" +
     "*Jumlah Personil* : 2 pers\n" +
     "✅ *Sudah melaksanakan* : 0 pers\n" +
     "⚠️ *Melaksanakan kurang lengkap* : 1 pers\n" +
     "❌ *Belum melaksanakan* : 1 pers\n" +
     "⚠️ *Belum Update Username TikTok* : 0 pers";
-  expect(msg).toContain(expectedPolres);
-});
-
-test('filters polres and users when clientFilter is provided', async () => {
-  mockQuery
-    .mockResolvedValueOnce({ rows: [{ nama: 'DIREKTORAT BINMAS', client_tiktok: 'ditbinmastiktok' }] })
-    .mockResolvedValueOnce({ rows: [{ nama: 'POLRES A' }] });
-
-  mockGetClientsByRole.mockResolvedValueOnce(['polresa']);
-  mockGetPostsTodayByClient.mockResolvedValueOnce([{ video_id: 'vid1' }]);
-  mockGetCommentsByVideoId.mockResolvedValueOnce({ comments: [] });
-  mockGetUsersByDirektorat.mockResolvedValueOnce([
-    { user_id: 'u1', nama: 'User1', tiktok: '', client_id: 'POLRESA', status: true },
-  ]);
-
-  const msg = await absensiKomentarDitbinmasReport({ clientFilter: 'POLRESA' });
-
-  expect(mockGetClientsByRole).toHaveBeenCalledWith('ditbinmas', 'POLRESA');
-  expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas', 'POLRESA');
-  expect(msg).toContain('POLRES A');
+  expect(msg).toContain(expectedDivB);
 });

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -255,7 +255,7 @@ test('choose_menu option 3 absensi likes ditbinmas', async () => {
 });
 
 test('choose_menu option 5 absensi komentar tiktok', async () => {
-  mockAbsensiKomentarDitbinmasReport.mockResolvedValue('laporan komentar');
+  mockAbsensiKomentar.mockResolvedValue('laporan komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '333';
@@ -263,13 +263,12 @@ test('choose_menu option 5 absensi komentar tiktok', async () => {
 
   await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
 
-  expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
-  expect(mockAbsensiKomentar).not.toHaveBeenCalled();
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', { roleFlag: 'ditbinmas' });
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
 });
 
 test('choose_menu option 16 absensi komentar ditbinmas detail', async () => {
-  mockAbsensiKomentar.mockResolvedValue('detail komentar');
+  mockAbsensiKomentarDitbinmasReport.mockResolvedValue('detail komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '444';
@@ -277,7 +276,7 @@ test('choose_menu option 16 absensi komentar ditbinmas detail', async () => {
 
   await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
 
-  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', { roleFlag: 'ditbinmas' });
+  expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'detail komentar');
 });
 


### PR DESCRIPTION
## Summary
- Fetch Ditbinmas users directly by client and role, then group by division for comment recap
- Update Ditbinmas comment report tests and menu handler tests for new grouping logic

## Testing
- `npm run lint`
- `npm test` *(fails: A jest worker process was terminated by SIGTERM, indicating possible out-of-memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6864f6efc8327b9dfffa4f323128d