### PR TITLE
feat: enhance weekly likes recap excel

### DIFF
--- a/src/service/weeklyLikesRecapExcelService.js
+++ b/src/service/weeklyLikesRecapExcelService.js
@@ -30,11 +30,18 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
   const endDate = new Date();
   const startDate = new Date();
   startDate.setDate(endDate.getDate() - 6);
-  const formatDate = (d) => d.toISOString().slice(0, 10);
+
+  const formatIso = (d) => d.toISOString().slice(0, 10);
+  const formatDisplay = (d) =>
+    new Date(d).toLocaleDateString('id-ID', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
 
   const dateList = [];
   for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
-    dateList.push(formatDate(d));
+    dateList.push(formatIso(d));
   }
 
   const grouped = {};
@@ -63,9 +70,7 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
           totalLikes: 0,
         };
       }
-      grouped[satker][key].perDate[dateStr] = {
-        likes: u.jumlah_like || 0,
-      };
+      grouped[satker][key].perDate[dateStr] = { likes: u.jumlah_like || 0 };
       grouped[satker][key].totalLikes += u.jumlah_like || 0;
     }
   }
@@ -80,27 +85,82 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
       if (rankA !== rankB) return rankA - rankB;
       return a.nama.localeCompare(b.nama);
     });
-    const header = ['Pangkat Nama', 'Divisi / Satfung'];
+
+    const aoa = [];
+    const colCount = 4 + dateList.length * 3;
+    const title = `${satker} – Rekap Engagement Instagram`;
+    const periodStr = `${formatDisplay(startDate)} - ${formatDisplay(endDate)}`;
+    const subtitle = `Rekap Likes Instagram Periode ${periodStr}`;
+    aoa.push([title]);
+    aoa.push([subtitle]);
+
+    const headerDates = ['No', 'Pangkat', 'Nama', 'Divisi / Satfung'];
+    const subHeader = ['', '', '', ''];
     dateList.forEach((d) => {
-      header.push(`${d} Jumlah Post`);
-      header.push(`${d} Sudah Likes`);
-      header.push(`${d} Belum Likes`);
+      const disp = formatDisplay(d);
+      headerDates.push(disp, '', '');
+      subHeader.push('Jumlah Post', 'Sudah Likes', 'Belum Likes');
     });
-    const rowsData = users.map((u) => {
-      const row = {
-        'Pangkat Nama': `${u.pangkat ? u.pangkat + ' ' : ''}${u.nama}`.trim(),
-        'Divisi / Satfung': u.satfung || '',
-      };
+    aoa.push(headerDates);
+    aoa.push(subHeader);
+
+    users.forEach((u, idx) => {
+      const row = [idx + 1, u.pangkat || '', u.nama || '', u.satfung || ''];
       dateList.forEach((d) => {
         const likes = u.perDate[d]?.likes || 0;
         const posts = dailyPosts[d] || 0;
-        row[`${d} Jumlah Post`] = posts;
-        row[`${d} Sudah Likes`] = likes;
-        row[`${d} Belum Likes`] = Math.max(posts - likes, 0);
+        row.push(posts, likes, Math.max(posts - likes, 0));
       });
-      return row;
+      aoa.push(row);
     });
-    const ws = XLSX.utils.json_to_sheet(rowsData, { header });
+
+    const summaryRow = ['TOTAL', '', '', ''];
+    const startRow = 5; // 1-indexed data start row
+    const endRow = 4 + users.length;
+    dateList.forEach((_, i) => {
+      const postsCol = XLSX.utils.encode_col(4 + i * 3);
+      const sudahCol = XLSX.utils.encode_col(4 + i * 3 + 1);
+      const belumCol = XLSX.utils.encode_col(4 + i * 3 + 2);
+      summaryRow.push(
+        { f: `SUM(${postsCol}${startRow}:${postsCol}${endRow})` },
+        { f: `SUM(${sudahCol}${startRow}:${sudahCol}${endRow})` },
+        { f: `SUM(${belumCol}${startRow}:${belumCol}${endRow})` }
+      );
+    });
+    aoa.push(summaryRow);
+
+    const ws = XLSX.utils.aoa_to_sheet(aoa);
+
+    const merges = [
+      { s: { r: 0, c: 0 }, e: { r: 0, c: colCount - 1 } },
+      { s: { r: 1, c: 0 }, e: { r: 1, c: colCount - 1 } },
+    ];
+    dateList.forEach((_, i) => {
+      merges.push({
+        s: { r: 2, c: 4 + i * 3 },
+        e: { r: 2, c: 4 + i * 3 + 2 },
+      });
+    });
+    ws['!merges'] = merges;
+
+    ws['!freeze'] = { xSplit: 4, ySplit: 4 };
+
+    const lastDataRow = 4 + users.length;
+    ws['!autofilter'] = {
+      ref: XLSX.utils.encode_range({ r: 3, c: 0 }, { r: lastDataRow - 1, c: colCount - 1 }),
+    };
+
+    const green = { patternType: 'solid', fgColor: { rgb: 'C6EFCE' } };
+    const red = { patternType: 'solid', fgColor: { rgb: 'F8CBAD' } };
+    for (let r = 4; r <= lastDataRow; r++) {
+      dateList.forEach((_, i) => {
+        const sudahCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 1 });
+        const belumCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 2 });
+        if (ws[sudahCell]) ws[sudahCell].s = { fill: green };
+        if (ws[belumCell]) ws[belumCell].s = { fill: red };
+      });
+    }
+
     XLSX.utils.book_append_sheet(wb, ws, satker);
   });
 
