### PR TITLE
Hide zero-count sections in TikTok comment report

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -478,14 +478,25 @@ export async function absensiKomentarDitbinmasReport() {
     const noUsernameList = r.noUsernameList.length
       ? r.noUsernameList.join("\n")
       : "-";
-    return (
+
+    let entry =
       `${idx + 1}. ${r.clientName}\n\n` +
       `*Jumlah Personil* : ${r.usersCount} pers\n` +
-      `✅ Melaksanakan Lengkap (${r.sudahCount} pers):\n${sudahList}\n\n` +
-      `⚠️ Melaksanakan Kurang Lengkap (${r.kurangCount} pers):\n${kurangList}\n\n` +
-      `❌ Belum melaksanakan (${r.belumList.length} pers):\n${belumList}\n\n` +
-      `⚠️ Belum Update Username TikTok (${r.noUsernameCount} pers):\n${noUsernameList}`
-    );
+      `✅ Melaksanakan Lengkap (${r.sudahCount} pers):\n${sudahList}`;
+
+    if (r.kurangCount > 0) {
+      entry += `\n\n⚠️ Melaksanakan Kurang Lengkap (${r.kurangCount} pers):\n${kurangList}`;
+    }
+
+    if (r.belumList.length > 0) {
+      entry += `\n\n❌ Belum melaksanakan (${r.belumList.length} pers):\n${belumList}`;
+    }
+
+    if (r.noUsernameCount > 0) {
+      entry += `\n\n⚠️ Belum Update Username TikTok (${r.noUsernameCount} pers):\n${noUsernameList}`;
+    }
+
+    return entry;
   });
 
   let msg =

--- a/tests/absensiKomentarDitbinmasReport.test.js
+++ b/tests/absensiKomentarDitbinmasReport.test.js
@@ -57,29 +57,15 @@ test('aggregates komentar report per division for Ditbinmas with Ditbinmas first
   expect(msg).toContain('⚠️ *Melaksanakan kurang lengkap* : *0 pers*');
   expect(msg).toContain('❌ *Belum melaksanakan* : *2 pers*');
   expect(msg).toContain('⚠️ *Belum Update Username TikTok* : *0 pers*');
-  const expectedDivDitbinmas =
-    "1. DITBINMAS\n\n" +
-    "*Jumlah Personil* : 1 pers\n" +
-    "✅ *Sudah melaksanakan* : 0 pers\n" +
-    "⚠️ *Melaksanakan kurang lengkap* : 0 pers\n" +
-    "❌ *Belum melaksanakan* : 1 pers\n" +
-    "⚠️ *Belum Update Username TikTok* : 0 pers";
-  expect(msg).toContain(expectedDivDitbinmas);
-  const expectedDivA =
-    "2. DIV A\n\n" +
+  // ensure zero-count segments are hidden in division reports
+  expect(msg).not.toContain('⚠️ Melaksanakan Kurang Lengkap (0 pers)');
+  expect(msg).not.toContain('⚠️ Belum Update Username TikTok (0 pers)');
 
-    "*Jumlah Personil* : 2 pers\n" +
-    "✅ *Sudah melaksanakan* : 2 pers\n" +
-    "⚠️ *Melaksanakan kurang lengkap* : 0 pers\n" +
-    "❌ *Belum melaksanakan* : 0 pers\n" +
-    "⚠️ *Belum Update Username TikTok* : 0 pers";
-  expect(msg).toContain(expectedDivA);
-  const expectedDivB =
-    "3. DIV B\n\n" +
-    "*Jumlah Personil* : 2 pers\n" +
-    "✅ *Sudah melaksanakan* : 1 pers\n" +
-    "⚠️ *Melaksanakan kurang lengkap* : 0 pers\n" +
-    "❌ *Belum melaksanakan* : 1 pers\n" +
-    "⚠️ *Belum Update Username TikTok* : 0 pers";
-  expect(msg).toContain(expectedDivB);
+  // division headers should still be present
+  expect(msg).toContain('1. DITBINMAS');
+  expect(msg).toContain('2. DIV A');
+  expect(msg).toContain('3. DIV B');
+
+  // two divisions should have one person who has not performed
+  expect((msg.match(/❌ Belum melaksanakan \(1 pers\)/g) || []).length).toBe(2);
 });


### PR DESCRIPTION
## Summary
- Skip 'Melaksanakan Kurang Lengkap', 'Belum melaksanakan', and 'Belum Update Username TikTok' sections when their counts are zero
- Update Ditbinmas report test to assert hidden zero-count sections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a51aad748327ac04e5ef4c4bc46a