### PR TITLE
Call TikTok comment fetch in dirrequest cron

### DIFF
--- a/src/cron/cronDirRequestFetchSosmed.js
+++ b/src/cron/cronDirRequestFetchSosmed.js
@@ -6,6 +6,7 @@ import { waGatewayClient } from "../service/waService.js";
 import { fetchAndStoreInstaContent } from "../handler/fetchpost/instaFetchPost.js";
 import { handleFetchLikesInstagram } from "../handler/fetchengagement/fetchLikesInstagram.js";
 import { fetchAndStoreTiktokContent } from "../handler/fetchpost/tiktokFetchPost.js";
+import { handleFetchKomentarTiktokBatch } from "../handler/fetchengagement/fetchCommentTiktok.js";
 import { generateSosmedTaskMessage } from "../handler/fetchabsensi/sosmedTask.js";
 import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
 import { sendDebug } from "../middleware/debugHandler.js";
@@ -30,6 +31,7 @@ export async function runCron() {
     );
     await handleFetchLikesInstagram(null, null, "DITBINMAS");
     await fetchAndStoreTiktokContent("DITBINMAS");
+    await handleFetchKomentarTiktokBatch(null, null, "DITBINMAS");
     const { text, igCount, tiktokCount } = await generateSosmedTaskMessage();
     if (igCount !== lastIgCount || tiktokCount !== lastTiktokCount) {
       const recipients = getRecipients();


### PR DESCRIPTION
## Summary
- import `handleFetchKomentarTiktokBatch` in TikTok cron
- fetch TikTok comments for `DITBINMAS` after fetching posts

## Testing
- `npm run lint`
- `npm test` *(fails: Jest worker exited, heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c3ec330c83278d3c1e153da96e28