### PR TITLE
feat: add weekly instagram recap

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -18,6 +18,7 @@ import { writeFile, mkdir, readFile, unlink } from "fs/promises";
 import { join, basename } from "path";
 import { saveLikesRecapExcel } from "../../service/likesRecapExcelService.js";
 import { saveCommentRecapExcel } from "../../service/commentRecapExcelService.js";
+import { saveWeeklyLikesRecapExcel } from "../../service/weeklyLikesRecapExcelService.js";
 import { hariIndo } from "../../utils/constants.js";
 
 const dirRequestGroup = "120363419830216549@g.us";
@@ -761,6 +762,20 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
     case "16":
       msg = await absensiKomentarDitbinmas();
       break;
+    case "17": {
+      const filePath = await saveWeeklyLikesRecapExcel(clientId);
+      const buffer = await readFile(filePath);
+      await sendWAFile(
+        waClient,
+        buffer,
+        basename(filePath),
+        chatId,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      );
+      await unlink(filePath);
+      msg = "✅ File Excel dikirim.";
+      break;
+    }
     default:
       msg = "Menu tidak dikenal.";
   }
@@ -875,6 +890,8 @@ export const dirRequestHandlers = {
         "1️⃣3️⃣ Laporan harian TikTok Ditbinmas\n" +
         "1️⃣4️⃣ Rekap like Instagram (Excel)\n" +
         "1️⃣5️⃣ Rekap gabungan semua sosmed\n\n" +
+        "📆 *Laporan Mingguan*\n" +
+        "1️⃣7️⃣ Rekap file Instagram mingguan\n\n" +
         "┗━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -916,6 +933,7 @@ export const dirRequestHandlers = {
       "14",
       "15",
       "16",
+      "17",
     ].includes(choice)) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
       return;

