### PR TITLE
Adjust weekly Instagram recap Excel columns

### DIFF
--- a/src/service/weeklyLikesRecapExcelService.js
+++ b/src/service/weeklyLikesRecapExcelService.js
@@ -80,21 +80,21 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
       if (rankA !== rankB) return rankA - rankB;
       return a.nama.localeCompare(b.nama);
     });
-    const header = ['Pangkat Nama', 'Satfung'];
+    const header = ['Pangkat Nama', 'Divisi / Satfung'];
     dateList.forEach((d) => {
-      header.push(`${d} Jumlah Post Tugas`);
+      header.push(`${d} Jumlah Post`);
       header.push(`${d} Sudah Likes`);
       header.push(`${d} Belum Likes`);
     });
     const rowsData = users.map((u) => {
       const row = {
         'Pangkat Nama': `${u.pangkat ? u.pangkat + ' ' : ''}${u.nama}`.trim(),
-        Satfung: u.satfung || '',
+        'Divisi / Satfung': u.satfung || '',
       };
       dateList.forEach((d) => {
         const likes = u.perDate[d]?.likes || 0;
         const posts = dailyPosts[d] || 0;
-        row[`${d} Jumlah Post Tugas`] = posts;
+        row[`${d} Jumlah Post`] = posts;
         row[`${d} Sudah Likes`] = likes;
         row[`${d} Belum Likes`] = Math.max(posts - likes, 0);
       });

--- a/tests/weeklyLikesRecapExcelService.test.js
+++ b/tests/weeklyLikesRecapExcelService.test.js
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals';
+import { unlink } from 'fs/promises';
+import XLSX from 'xlsx';
+
+process.env.TZ = 'Asia/Jakarta';
+
+const mockGetRekapLikesByClient = jest.fn();
+
+jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({
+  getRekapLikesByClient: mockGetRekapLikesByClient,
+}));
+
+const { saveWeeklyLikesRecapExcel } = await import(
+  '../src/service/weeklyLikesRecapExcelService.js'
+);
+
+test('saveWeeklyLikesRecapExcel creates recap with per-date columns', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-07T00:00:00Z'));
+
+  mockGetRekapLikesByClient.mockImplementation(async (clientId, periode, tanggal) => {
+    if (tanggal === '2024-04-07') {
+      return {
+        rows: [
+          {
+            client_name: 'POLRES A',
+            title: 'AKP',
+            nama: 'Budi',
+            divisi: 'Sat A',
+            jumlah_like: 2,
+          },
+        ],
+        totalKonten: 3,
+      };
+    }
+    return { rows: [], totalKonten: 0 };
+  });
+
+  const filePath = await saveWeeklyLikesRecapExcel('DITBINMAS');
+  const wb = XLSX.readFile(filePath);
+  const sheet = wb.Sheets['POLRES A'];
+  const rows = XLSX.utils.sheet_to_json(sheet);
+
+  expect(rows[0]).toMatchObject({
+    'Pangkat Nama': 'AKP Budi',
+    'Divisi / Satfung': 'Sat A',
+    '2024-04-07 Jumlah Post': 3,
+    '2024-04-07 Sudah Likes': 2,
+    '2024-04-07 Belum Likes': 1,
+  });
+
+  await unlink(filePath);
+  jest.useRealTimers();
+});
+


### PR DESCRIPTION
## Summary
- refine weekly Instagram recap export to use `Divisi / Satfung` and per-date `Jumlah Post`, `Sudah Likes`, `Belum Likes` columns
- add unit test covering weekly recap Excel generation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c78b5b29cc83279fb3abd7cfc15e78