### PR TITLE
Handle missing weekly recap data

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -800,6 +800,10 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       let filePath;
       try {
         filePath = await saveWeeklyLikesRecapExcel(clientId);
+        if (!filePath) {
+          msg = "Tidak ada data.";
+          break;
+        }
         const buffer = await readFile(filePath);
         await sendWAFile(
           waClient,

--- a/src/service/weeklyLikesRecapExcelService.js
+++ b/src/service/weeklyLikesRecapExcelService.js
@@ -87,6 +87,10 @@ export async function saveWeeklyLikesRecapExcel(clientId) {
     }
   });
 
+  if (Object.keys(grouped).length === 0) {
+    return null;
+  }
+
   const wb = XLSX.utils.book_new();
   Object.entries(grouped).forEach(([satker, usersMap]) => {
     const users = Object.values(usersMap);

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -642,6 +642,23 @@ test('choose_menu option 17 generates weekly likes recap excel and sends file', 
   );
 });
 
+test('choose_menu option 17 sends no data message when service returns null', async () => {
+  mockSaveWeeklyLikesRecapExcel.mockResolvedValue(null);
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '791';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '17', waClient);
+
+  expect(mockReadFile).not.toHaveBeenCalled();
+  expect(mockSendWAFile).not.toHaveBeenCalled();
+  expect(mockUnlink).not.toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringMatching(/tidak ada data/i)
+  );
+});
+
 test('choose_menu option 18 generates weekly tiktok recap excel and sends file', async () => {
   mockSaveWeeklyCommentRecapExcel.mockResolvedValue('/tmp/weekly-tt.xlsx');
   mockReadFile.mockResolvedValue(Buffer.from('excel'));

--- a/tests/weeklyLikesRecapExcelService.test.js
+++ b/tests/weeklyLikesRecapExcelService.test.js
@@ -16,7 +16,7 @@ const { saveWeeklyLikesRecapExcel } = await import(
 
 test('saveWeeklyLikesRecapExcel creates formatted weekly recap', async () => {
   jest.useFakeTimers().setSystemTime(new Date('2024-04-07T00:00:00Z'));
-
+  mockGetRekapLikesByClient.mockReset();
   mockGetRekapLikesByClient.mockImplementation(async (clientId, periode, tanggal) => {
     if (tanggal === '2024-04-07') {
       return {
@@ -60,6 +60,16 @@ test('saveWeeklyLikesRecapExcel creates formatted weekly recap', async () => {
   expect(aoa[4].slice(lastIdx, lastIdx + 3)).toEqual([3, 2, 1]);
 
   await unlink(filePath);
+  jest.useRealTimers();
+});
+
+test('saveWeeklyLikesRecapExcel returns null when no data', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-07T00:00:00Z'));
+  mockGetRekapLikesByClient.mockReset();
+  mockGetRekapLikesByClient.mockResolvedValue({ rows: [], totalKonten: 0 });
+
+  const filePath = await saveWeeklyLikesRecapExcel('DITBINMAS');
+  expect(filePath).toBeNull();
   jest.useRealTimers();
 });
 


### PR DESCRIPTION
## Summary
- return `null` from `saveWeeklyLikesRecapExcel` when no records are available
- send a "tidak ada data" message without sending files in menu option 17
- test weekly recap service and handler for no-data scenarios

## Testing
- `npm run lint`
- `npm test` *(fails: Jest worker encountered child process exceptions / JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c80f8f6ad88327984d2b44f8ebd7e5