@@ -120,7 +180,7 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
     exportDir,
     `Rekap_Mingguan_Instagram_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
   );
-  XLSX.writeFile(wb, filePath);
+  XLSX.writeFile(wb, filePath, { cellStyles: true });
   return filePath;
 }
 

--- a/tests/weeklyLikesRecapExcelService.test.js
+++ b/tests/weeklyLikesRecapExcelService.test.js
@@ -14,7 +14,7 @@ const { saveWeeklyLikesRecapExcel } = await import(
   '../src/service/weeklyLikesRecapExcelService.js'
 );
 
-test('saveWeeklyLikesRecapExcel creates recap with per-date columns', async () => {
+test('saveWeeklyLikesRecapExcel creates formatted weekly recap', async () => {
   jest.useFakeTimers().setSystemTime(new Date('2024-04-07T00:00:00Z'));
 
   mockGetRekapLikesByClient.mockImplementation(async (clientId, periode, tanggal) => {
@@ -38,15 +38,26 @@ test('saveWeeklyLikesRecapExcel creates recap with per-date columns', async () =
   const filePath = await saveWeeklyLikesRecapExcel('DITBINMAS');
   const wb = XLSX.readFile(filePath);
   const sheet = wb.Sheets['POLRES A'];
-  const rows = XLSX.utils.sheet_to_json(sheet);
+  const aoa = XLSX.utils.sheet_to_json(sheet, { header: 1 });
 
-  expect(rows[0]).toMatchObject({
-    'Pangkat Nama': 'AKP Budi',
-    'Divisi / Satfung': 'Sat A',
-    '2024-04-07 Jumlah Post': 3,
-    '2024-04-07 Sudah Likes': 2,
-    '2024-04-07 Belum Likes': 1,
-  });
+  expect(aoa[0][0]).toBe('POLRES A – Rekap Engagement Instagram');
+  expect(aoa[1][0]).toBe(
+    'Rekap Likes Instagram Periode 01/04/2024 - 07/04/2024'
+  );
+  expect(aoa[2].slice(0, 4)).toEqual([
+    'No',
+    'Pangkat',
+    'Nama',
+    'Divisi / Satfung',
+  ]);
+  expect(aoa[3].slice(4, 7)).toEqual([
+    'Jumlah Post',
+    'Sudah Likes',
+    'Belum Likes',
+  ]);
+  const lastIdx = aoa[2].length - 3;
+  expect(aoa[4].slice(0, 4)).toEqual([1, 'AKP', 'Budi', 'Sat A']);
+  expect(aoa[4].slice(lastIdx, lastIdx + 3)).toEqual([3, 2, 1]);
 
   await unlink(filePath);
   jest.useRealTimers();


### PR DESCRIPTION
## Summary
- build multi-row Excel headers with per-date grouped columns and summary formulas
- apply freeze panes, auto filters, and cell coloring for better readability
- add tests validating weekly recap Excel structure

## Testing
- `npm run lint`
- `npm test` *(fails: absensiKomentarDitbinmasReport.test.js – JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c792661764832785c1694f3a36df47