--- a/src/service/weeklyLikesRecapExcelService.js
+++ b/src/service/weeklyLikesRecapExcelService.js
@@ -1,0 +1,124 @@
+import { mkdir } from 'fs/promises';
+import path from 'path';
+import XLSX from 'xlsx';
+import { hariIndo } from '../utils/constants.js';
+import { getRekapLikesByClient } from '../model/instaLikeModel.js';
+
+const RANK_ORDER = [
+  'KOMISARIS BESAR POLISI',
+  'AKBP',
+  'KOMPOL',
+  'AKP',
+  'IPTU',
+  'IPDA',
+  'AIPTU',
+  'AIPDA',
+  'BRIPKA',
+  'BRIGPOL',
+  'BRIGADIR',
+  'BRIGADIR POLISI',
+  'BRIPTU',
+  'BRIPDA',
+];
+
+function rankWeight(rank) {
+  const idx = RANK_ORDER.indexOf(String(rank || '').toUpperCase());
+  return idx === -1 ? RANK_ORDER.length : idx;
+}
+
+export async function saveWeeklyLikesRecapExcel(clientId) {
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(endDate.getDate() - 6);
+  const formatDate = (d) => d.toISOString().slice(0, 10);
+
+  const dateList = [];
+  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+    dateList.push(formatDate(d));
+  }
+
+  const grouped = {};
+  const dailyPosts = {};
+
+  for (const dateStr of dateList) {
+    const { rows, totalKonten } = await getRekapLikesByClient(
+      clientId,
+      'harian',
+      dateStr,
+      undefined,
+      undefined,
+      'ditbinmas'
+    );
+    dailyPosts[dateStr] = totalKonten;
+    for (const u of rows) {
+      const satker = u.client_name || '';
+      if (!grouped[satker]) grouped[satker] = {};
+      const key = `${u.title || ''}|${u.nama || ''}`;
+      if (!grouped[satker][key]) {
+        grouped[satker][key] = {
+          pangkat: u.title || '',
+          nama: u.nama || '',
+          perDate: {},
+          totalLikes: 0,
+        };
+      }
+      grouped[satker][key].perDate[dateStr] = {
+        likes: u.jumlah_like || 0,
+      };
+      grouped[satker][key].totalLikes += u.jumlah_like || 0;
+    }
+  }
+
+  const wb = XLSX.utils.book_new();
+  Object.entries(grouped).forEach(([satker, usersMap]) => {
+    const users = Object.values(usersMap);
+    users.sort((a, b) => {
+      if (b.totalLikes !== a.totalLikes) return b.totalLikes - a.totalLikes;
+      const rankA = rankWeight(a.pangkat);
+      const rankB = rankWeight(b.pangkat);
+      if (rankA !== rankB) return rankA - rankB;
+      return a.nama.localeCompare(b.nama);
+    });
+    const header = ['Pangkat Nama'];
+    dateList.forEach((d) => {
+      header.push(`${d} Jumlah Post Tugas`);
+      header.push(`${d} Sudah Likes`);
+      header.push(`${d} Belum Likes`);
+    });
+    const rowsData = users.map((u) => {
+      const row = {
+        'Pangkat Nama': `${u.pangkat ? u.pangkat + ' ' : ''}${u.nama}`.trim(),
+      };
+      dateList.forEach((d) => {
+        const likes = u.perDate[d]?.likes || 0;
+        const posts = dailyPosts[d] || 0;
+        row[`${d} Jumlah Post Tugas`] = posts;
+        row[`${d} Sudah Likes`] = likes;
+        row[`${d} Belum Likes`] = Math.max(posts - likes, 0);
+      });
+      return row;
+    });
+    const ws = XLSX.utils.json_to_sheet(rowsData, { header });
+    XLSX.utils.book_append_sheet(wb, ws, satker);
+  });
+
+  const exportDir = path.resolve('export_data/weekly_likes');
+  await mkdir(exportDir, { recursive: true });
+
+  const now = new Date();
+  const hari = hariIndo[now.getDay()];
+  const tanggal = now.toLocaleDateString('id-ID');
+  const jam = now.toLocaleTimeString('id-ID', { hour12: false });
+  const dateSafe = tanggal.replace(/\//g, '-');
+  const timeSafe = jam.replace(/[:.]/g, '-');
+  const formattedClient = (clientId || '')
+    .toLowerCase()
+    .replace(/^./, (c) => c.toUpperCase());
+  const filePath = path.join(
+    exportDir,
+    `Rekap_Mingguan_Instagram_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+  );
+  XLSX.writeFile(wb, filePath);
+  return filePath;
+}
+

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -17,6 +17,7 @@ const mockLapharDitbinmas = jest.fn();
 const mockLapharTiktokDitbinmas = jest.fn();
 const mockCollectLikesRecap = jest.fn();
 const mockSaveLikesRecapExcel = jest.fn();
+const mockSaveWeeklyLikesRecapExcel = jest.fn();
 const mockCollectKomentarRecap = jest.fn();
 const mockSaveCommentRecapExcel = jest.fn();
 const mockWriteFile = jest.fn();
@@ -79,6 +80,9 @@ jest.unstable_mockModule('../src/service/likesRecapExcelService.js', () => ({
 }));
 jest.unstable_mockModule('../src/service/commentRecapExcelService.js', () => ({
   saveCommentRecapExcel: mockSaveCommentRecapExcel,
+}));
+jest.unstable_mockModule('../src/service/weeklyLikesRecapExcelService.js', () => ({
+  saveWeeklyLikesRecapExcel: mockSaveWeeklyLikesRecapExcel,
 }));
 jest.unstable_mockModule('../src/utils/utilsHelper.js', () => ({
   getGreeting: () => 'Selamat malam',
@@ -597,6 +601,31 @@ test('choose_menu option 14 generates likes recap excel and sends file', async (
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
   );
   expect(mockUnlink).toHaveBeenCalledWith('/tmp/recap.xlsx');
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('File Excel dikirim')
+  );
+});
+
+test('choose_menu option 17 generates weekly likes recap excel and sends file', async () => {
+  mockSaveWeeklyLikesRecapExcel.mockResolvedValue('/tmp/weekly.xlsx');
+  mockReadFile.mockResolvedValue(Buffer.from('excel'));
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '789';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '17', waClient);
+
+  expect(mockSaveWeeklyLikesRecapExcel).toHaveBeenCalledWith('ditbinmas');
+  expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly.xlsx');
+  expect(mockSendWAFile).toHaveBeenCalledWith(
+    waClient,
+    expect.any(Buffer),
+    path.basename('/tmp/weekly.xlsx'),
+    chatId,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  expect(mockUnlink).toHaveBeenCalledWith('/tmp/weekly.xlsx');
   expect(waClient.sendMessage).toHaveBeenCalledWith(
     chatId,
     expect.stringContaining('File Excel dikirim')


### PR DESCRIPTION
## Summary
- add weekly report menu for dirrequest to export instagram engagement
- implement weekly likes recap Excel export grouped by satker with daily columns for posts, likes, and pending likes
- cover new menu with tests

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: SyntaxError in absensiKomentarDitbinmasReport.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c75b42c7e48327ab717b53486aaac6