### PR TITLE
feat: add cron for sosmed rank

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ const cronModules = [
   './src/cron/cronDirRequestFetchSosmed.js',
   './src/cron/cronDirRequestRekapUpdate.js',
   './src/cron/cronDirRequestRekapAllSocmed.js',
+  './src/cron/cronDirRequestSosmedRank.js',
   './src/cron/cronDirRequestDirektorat.js',
   './src/cron/cronDbBackup.js',
 ];

--- a/docs/activity_schedule.md
+++ b/docs/activity_schedule.md
@@ -1,5 +1,5 @@
 # System Activity Schedule
-*Last updated: 2025-08-19*
+*Last updated: 2025-09-14*
 
 This document summarizes the automated jobs ("activity") that run inside Cicero_V2. All jobs use `node-cron` and are started automatically when `app.js` boots. Times are in **Asia/Jakarta** timezone.
 
@@ -13,6 +13,7 @@ This document summarizes the automated jobs ("activity") that run inside Cicero_
 | `cronAbsensiUserData.js` | `0 13 * * *` | Daily at 13:00. Notifies users and operators about incomplete registration data. |
 | `cronAmplifyLinkMonthly.js` | `0 23 28-31 * *` | At 23:00 on the last day of each month. Generates monthly amplification link reports and sends an Excel file to each operator. |
 | `cronDirRequestRekapAllSocmed.js` | `0 0 15,18 * * *` & `0 30 20 * * *` | 15:00 & 18:00 send recaps to admins and group; 20:30 also sends to the rekap recipient. |
+| `cronDirRequestSosmedRank.js` | `7 15,18 * * *` & `32 20 * * *` | Executes menu 4 & 5 for DITBINMAS; 15:07 & 18:07 send to admins and group; 20:32 also sends to the rank recipient. |
 
 Each job collects data from the database, interacts with RapidAPI or WhatsApp, and updates the system accordingly. The cron files are imported in `app.js` so no additional setup is required.
 

--- a/src/cron/cronDirRequestSosmedRank.js
+++ b/src/cron/cronDirRequestSosmedRank.js
@@ -1,0 +1,46 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import { waGatewayClient } from "../service/waService.js";
+import { absensiLikes } from "../handler/fetchabsensi/insta/absensiLikesInsta.js";
+import { absensiKomentar } from "../handler/fetchabsensi/tiktok/absensiKomentarTiktok.js";
+import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+
+const DIRREQUEST_GROUP = "120363419830216549@g.us";
+const RANK_RECIPIENT = "6281234560377@c.us";
+
+function getRecipients(includeRankRecipient = false) {
+  const recipients = new Set([...getAdminWAIds(), DIRREQUEST_GROUP]);
+  if (includeRankRecipient) recipients.add(RANK_RECIPIENT);
+  return recipients;
+}
+
+export async function runCron(includeRankRecipient = false) {
+  sendDebug({ tag: "CRON DIRREQ SOSMED RANK", msg: "Mulai cron dirrequest sosmed rank" });
+  try {
+    const likesMsg = await absensiLikes("DITBINMAS", { mode: "all", roleFlag: "ditbinmas" });
+    const komentarMsg = await absensiKomentar("DITBINMAS", { roleFlag: "ditbinmas" });
+    const recipients = getRecipients(includeRankRecipient);
+    for (const wa of recipients) {
+      await safeSendMessage(waGatewayClient, wa, likesMsg.trim());
+      await safeSendMessage(waGatewayClient, wa, komentarMsg.trim());
+    }
+    sendDebug({
+      tag: "CRON DIRREQ SOSMED RANK",
+      msg: `Laporan dikirim ke ${recipients.size} penerima`,
+    });
+  } catch (err) {
+    sendDebug({
+      tag: "CRON DIRREQ SOSMED RANK",
+      msg: `[ERROR] ${err.message || err}`,
+    });
+  }
+}
+
+cron.schedule("7 15 * * *", () => runCron(false), { timezone: "Asia/Jakarta" });
+cron.schedule("7 18 * * *", () => runCron(false), { timezone: "Asia/Jakarta" });
+cron.schedule("32 20 * * *", () => runCron(true), { timezone: "Asia/Jakarta" });
+
+export default null;

--- a/tests/cronDirRequestSosmedRank.test.js
+++ b/tests/cronDirRequestSosmedRank.test.js
@@ -1,0 +1,53 @@
+import { jest } from '@jest/globals';
+
+const mockAbsensiLikes = jest.fn();
+const mockAbsensiKomentar = jest.fn();
+const mockSafeSend = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/service/waService.js', () => ({ waGatewayClient: {} }));
+jest.unstable_mockModule('../src/handler/fetchabsensi/insta/absensiLikesInsta.js', () => ({
+  absensiLikes: mockAbsensiLikes,
+}));
+jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js', () => ({
+  absensiKomentar: mockAbsensiKomentar,
+}));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  safeSendMessage: mockSafeSend,
+  getAdminWAIds: () => ['123@c.us'],
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let runCron;
+
+beforeAll(async () => {
+  ({ runCron } = await import('../src/cron/cronDirRequestSosmedRank.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAbsensiLikes.mockResolvedValue('likes');
+  mockAbsensiKomentar.mockResolvedValue('komentar');
+});
+
+test('runCron sends likes and komentar to admin and group', async () => {
+  await runCron();
+
+  expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', { mode: 'all', roleFlag: 'ditbinmas' });
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', { roleFlag: 'ditbinmas' });
+
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'likes');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '123@c.us', 'komentar');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'likes');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'komentar');
+  expect(mockSafeSend).toHaveBeenCalledTimes(4);
+});
+
+test('runCron with rank recipient includes extra number', async () => {
+  await runCron(true);
+
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '6281234560377@c.us', 'likes');
+  expect(mockSafeSend).toHaveBeenCalledWith({}, '6281234560377@c.us', 'komentar');
+});


### PR DESCRIPTION
## Summary
- add cronDirRequestSosmedRank to run Instagram like and TikTok comment attendance sequentially
- document and wire up new cron schedule
- cover cronDirRequestSosmedRank with tests

## Testing
- `npm run lint`
- `npm test` *(fails: cronDirRequestRekapAllSocmed.test.js, absensiLikesInsta.test.js, absensiKomentarDirektorat.test.js, absensiKomentarDitbinmasReport.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e4218c308327b83f2faefc0744cc