### PR TITLE
feat: add weekly tiktok recap menu

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -19,6 +19,7 @@ import { join, basename } from "path";
 import { saveLikesRecapExcel } from "../../service/likesRecapExcelService.js";
 import { saveCommentRecapExcel } from "../../service/commentRecapExcelService.js";
 import { saveWeeklyLikesRecapExcel } from "../../service/weeklyLikesRecapExcelService.js";
+import { saveWeeklyCommentRecapExcel } from "../../service/weeklyCommentRecapExcelService.js";
 import { hariIndo } from "../../utils/constants.js";
 
 const dirRequestGroup = "120363419830216549@g.us";
@@ -809,6 +810,20 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = "✅ File Excel dikirim.";
       break;
     }
+    case "18": {
+      const filePath = await saveWeeklyCommentRecapExcel(clientId);
+      const buffer = await readFile(filePath);
+      await sendWAFile(
+        waClient,
+        buffer,
+        basename(filePath),
+        chatId,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      );
+      await unlink(filePath);
+      msg = "✅ File Excel dikirim.";
+      break;
+    }
     default:
       msg = "Menu tidak dikenal.";
   }
@@ -924,7 +939,8 @@ export const dirRequestHandlers = {
         "1️⃣4️⃣ Rekap like Instagram (Excel)\n" +
         "1️⃣5️⃣ Rekap gabungan semua sosmed\n\n" +
         "📆 *Laporan Mingguan*\n" +
-        "1️⃣7️⃣ Rekap file Instagram mingguan\n\n" +
+        "1️⃣7️⃣ Rekap file Instagram mingguan\n" +
+        "1️⃣8️⃣ Rekap file Tiktok mingguan\n\n" +
         "┗━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -967,6 +983,7 @@ export const dirRequestHandlers = {
       "15",
       "16",
       "17",
+      "18",
     ].includes(choice)) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
       return;

