### PR TITLE
Include Satfung column in weekly Instagram recap export

### DIFF
--- a/src/service/weeklyLikesRecapExcelService.js
+++ b/src/service/weeklyLikesRecapExcelService.js
@@ -58,6 +58,7 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
         grouped[satker][key] = {
           pangkat: u.title || '',
           nama: u.nama || '',
+          satfung: u.divisi || '',
           perDate: {},
           totalLikes: 0,
         };
@@ -79,7 +80,7 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
       if (rankA !== rankB) return rankA - rankB;
       return a.nama.localeCompare(b.nama);
     });
-    const header = ['Pangkat Nama'];
+    const header = ['Pangkat Nama', 'Satfung'];
     dateList.forEach((d) => {
       header.push(`${d} Jumlah Post Tugas`);
       header.push(`${d} Sudah Likes`);
@@ -88,6 +89,7 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
     const rowsData = users.map((u) => {
       const row = {
         'Pangkat Nama': `${u.pangkat ? u.pangkat + ' ' : ''}${u.nama}`.trim(),
+        Satfung: u.satfung || '',
       };
       dateList.forEach((d) => {
         const likes = u.perDate[d]?.likes || 0;


### PR DESCRIPTION
## Summary
- add Satfung column to weekly Instagram likes recap Excel export

## Testing
- `npm run lint`
- `npm test` *(fails: A jest worker process was terminated due to heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7791c95dc83278f11154742cd40d7