### PR TITLE
feat: allow skipping likes fetch

### DIFF
--- a/src/handler/fetchabsensi/sosmedTask.js
+++ b/src/handler/fetchabsensi/sosmedTask.js
@@ -8,8 +8,13 @@ import { handleFetchKomentarTiktokBatch } from "../fetchengagement/fetchCommentT
 
 export async function generateSosmedTaskMessage(
   clientId = "DITBINMAS",
-  skipTiktokFetch = false
+  options = {}
 ) {
+
+  if (typeof options === "boolean") {
+    options = { skipTiktokFetch: options };
+  }
+  const { skipTiktokFetch = false, skipLikesFetch = false } = options;
 
   let clientName = clientId;
   let tiktokUsername = "";
@@ -25,7 +30,9 @@ export async function generateSosmedTaskMessage(
   let shortcodes = [];
   try {
     shortcodes = await getShortcodesTodayByClient(clientId);
-    await handleFetchLikesInstagram(null, null, clientId);
+    if (!skipLikesFetch) {
+      await handleFetchLikesInstagram(null, null, clientId);
+    }
   } catch {
     shortcodes = [];
   }

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -641,11 +641,14 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         targetId
       );
       await handleFetchLikesInstagram(null, null, targetId);
-        await fetchAndStoreTiktokContent(targetId, waClient, chatId);
-        await handleFetchKomentarTiktokBatch(null, null, targetId);
-        ({ text: msg } = await generateSosmedTaskMessage(targetId, true));
-        break;
-      }
+      await fetchAndStoreTiktokContent(targetId, waClient, chatId);
+      await handleFetchKomentarTiktokBatch(null, null, targetId);
+      ({ text: msg } = await generateSosmedTaskMessage(targetId, {
+        skipTiktokFetch: true,
+        skipLikesFetch: true,
+      }));
+      break;
+    }
     case "13": {
       const { text, filename, narrative, textBelum, filenameBelum } =
         await lapharTiktokDitbinmas();

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -432,8 +432,11 @@ test('choose_menu option 12 fetch sosial media sends combined task', async () =>
     waClient,
     chatId
   );
-  expect(mockHandleFetchKomentarTiktokBatch).toHaveBeenCalledWith(null, null, 'DITBINMAS');
-  expect(mockGenerateSosmedTaskMessage).toHaveBeenCalledWith('DITBINMAS', true);
+    expect(mockHandleFetchKomentarTiktokBatch).toHaveBeenCalledWith(null, null, 'DITBINMAS');
+    expect(mockGenerateSosmedTaskMessage).toHaveBeenCalledWith('DITBINMAS', {
+      skipTiktokFetch: true,
+      skipLikesFetch: true,
+    });
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'tugas sosmed');
   expect(mockSafeSendMessage).toHaveBeenCalledWith(
     waClient,

--- a/tests/sosmedTask.test.js
+++ b/tests/sosmedTask.test.js
@@ -61,13 +61,17 @@ test('generateSosmedTaskMessage formats message correctly', async () => {
   expect(mockHandleFetchKomentarTiktokBatch).toHaveBeenCalledWith(null, null, 'DITBINMAS');
 });
 
-test('generateSosmedTaskMessage can skip tiktok fetch', async () => {
+test('generateSosmedTaskMessage can skip internal fetches', async () => {
   mockFindClientById.mockResolvedValue({ nama: 'Dit Binmas', client_tiktok: '' });
   mockGetShortcodesTodayByClient.mockResolvedValue([]);
   mockGetTiktokPostsToday.mockResolvedValue([]);
   mockHandleFetchLikesInstagram.mockResolvedValue();
 
-  await generateSosmedTaskMessage('DITBINMAS', true);
+  await generateSosmedTaskMessage('DITBINMAS', {
+    skipTiktokFetch: true,
+    skipLikesFetch: true,
+  });
 
   expect(mockHandleFetchKomentarTiktokBatch).not.toHaveBeenCalled();
+  expect(mockHandleFetchLikesInstagram).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- add `skipLikesFetch` option to `generateSosmedTaskMessage`
- avoid fetching likes or tiktok comments when skipped
- pass skip options in dirRequestHandlers submenu 12

## Testing
- `npm run lint`
- `npm test -- tests/sosmedTask.test.js tests/dirRequestHandlers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7bf73432483278a4775b8f1a35480