--- a/src/service/weeklyCommentRecapExcelService.js
+++ b/src/service/weeklyCommentRecapExcelService.js
@@ -1,0 +1,196 @@
+import { mkdir } from 'fs/promises';
+import path from 'path';
+import XLSX from 'xlsx';
+import { hariIndo } from '../utils/constants.js';
+import { getRekapKomentarByClient } from '../model/tiktokCommentModel.js';
+import { countPostsByClient } from '../model/tiktokPostModel.js';
+
+const RANK_ORDER = [
+  'KOMISARIS BESAR POLISI',
+  'AKBP',
+  'KOMPOL',
+  'AKP',
+  'IPTU',
+  'IPDA',
+  'AIPTU',
+  'AIPDA',
+  'BRIPKA',
+  'BRIGPOL',
+  'BRIGADIR',
+  'BRIGADIR POLISI',
+  'BRIPTU',
+  'BRIPDA',
+];
+
+function rankWeight(rank) {
+  const idx = RANK_ORDER.indexOf(String(rank || '').toUpperCase());
+  return idx === -1 ? RANK_ORDER.length : idx;
+}
+
+export async function saveWeeklyCommentRecapExcel(clientId) {
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(endDate.getDate() - 6);
+
+  const formatIso = (d) => d.toISOString().slice(0, 10);
+  const formatDisplay = (d) =>
+    new Date(d).toLocaleDateString('id-ID', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+
+  const dateList = [];
+  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+    dateList.push(formatIso(d));
+  }
+
+  const grouped = {};
+  const dailyPosts = {};
+
+  for (const dateStr of dateList) {
+    const rows = await getRekapKomentarByClient(
+      clientId,
+      'harian',
+      dateStr,
+      undefined,
+      undefined,
+      'ditbinmas'
+    );
+    const totalPosts = await countPostsByClient(
+      clientId,
+      'harian',
+      dateStr
+    );
+    dailyPosts[dateStr] = totalPosts;
+    for (const u of rows) {
+      const satker = u.client_name || '';
+      if (!grouped[satker]) grouped[satker] = {};
+      const key = `${u.title || ''}|${u.nama || ''}`;
+      if (!grouped[satker][key]) {
+        grouped[satker][key] = {
+          pangkat: u.title || '',
+          nama: u.nama || '',
+          satfung: u.divisi || '',
+          perDate: {},
+          totalKomentar: 0,
+        };
+      }
+      grouped[satker][key].perDate[dateStr] = {
+        komentar: u.jumlah_komentar || 0,
+      };
+      grouped[satker][key].totalKomentar += u.jumlah_komentar || 0;
+    }
+  }
+
+  const wb = XLSX.utils.book_new();
+  Object.entries(grouped).forEach(([satker, usersMap]) => {
+    const users = Object.values(usersMap);
+    users.sort((a, b) => {
+      if (b.totalKomentar !== a.totalKomentar)
+        return b.totalKomentar - a.totalKomentar;
+      const rankA = rankWeight(a.pangkat);
+      const rankB = rankWeight(b.pangkat);
+      if (rankA !== rankB) return rankA - rankB;
+      return a.nama.localeCompare(b.nama);
+    });
+
+    const aoa = [];
+    const colCount = 4 + dateList.length * 3;
+    const title = `${satker} – Rekap Engagement Tiktok`;
+    const periodStr = `${formatDisplay(startDate)} - ${formatDisplay(endDate)}`;
+    const subtitle = `Rekap Komentar Tiktok Periode ${periodStr}`;
+    aoa.push([title]);
+    aoa.push([subtitle]);
+
+    const headerDates = ['No', 'Pangkat', 'Nama', 'Divisi / Satfung'];
+    const subHeader = ['', '', '', ''];
+    dateList.forEach((d) => {
+      const disp = formatDisplay(d);
+      headerDates.push(disp, '', '');
+      subHeader.push('Jumlah Post', 'Sudah Komentar', 'Belum Komentar');
+    });
+    aoa.push(headerDates);
+    aoa.push(subHeader);
+
+    users.forEach((u, idx) => {
+      const row = [idx + 1, u.pangkat || '', u.nama || '', u.satfung || ''];
+      dateList.forEach((d) => {
+        const komentar = u.perDate[d]?.komentar || 0;
+        const posts = dailyPosts[d] || 0;
+        row.push(posts, komentar, Math.max(posts - komentar, 0));
+      });
+      aoa.push(row);
+    });
+
+    const summaryRow = ['TOTAL', '', '', ''];
+    const startRow = 5; // 1-indexed data start row
+    const endRow = 4 + users.length;
+    dateList.forEach((_, i) => {
+      const postsCol = XLSX.utils.encode_col(4 + i * 3);
+      const sudahCol = XLSX.utils.encode_col(4 + i * 3 + 1);
+      const belumCol = XLSX.utils.encode_col(4 + i * 3 + 2);
+      summaryRow.push(
+        { f: `SUM(${postsCol}${startRow}:${postsCol}${endRow})` },
+        { f: `SUM(${sudahCol}${startRow}:${sudahCol}${endRow})` },
+        { f: `SUM(${belumCol}${startRow}:${belumCol}${endRow})` }
+      );
+    });
+    aoa.push(summaryRow);
+
+    const ws = XLSX.utils.aoa_to_sheet(aoa);
+
+    const merges = [
+      { s: { r: 0, c: 0 }, e: { r: 0, c: colCount - 1 } },
+      { s: { r: 1, c: 0 }, e: { r: 1, c: colCount - 1 } },
+    ];
+    dateList.forEach((_, i) => {
+      merges.push({
+        s: { r: 2, c: 4 + i * 3 },
+        e: { r: 2, c: 4 + i * 3 + 2 },
+      });
+    });
+    ws['!merges'] = merges;
+
+    ws['!freeze'] = { xSplit: 4, ySplit: 4 };
+
+    const lastDataRow = 4 + users.length;
+    ws['!autofilter'] = {
+      ref: XLSX.utils.encode_range({ r: 3, c: 0 }, { r: lastDataRow - 1, c: colCount - 1 }),
+    };
+
+    const green = { patternType: 'solid', fgColor: { rgb: 'C6EFCE' } };
+    const red = { patternType: 'solid', fgColor: { rgb: 'F8CBAD' } };
+    for (let r = 4; r <= lastDataRow; r++) {
+      dateList.forEach((_, i) => {
+        const sudahCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 1 });
+        const belumCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 2 });
+        if (ws[sudahCell]) ws[sudahCell].s = { fill: green };
+        if (ws[belumCell]) ws[belumCell].s = { fill: red };
+      });
+    }
+
+    XLSX.utils.book_append_sheet(wb, ws, satker);
+  });
+
+  const exportDir = path.resolve('export_data/weekly_comment');
+  await mkdir(exportDir, { recursive: true });
+
+  const now = new Date();
+  const hari = hariIndo[now.getDay()];
+  const tanggal = now.toLocaleDateString('id-ID');
+  const jam = now.toLocaleTimeString('id-ID', { hour12: false });
+  const dateSafe = tanggal.replace(/\//g, '-');
+  const timeSafe = jam.replace(/[:.]/g, '-');
+  const formattedClient = (clientId || '')
+    .toLowerCase()
+    .replace(/^./, (c) => c.toUpperCase());
+  const filePath = path.join(
+    exportDir,
+    `Rekap_Mingguan_Tiktok_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+  );
+  XLSX.writeFile(wb, filePath, { cellStyles: true });
+  return filePath;
+}
+
+export default saveWeeklyCommentRecapExcel;

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -20,6 +20,7 @@ const mockSaveLikesRecapExcel = jest.fn();
 const mockSaveWeeklyLikesRecapExcel = jest.fn();
 const mockCollectKomentarRecap = jest.fn();
 const mockSaveCommentRecapExcel = jest.fn();
+const mockSaveWeeklyCommentRecapExcel = jest.fn();
 const mockWriteFile = jest.fn();
 const mockMkdir = jest.fn();
 const mockReadFile = jest.fn();
@@ -84,6 +85,12 @@ jest.unstable_mockModule('../src/service/commentRecapExcelService.js', () => ({
 jest.unstable_mockModule('../src/service/weeklyLikesRecapExcelService.js', () => ({
   saveWeeklyLikesRecapExcel: mockSaveWeeklyLikesRecapExcel,
 }));
+jest.unstable_mockModule(
+  '../src/service/weeklyCommentRecapExcelService.js',
+  () => ({
+    saveWeeklyCommentRecapExcel: mockSaveWeeklyCommentRecapExcel,
+  })
+);
 jest.unstable_mockModule('../src/utils/utilsHelper.js', () => ({
   getGreeting: () => 'Selamat malam',
   sortDivisionKeys: (arr) => arr.sort(),
@@ -629,6 +636,31 @@ test('choose_menu option 17 generates weekly likes recap excel and sends file', 
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
   );
   expect(mockUnlink).toHaveBeenCalledWith('/tmp/weekly.xlsx');
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('File Excel dikirim')
+  );
+});
+
+test('choose_menu option 18 generates weekly tiktok recap excel and sends file', async () => {
+  mockSaveWeeklyCommentRecapExcel.mockResolvedValue('/tmp/weekly-tt.xlsx');
+  mockReadFile.mockResolvedValue(Buffer.from('excel'));
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '790';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '18', waClient);
+
+  expect(mockSaveWeeklyCommentRecapExcel).toHaveBeenCalledWith('ditbinmas');
+  expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly-tt.xlsx');
+  expect(mockSendWAFile).toHaveBeenCalledWith(
+    waClient,
+    expect.any(Buffer),
+    path.basename('/tmp/weekly-tt.xlsx'),
+    chatId,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  expect(mockUnlink).toHaveBeenCalledWith('/tmp/weekly-tt.xlsx');
   expect(waClient.sendMessage).toHaveBeenCalledWith(
     chatId,
     expect.stringContaining('File Excel dikirim')

--- a/tests/weeklyCommentRecapExcelService.test.js
+++ b/tests/weeklyCommentRecapExcelService.test.js
@@ -1,0 +1,70 @@
+import { jest } from '@jest/globals';
+import { unlink } from 'fs/promises';
+import XLSX from 'xlsx';
+
+process.env.TZ = 'Asia/Jakarta';
+
+const mockGetRekapKomentarByClient = jest.fn();
+const mockCountPostsByClient = jest.fn();
+
+jest.unstable_mockModule('../src/model/tiktokCommentModel.js', () => ({
+  getRekapKomentarByClient: mockGetRekapKomentarByClient,
+}));
+
+jest.unstable_mockModule('../src/model/tiktokPostModel.js', () => ({
+  countPostsByClient: mockCountPostsByClient,
+}));
+
+const { saveWeeklyCommentRecapExcel } = await import(
+  '../src/service/weeklyCommentRecapExcelService.js'
+);
+
+test('saveWeeklyCommentRecapExcel creates formatted weekly recap', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-07T00:00:00Z'));
+
+  mockGetRekapKomentarByClient.mockImplementation(async (clientId, periode, tanggal) => {
+    if (tanggal === '2024-04-07') {
+      return [
+        {
+          client_name: 'POLRES A',
+          title: 'AKP',
+          nama: 'Budi',
+          divisi: 'Sat A',
+          jumlah_komentar: 2,
+        },
+      ];
+    }
+    return [];
+  });
+  mockCountPostsByClient.mockImplementation(async (clientId, periode, tanggal) => {
+    if (tanggal === '2024-04-07') return 3;
+    return 0;
+  });
+
+  const filePath = await saveWeeklyCommentRecapExcel('DITBINMAS');
+  const wb = XLSX.readFile(filePath);
+  const sheet = wb.Sheets['POLRES A'];
+  const aoa = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+
+  expect(aoa[0][0]).toBe('POLRES A – Rekap Engagement Tiktok');
+  expect(aoa[1][0]).toBe(
+    'Rekap Komentar Tiktok Periode 01/04/2024 - 07/04/2024'
+  );
+  expect(aoa[2].slice(0, 4)).toEqual([
+    'No',
+    'Pangkat',
+    'Nama',
+    'Divisi / Satfung',
+  ]);
+  expect(aoa[3].slice(4, 7)).toEqual([
+    'Jumlah Post',
+    'Sudah Komentar',
+    'Belum Komentar',
+  ]);
+  const lastIdx = aoa[2].length - 3;
+  expect(aoa[4].slice(0, 4)).toEqual([1, 'AKP', 'Budi', 'Sat A']);
+  expect(aoa[4].slice(lastIdx, lastIdx + 3)).toEqual([3, 2, 1]);
+
+  await unlink(filePath);
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- add weekly TikTok recap Excel generator
- extend dirrequest menu with TikTok weekly recap option
- cover weekly TikTok recap service with tests

## Testing
- `npm run lint`
- `npm test` *(fails: Jest worker encountered 4 child process exceptions; JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cbac88288327b2357d23d502fcad