### PR TITLE
feat: format instagram recap excel by date

### DIFF
--- a/tests/likesRecapExcelService.test.js
+++ b/tests/likesRecapExcelService.test.js
@@ -1,0 +1,30 @@
+import { unlink } from 'fs/promises';
+import XLSX from 'xlsx';
+import { saveLikesRecapExcel } from '../src/service/likesRecapExcelService.js';
+
+test('saveLikesRecapExcel creates recap with date columns', async () => {
+  const data = {
+    shortcodes: ['SC1', 'SC2'],
+    recap: {
+      'POLRES A': [
+        { pangkat: 'AKP', nama: 'Budi', satfung: 'Sat A', SC1: 1, SC2: 0 },
+      ],
+    },
+  };
+
+  const filePath = await saveLikesRecapExcel(data, 'DITBINMAS');
+  const wb = XLSX.readFile(filePath);
+  const sheet = wb.Sheets['POLRES A'];
+  const rows = XLSX.utils.sheet_to_json(sheet);
+  const recapDate = new Date().toLocaleDateString('id-ID');
+
+  expect(rows[0]).toEqual({
+    'Pangkat Nama': 'AKP Budi',
+    'Divisi / Satfung': 'Sat A',
+    [`${recapDate} Jumlah Post`]: 2,
+    [`${recapDate} Sudah Likes`]: 1,
+    [`${recapDate} Belum Likes`]: 1,
+  });
+
+  await unlink(filePath);
+});


### PR DESCRIPTION
## Summary
- revise Instagram recap Excel generator to include per-date post, liked, and unliked counts
- add test to verify Excel output includes new columns

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: A jest worker process (pid=4692) was terminated by another process: signal=SIGTERM, exitCode=null)*

------
https://chatgpt.com/codex/tasks/task_e_68c77f38e6008327a47054456308e70f