### PR TITLE
feat: hide zero-count tiktok report lines

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -228,14 +228,21 @@ export async function absensiKomentar(client_id, opts = {}) {
       sortedCids.map(async (cid, index) => {
         const { nama } = await getClientInfo(cid);
         const g = groups[cid];
-        return (
-          `*${index + 1}. ${nama}*\n` +
-          `*Jumlah user:* ${g.total}\n` +
-          `*Melaksanakan Lengkap* : *${g.sudah} user*\n` +
-          `*Melaksanakan Kurang Lengkap* : *${g.kurang} user*\n` +
-          `*Belum Melaksanakan* : *${g.belum} user*\n` +
-          `*Belum Input Username Tiktok* : *${g.noUsername} user*`
-        );
+        const lines = [
+          `*${index + 1}. ${nama}*`,
+          `*Jumlah user:* ${g.total}`,
+          `*Melaksanakan Lengkap* : *${g.sudah} user*`,
+        ];
+        if (g.kurang) {
+          lines.push(`*Melaksanakan Kurang Lengkap* : *${g.kurang} user*`);
+        }
+        if (g.belum) {
+          lines.push(`*Belum Melaksanakan* : *${g.belum} user*`);
+        }
+        if (g.noUsername) {
+          lines.push(`*Belum Input Username Tiktok* : *${g.noUsername} user*`);
+        }
+        return lines.join("\n");
       })
     );
 

--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -45,11 +45,12 @@ test('aggregates directorate data per client', async () => {
 
   expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
 
-  expect(msg).toContain('POLRES A');
-  expect(msg).toContain('✅ *Sudah melaksanakan* : *1 user*');
-  expect(msg).toContain('⚠️ *Melaksanakan kurang lengkap* : *0 user*');
+  expect(msg).toContain(
+    '*1. POLRES A*\n*Jumlah user:* 1\n*Melaksanakan Lengkap* : *1 user*'
+  );
+  expect(msg).toContain('⚠️ *Melaksanakan Kurang Lengkap* : *0 user*');
   expect(msg).toContain('POLRES B');
-  expect(msg).toContain('❌ *Belum melaksanakan* : *1 user*');
+  expect(msg).toContain('❌ *Belum Melaksanakan* : *1 user*');
   expect(msg).not.toMatch(/usera/i);
 });
 


### PR DESCRIPTION
## Summary
- skip zero-count rows in TikTok comment recap
- adjust directorate recap tests for new output

## Testing
- `npm run lint`
- `npm test` *(fails: absensiKomentarDitbinmasReport.test.js - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c69c1365248327b7845b8953ddfe89