### PR TITLE
Initialize sosmed counts on cron startup

### DIFF
--- a/src/cron/cronDirRequestFetchSosmed.js
+++ b/src/cron/cronDirRequestFetchSosmed.js
@@ -3,6 +3,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 import { waGatewayClient } from "../service/waService.js";
+import { getInstaPostCount, getTiktokPostCount } from "../service/postCountService.js";
 import { fetchAndStoreInstaContent } from "../handler/fetchpost/instaFetchPost.js";
 import { handleFetchLikesInstagram } from "../handler/fetchengagement/fetchLikesInstagram.js";
 import { fetchAndStoreTiktokContent } from "../handler/fetchpost/tiktokFetchPost.js";
@@ -15,6 +16,15 @@ const DIRREQUEST_GROUP = "120363419830216549@g.us";
 
 let lastIgCount = null;
 let lastTiktokCount = null;
+
+async function initializeLastCounts() {
+  lastIgCount = await getInstaPostCount("DITBINMAS");
+  lastTiktokCount = await getTiktokPostCount("DITBINMAS");
+}
+
+if (process.env.JEST_WORKER_ID === undefined) {
+  await initializeLastCounts();
+}
 
 function getRecipients() {
   return new Set([...getAdminWAIds(), DIRREQUEST_GROUP]);


### PR DESCRIPTION
## Summary
- import Instagram and Tiktok post count helpers
- initialize cached post counts for DITBINMAS when cron module loads

## Testing
- `npm run lint`
- `npm test` *(fails: Missing environment variables: JWT_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c785e764832788fe0accc97eebab