### PR TITLE
Parallelize Instagram like lookups

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1216,8 +1216,10 @@ Ketik *angka* menu, atau *batal* untuk keluar.
       userStats[u.user_id] = { ...u, count: 0 };
     });
 
-    for (const shortcode of shortcodes) {
-      const likes = await getLikesByShortcode(shortcode);
+    const likesLists = await Promise.all(
+      shortcodes.map((sc) => getLikesByShortcode(sc))
+    );
+    likesLists.forEach((likes) => {
       const likesSet = new Set(
         (likes || []).map((l) => (l || "").toLowerCase())
       );
@@ -1226,7 +1228,7 @@ Ketik *angka* menu, atau *batal* untuk keluar.
           userStats[u.user_id].count += 1;
         }
       });
-    }
+    });
 
     let sudah = [],
       belum = [];


### PR DESCRIPTION
## Summary
- fetch Instagram likes concurrently with `Promise.all` in absensi handlers
- parallelize WA service like lookups to avoid sequential waits

## Testing
- `npm run lint`
- `NODE_OPTIONS="--max_old_space_size=4096" npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6aa3e1a5483279e9a1b068b334275