### PR TITLE
Handle errors in weekly likes recap export

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -797,17 +797,30 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = await absensiKomentarDitbinmas();
       break;
     case "17": {
-      const filePath = await saveWeeklyLikesRecapExcel(clientId);
-      const buffer = await readFile(filePath);
-      await sendWAFile(
-        waClient,
-        buffer,
-        basename(filePath),
-        chatId,
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-      );
-      await unlink(filePath);
-      msg = "✅ File Excel dikirim.";
+      let filePath;
+      try {
+        filePath = await saveWeeklyLikesRecapExcel(clientId);
+        const buffer = await readFile(filePath);
+        await sendWAFile(
+          waClient,
+          buffer,
+          basename(filePath),
+          chatId,
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        );
+        msg = "✅ File Excel dikirim.";
+      } catch (error) {
+        console.error("Gagal mengirim file Excel:", error);
+        msg = "❌ Gagal mengirim file Excel.";
+      } finally {
+        if (filePath) {
+          try {
+            await unlink(filePath);
+          } catch (err) {
+            console.error("Gagal menghapus file sementara:", err);
+          }
+        }
+      }
       break;
     }
     case "18": {


### PR DESCRIPTION
## Summary
- add try/catch around weekly likes recap export to send failure messages and log errors

## Testing
- `npm run lint`
- `npm test` *(fails: Jest worker encountered child process exceptions in cronDirRequestFetchSosmed.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c80bbabd0c8327a6f47354b681ef5f