### PR TITLE
Group Instagram likes report by division

### DIFF
--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -46,9 +46,8 @@ test('aggregates directorate data per client', async () => {
   expect(mockGetUsersByDirektorat).toHaveBeenCalledWith('ditbinmas');
 
   expect(msg).toContain(
-    '*1. POLRES A*\n*Jumlah user:* 1\n*Melaksanakan Lengkap* : *1 user*'
+    '*1. POLRES A*\n*Jumlah user:* 1\n*Sudah Melaksanakan* : *1 user*\n*Melaksanakan Lengkap* : *1 user*'
   );
-  expect(msg).toContain('⚠️ *Melaksanakan Kurang Lengkap* : *0 user*');
   expect(msg).toContain('POLRES B');
   expect(msg).toContain('❌ *Belum Melaksanakan* : *1 user*');
   expect(msg).not.toMatch(/usera/i);

--- a/tests/cronDirRequestRekapAllSocmed.test.js
+++ b/tests/cronDirRequestRekapAllSocmed.test.js
@@ -86,8 +86,8 @@ beforeEach(() => {
 test('runCron without rekap sends to admin and group only', async () => {
   await runCron(false);
 
-  expect(mockCollectLikesRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
-  expect(mockCollectKomentarRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
+  expect(mockCollectLikesRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: false });
+  expect(mockCollectKomentarRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: false });
 
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'nar ig + nar tt');
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'nar ig + nar tt');
@@ -105,8 +105,8 @@ test('runCron without rekap sends to admin and group only', async () => {
 test('runCron with rekap sends to all recipients', async () => {
   await runCron(true);
 
-  expect(mockCollectLikesRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
-  expect(mockCollectKomentarRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: true });
+  expect(mockCollectLikesRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: false });
+  expect(mockCollectKomentarRecap).toHaveBeenCalledWith('DITBINMAS', { selfOnly: false });
 
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '123@c.us', 'nar ig + nar tt');
   expect(mockSafeSendMessage).toHaveBeenCalledWith({}, '120363419830216549@g.us', 'nar ig + nar tt');


### PR DESCRIPTION
## Summary
- Group Instagram like recap by division and summarize per-division engagement
- Always list DITBINMAS division first in the detailed report
- Add tests for division grouping and update existing expectations

## Testing
- `npm run lint`
- `npm test` *(fails: absensiKomentarDitbinmasReport.test.js out-of-memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ea012ea08327828c83efe15e862a