### PR TITLE
fix: reorder dirrequest menu and update tests

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -498,9 +498,12 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "3":
+      msg = await formatRekapBelumLengkapDitbinmas();
+      break;
+    case "4":
       msg = await absensiLikesDitbinmas();
       break;
-    case "4": { 
+    case "5": {
       const normalizedId = (clientId || "").toUpperCase();
       if (normalizedId !== "DITBINMAS") {
         msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
@@ -510,139 +513,58 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = await absensiLikes("DITBINMAS", opts);
       break;
     }
-    case "5":
+    case "6":
       msg = await absensiKomentarTiktok();
       break;
-    case "6": { 
-      const { fetchAndStoreInstaContent } = await import(
-        "../fetchpost/instaFetchPost.js"
-      );
-      const { handleFetchLikesInstagram } = await import(
-        "../fetchengagement/fetchLikesInstagram.js"
-      );
-      const { rekapLikesIG } = await import(
-        "../fetchabsensi/insta/absensiLikesInsta.js"
-      );
-      await fetchAndStoreInstaContent(
-        ["shortcode", "caption", "like_count", "timestamp"],
-        waClient,
-        chatId,
-        "DITBINMAS"
-      );
+    case "7":
+      msg = await absensiKomentarDitbinmas();
+      break;
+    case "8": {
+      const { fetchAndStoreInstaContent } = await import("../fetchpost/instaFetchPost.js");
+      const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
+      const { rekapLikesIG } = await import("../fetchabsensi/insta/absensiLikesInsta.js");
+      await fetchAndStoreInstaContent(["shortcode", "caption", "like_count", "timestamp"], waClient, chatId, "DITBINMAS");
       await handleFetchLikesInstagram(null, null, "DITBINMAS");
       const rekapMsg = await rekapLikesIG("DITBINMAS");
-      msg =
-        rekapMsg ||
-        "Tidak ada konten IG untuk DIREKTORAT BINMAS hari ini.";
+      msg = rekapMsg || "Tidak ada konten IG untuk DIREKTORAT BINMAS hari ini.";
       break;
     }
-    case "7": {
-      const { handleFetchLikesInstagram } = await import(
-        "../fetchengagement/fetchLikesInstagram.js"
-      );
+    case "9": {
+      const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
       await handleFetchLikesInstagram(waClient, chatId, "DITBINMAS");
       msg = "✅ Selesai fetch likes Instagram DITBINMAS.";
       break;
     }
-    case "8": {
+    case "10": {
       const normalizedId = (clientId || "").toUpperCase();
       if (normalizedId !== "DITBINMAS") {
         msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
         break;
       }
-      const { fetchAndStoreTiktokContent } = await import(
-        "../fetchpost/tiktokFetchPost.js"
-      );
-      const { handleFetchKomentarTiktokBatch } = await import(
-        "../fetchengagement/fetchCommentTiktok.js"
-      );
+      const { fetchAndStoreTiktokContent } = await import("../fetchpost/tiktokFetchPost.js");
+      const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
       await fetchAndStoreTiktokContent("DITBINMAS", waClient, chatId);
       await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
-      const rekapTiktok = await absensiKomentarDitbinmasReport(
-        userType === "org" ? { clientFilter: userClientId } : {}
-      );
-      msg =
-        rekapTiktok ||
-        "Tidak ada konten TikTok untuk DIREKTORAT BINMAS hari ini.";
+      const rekapTiktok = await absensiKomentarDitbinmasReport(userType === "org" ? { clientFilter: userClientId } : {});
+      msg = rekapTiktok || "Tidak ada konten TikTok untuk DIREKTORAT BINMAS hari ini.";
       break;
     }
-    case "9": {
-      const { handleFetchKomentarTiktokBatch } = await import(
-        "../fetchengagement/fetchCommentTiktok.js"
-      );
+    case "11": {
+      const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
       await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
       msg = "✅ Selesai fetch komentar TikTok DITBINMAS.";
       break;
     }
-    case "10": {
-        const { text, filename, narrative, textBelum, filenameBelum } =
-          await lapharDitbinmas();
-        const dirPath = "laphar";
-        await mkdir(dirPath, { recursive: true });
-        if (narrative) {
-          await waClient.sendMessage(chatId, narrative.trim());
-        }
-        if (text && filename) {
-          const buffer = Buffer.from(text, "utf-8");
-          const filePath = join(dirPath, filename);
-          await writeFile(filePath, buffer);
-          await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
-        }
-        if (textBelum && filenameBelum) {
-          const bufferBelum = Buffer.from(textBelum, "utf-8");
-          const filePathBelum = join(dirPath, filenameBelum);
-          await writeFile(filePathBelum, bufferBelum);
-          await sendWAFile(
-            waClient,
-            bufferBelum,
-            filenameBelum,
-            chatId,
-            "text/plain"
-          );
-        }
-        const recapData = await collectLikesRecap(clientId);
-        if (recapData.shortcodes.length) {
-          const excelPath = await saveLikesRecapExcel(recapData, clientId);
-          const bufferExcel = await readFile(excelPath);
-          await sendWAFile(
-            waClient,
-            bufferExcel,
-            basename(excelPath),
-            chatId,
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-          );
-          await unlink(excelPath);
-        }
-        return;
-      }
-    case "11":
-      msg = await formatRekapBelumLengkapDitbinmas();
-      break;
     case "12": {
-      const { fetchAndStoreInstaContent } = await import(
-        "../fetchpost/instaFetchPost.js"
-      );
-      const { handleFetchLikesInstagram } = await import(
-        "../fetchengagement/fetchLikesInstagram.js"
-      );
-      const { fetchAndStoreTiktokContent } = await import(
-        "../fetchpost/tiktokFetchPost.js"
-      );
-      const { handleFetchKomentarTiktokBatch } = await import(
-        "../fetchengagement/fetchCommentTiktok.js"
-      );
-      const { generateSosmedTaskMessage } = await import(
-        "../fetchabsensi/sosmedTask.js"
-      );
+      const { fetchAndStoreInstaContent } = await import("../fetchpost/instaFetchPost.js");
+      const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
+      const { fetchAndStoreTiktokContent } = await import("../fetchpost/tiktokFetchPost.js");
+      const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
+      const { generateSosmedTaskMessage } = await import("../fetchabsensi/sosmedTask.js");
       const targetId = (clientId || "").toUpperCase();
       const fetchErrors = [];
       try {
-        await fetchAndStoreInstaContent(
-          ["shortcode", "caption", "like_count", "timestamp"],
-          waClient,
-          chatId,
-          targetId
-        );
+        await fetchAndStoreInstaContent(["shortcode", "caption", "like_count", "timestamp"], waClient, chatId, targetId);
       } catch (err) {
         console.error("Error fetching Instagram content:", err);
         fetchErrors.push("Instagram content");
@@ -666,10 +588,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         fetchErrors.push("TikTok comments");
       }
       try {
-        ({ text: msg } = await generateSosmedTaskMessage(targetId, {
-          skipTiktokFetch: true,
-          skipLikesFetch: true,
-        }));
+        ({ text: msg } = await generateSosmedTaskMessage(targetId, { skipTiktokFetch: true, skipLikesFetch: true }));
       } catch (err) {
         console.error("Error generating sosmed task message:", err);
         msg = "Gagal membuat pesan tugas.";
@@ -681,8 +600,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "13": {
-      const { text, filename, narrative, textBelum, filenameBelum } =
-        await lapharTiktokDitbinmas();
+      const { text, filename, narrative, textBelum, filenameBelum } = await lapharDitbinmas();
       const dirPath = "laphar";
       await mkdir(dirPath, { recursive: true });
       if (narrative) {
@@ -698,30 +616,46 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         const bufferBelum = Buffer.from(textBelum, "utf-8");
         const filePathBelum = join(dirPath, filenameBelum);
         await writeFile(filePathBelum, bufferBelum);
-        await sendWAFile(
-          waClient,
-          bufferBelum,
-          filenameBelum,
-          chatId,
-          "text/plain"
-        );
+        await sendWAFile(waClient, bufferBelum, filenameBelum, chatId, "text/plain");
       }
-      const recapData = await collectKomentarRecap(clientId);
-      if (recapData.videoIds.length) {
-        const excelPath = await saveCommentRecapExcel(recapData, clientId);
+      const recapData = await collectLikesRecap(clientId);
+      if (recapData.shortcodes.length) {
+        const excelPath = await saveLikesRecapExcel(recapData, clientId);
         const bufferExcel = await readFile(excelPath);
-        await sendWAFile(
-          waClient,
-          bufferExcel,
-          basename(excelPath),
-          chatId,
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        );
+        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         await unlink(excelPath);
       }
       return;
     }
     case "14": {
+      const { text, filename, narrative, textBelum, filenameBelum } = await lapharTiktokDitbinmas();
+      const dirPath = "laphar";
+      await mkdir(dirPath, { recursive: true });
+      if (narrative) {
+        await waClient.sendMessage(chatId, narrative.trim());
+      }
+      if (text && filename) {
+        const buffer = Buffer.from(text, "utf-8");
+        const filePath = join(dirPath, filename);
+        await writeFile(filePath, buffer);
+        await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
+      }
+      if (textBelum && filenameBelum) {
+        const bufferBelum = Buffer.from(textBelum, "utf-8");
+        const filePathBelum = join(dirPath, filenameBelum);
+        await writeFile(filePathBelum, bufferBelum);
+        await sendWAFile(waClient, bufferBelum, filenameBelum, chatId, "text/plain");
+      }
+      const recapData = await collectKomentarRecap(clientId);
+      if (recapData.videoIds.length) {
+        const excelPath = await saveCommentRecapExcel(recapData, clientId);
+        const bufferExcel = await readFile(excelPath);
+        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        await unlink(excelPath);
+      }
+      return;
+    }
+    case "15": {
       const data = await collectLikesRecap(clientId);
       if (!data.shortcodes.length) {
         msg = `Tidak ada konten IG untuk *${clientId}* hari ini.`;
@@ -729,29 +663,19 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       }
       const filePath = await saveLikesRecapExcel(data, clientId);
       const buffer = await readFile(filePath);
-      await sendWAFile(
-        waClient,
-        buffer,
-        basename(filePath),
-        chatId,
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-      );
+      await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
       await unlink(filePath);
       msg = "✅ File Excel dikirim.";
       break;
     }
-    case "15": {
+    case "16": {
       const dirPath = "laphar";
       await mkdir(dirPath, { recursive: true });
-      const [ig, tt] = await Promise.all([
-        lapharDitbinmas(),
-        lapharTiktokDitbinmas(),
-      ]);
+      const [ig, tt] = await Promise.all([lapharDitbinmas(), lapharTiktokDitbinmas()]);
       const narrative = formatRekapAllSosmed(ig.narrative, tt.narrative);
       if (narrative) {
         await waClient.sendMessage(chatId, narrative);
       }
-
       if (ig.text && ig.filename) {
         const buffer = Buffer.from(ig.text, "utf-8");
         const filePath = join(dirPath, ig.filename);
@@ -762,16 +686,9 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       if (igRecap.shortcodes.length) {
         const excelPath = await saveLikesRecapExcel(igRecap, clientId);
         const bufferExcel = await readFile(excelPath);
-        await sendWAFile(
-          waClient,
-          bufferExcel,
-          basename(excelPath),
-          chatId,
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        );
+        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         await unlink(excelPath);
       }
-
       if (tt.text && tt.filename) {
         const buffer = Buffer.from(tt.text, "utf-8");
         const filePath = join(dirPath, tt.filename);
@@ -782,20 +699,11 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       if (ttRecap.videoIds.length) {
         const excelPath = await saveCommentRecapExcel(ttRecap, clientId);
         const bufferExcel = await readFile(excelPath);
-        await sendWAFile(
-          waClient,
-          bufferExcel,
-          basename(excelPath),
-          chatId,
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        );
+        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         await unlink(excelPath);
       }
       return;
     }
-    case "16":
-      msg = await absensiKomentarDitbinmas();
-      break;
     case "17": {
       let filePath;
       try {
@@ -805,13 +713,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
           break;
         }
         const buffer = await readFile(filePath);
-        await sendWAFile(
-          waClient,
-          buffer,
-          basename(filePath),
-          chatId,
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        );
+        await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         msg = "✅ File Excel dikirim.";
       } catch (error) {
         console.error("Gagal mengirim file Excel:", error);
@@ -830,13 +732,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
     case "18": {
       const filePath = await saveWeeklyCommentRecapExcel(clientId);
       const buffer = await readFile(filePath);
-      await sendWAFile(
-        waClient,
-        buffer,
-        basename(filePath),
-        chatId,
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-      );
+      await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
       await unlink(filePath);
       msg = "✅ File Excel dikirim.";
       break;
@@ -845,7 +741,7 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       msg = "Menu tidak dikenal.";
   }
   await waClient.sendMessage(chatId, msg.trim());
-  if (action === "6" || action === "8" || action === "12") {
+  if (action === "8" || action === "10" || action === "12") {
     await safeSendMessage(waClient, dirRequestGroup, msg.trim());
   }
 }
@@ -934,31 +830,31 @@ export const dirRequestHandlers = {
     const clientName = session.clientName;
       const menu =
         `Client: *${clientName}*\n` +
-        "┏━━━ *MENU DIRREQUEST* ━━━\n" +
+        "┏━━━━━━━━━━━━ *MENU DIRREQUEST* ━━━━━━━━━━━━\n" +
         "📊 *Rekap Data*\n" +
         "1️⃣ Rekap personel belum lengkapi data\n" +
         "2️⃣ Ringkasan pengisian data personel\n" +
-        "1️⃣1️⃣ Rekap data belum lengkap Ditbinmas\n\n" +
+        "3️⃣ Rekap data belum lengkap Ditbinmas\n\n" +
         "📅 *Absensi*\n" +
-        "3️⃣ Absensi like Ditbinmas\n" +
-        "4️⃣ Absensi like Instagram\n" +
-        "5️⃣ Absensi komentar TikTok\n" +
-        "1️⃣6️⃣ Absensi komentar Ditbinmas\n\n" +
+        "4️⃣ Absensi like Ditbinmas\n" +
+        "5️⃣ Absensi like Instagram\n" +
+        "6️⃣ Absensi komentar TikTok\n" +
+        "7️⃣ Absensi komentar Ditbinmas\n\n" +
         "📥 *Pengambilan Data*\n" +
-        "6️⃣ Ambil konten & like Instagram\n" +
-        "7️⃣ Ambil like Instagram saja\n" +
-        "8️⃣ Ambil konten & komentar TikTok\n" +
-        "9️⃣ Ambil komentar TikTok saja\n" +
+        "8️⃣ Ambil konten & like Instagram\n" +
+        "9️⃣ Ambil like Instagram saja\n" +
+        "🔟 Ambil konten & komentar TikTok\n" +
+        "1️⃣1️⃣ Ambil komentar TikTok saja\n" +
         "1️⃣2️⃣ Ambil semua sosmed & buat tugas\n\n" +
         "📝 *Laporan*\n" +
-        "🔟 Laporan harian Instagram Ditbinmas\n" +
-        "1️⃣3️⃣ Laporan harian TikTok Ditbinmas\n" +
-        "1️⃣4️⃣ Rekap like Instagram (Excel)\n" +
-        "1️⃣5️⃣ Rekap gabungan semua sosmed\n\n" +
+        "1️⃣3️⃣ Laporan harian Instagram Ditbinmas\n" +
+        "1️⃣4️⃣ Laporan harian TikTok Ditbinmas\n" +
+        "1️⃣5️⃣ Rekap like Instagram (Excel)\n" +
+        "1️⃣6️⃣ Rekap gabungan semua sosmed\n\n" +
         "📆 *Laporan Mingguan*\n" +
         "1️⃣7️⃣ Rekap file Instagram mingguan\n" +
         "1️⃣8️⃣ Rekap file Tiktok mingguan\n\n" +
-        "┗━━━━━━━━━━━━━━━━━┛\n" +
+        "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
     session.step = "choose_menu";
@@ -982,26 +878,28 @@ export const dirRequestHandlers = {
 
   async choose_menu(session, chatId, text, waClient) {
     const choice = text.trim();
-    if (![
-      "1",
-      "2",
-      "11",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "12",
-      "10",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-    ].includes(choice)) {
+    if (
+      ![
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+      ].includes(choice)
+    ) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
       return;
     }

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -251,47 +251,47 @@ test('choose_menu option 2 executive summary reports totals', async () => {
   jest.useRealTimers();
 });
 
-test('choose_menu option 3 absensi likes ditbinmas', async () => {
+test('choose_menu option 4 absensi likes ditbinmas', async () => {
   mockAbsensiLikesDitbinmasReport.mockResolvedValue('laporan');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '321';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '3', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '4', waClient);
 
   expect(mockAbsensiLikesDitbinmasReport).toHaveBeenCalled();
   expect(mockAbsensiLikes).not.toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan');
 });
 
-test('choose_menu option 5 absensi komentar tiktok', async () => {
+test('choose_menu option 6 absensi komentar tiktok', async () => {
   mockAbsensiKomentar.mockResolvedValue('laporan komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '333';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '6', waClient);
 
   expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', { roleFlag: 'ditbinmas' });
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
 });
 
-test('choose_menu option 16 absensi komentar ditbinmas detail', async () => {
+test('choose_menu option 7 absensi komentar ditbinmas detail', async () => {
   mockAbsensiKomentarDitbinmasReport.mockResolvedValue('detail komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '444';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '7', waClient);
 
   expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'detail komentar');
 });
 
-test('choose_menu option 4 absensi likes uses ditbinmas data for all users', async () => {
+test('choose_menu option 5 absensi likes uses ditbinmas data for all users', async () => {
   mockAbsensiLikes.mockResolvedValue('laporan');
   mockFindClientById.mockResolvedValue({ client_type: 'org', nama: 'POLRES A' });
 
@@ -304,7 +304,7 @@ test('choose_menu option 4 absensi likes uses ditbinmas data for all users', asy
   const chatId = '999';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '4', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
 
   expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
     mode: 'all',
@@ -312,7 +312,7 @@ test('choose_menu option 4 absensi likes uses ditbinmas data for all users', asy
   });
 });
 
-test('choose_menu option 4 skips ketika client bukan ditbinmas', async () => {
+test('choose_menu option 5 skips ketika client bukan ditbinmas', async () => {
   mockAbsensiLikes.mockResolvedValue('laporan');
 
   const session = {
@@ -323,7 +323,7 @@ test('choose_menu option 4 skips ketika client bukan ditbinmas', async () => {
   const chatId = '555';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '4', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
 
   expect(mockAbsensiLikes).not.toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(
@@ -333,7 +333,7 @@ test('choose_menu option 4 skips ketika client bukan ditbinmas', async () => {
 });
 
 
-test('choose_menu option 6 fetch insta returns rekap likes report', async () => {
+test('choose_menu option 8 fetch insta returns rekap likes report', async () => {
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();
   mockRekapLikesIG.mockResolvedValue('laporan likes');
@@ -348,7 +348,7 @@ test('choose_menu option 6 fetch insta returns rekap likes report', async () => 
   const chatId = '777';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '6', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '8', waClient);
 
   expect(mockFetchAndStoreInstaContent).toHaveBeenCalledWith(
     ['shortcode', 'caption', 'like_count', 'timestamp'],
@@ -366,7 +366,7 @@ test('choose_menu option 6 fetch insta returns rekap likes report', async () => 
   );
 });
 
-test('choose_menu option 8 fetch tiktok returns komentar report', async () => {
+test('choose_menu option 10 fetch tiktok returns komentar report', async () => {
   mockFetchAndStoreTiktokContent.mockResolvedValue();
   mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
   mockAbsensiKomentarDitbinmasReport.mockResolvedValue('laporan tiktok');
@@ -382,7 +382,7 @@ test('choose_menu option 8 fetch tiktok returns komentar report', async () => {
   const chatId = '888';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '8', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '10', waClient);
 
   expect(mockFetchAndStoreTiktokContent).toHaveBeenCalledWith(
     'DITBINMAS',
@@ -452,7 +452,7 @@ test('choose_menu option 12 fetch sosial media sends combined task', async () =>
   );
 });
 
-test('choose_menu option 10 sends laphar file, narrative, and likes recap excel', async () => {
+test('choose_menu option 13 sends laphar file, narrative, and likes recap excel', async () => {
   mockLapharDitbinmas.mockResolvedValue({
     text: 'lap',
     filename: 'lap.txt',
@@ -468,7 +468,7 @@ test('choose_menu option 10 sends laphar file, narrative, and likes recap excel'
   const chatId = '999';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '10', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '13', waClient);
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
   expect(mockCollectLikesRecap).toHaveBeenCalledWith('ditbinmas');
@@ -517,7 +517,7 @@ test('choose_menu option 10 sends laphar file, narrative, and likes recap excel'
   );
 });
 
-test('choose_menu option 13 sends tiktok laphar file narrative and recap excel', async () => {
+test('choose_menu option 14 sends tiktok laphar file narrative and recap excel', async () => {
   mockLapharTiktokDitbinmas.mockResolvedValue({
     text: 'lap',
     filename: 'lap.txt',
@@ -535,7 +535,7 @@ test('choose_menu option 13 sends tiktok laphar file narrative and recap excel',
   const chatId = '555';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '13', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '14', waClient);
 
   expect(mockLapharTiktokDitbinmas).toHaveBeenCalled();
   expect(mockCollectKomentarRecap).toHaveBeenCalledWith('ditbinmas');
@@ -584,7 +584,7 @@ test('choose_menu option 13 sends tiktok laphar file narrative and recap excel',
   expect(waClient.sendMessage.mock.calls[0][1]).toBe('narasi');
 });
 
-test('choose_menu option 14 generates likes recap excel and sends file', async () => {
+test('choose_menu option 15 generates likes recap excel and sends file', async () => {
   mockCollectLikesRecap.mockResolvedValue({
     shortcodes: ['sc1'],
     recap: { POLRES_A: [{ pangkat: 'AKP', nama: 'Budi', satfung: 'SAT A', sc1: 1 }] },
@@ -595,7 +595,7 @@ test('choose_menu option 14 generates likes recap excel and sends file', async (
   const chatId = '777';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '14', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '15', waClient);
 
   expect(mockCollectLikesRecap).toHaveBeenCalledWith('ditbinmas');
   expect(mockSaveLikesRecapExcel).toHaveBeenCalledWith({
@@ -684,7 +684,7 @@ test('choose_menu option 18 generates weekly tiktok recap excel and sends file',
   );
 });
 
-test('choose_menu option 15 sends combined sosmed recap and files', async () => {
+test('choose_menu option 16 sends combined sosmed recap and files', async () => {
   mockLapharDitbinmas.mockResolvedValue({
     text: 'ig',
     filename: 'ig.txt',
@@ -708,7 +708,7 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
   const chatId = '888';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '15', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
   expect(mockLapharTiktokDitbinmas).toHaveBeenCalled();
@@ -753,7 +753,7 @@ test('choose_menu option 15 sends combined sosmed recap and files', async () => 
   expect(mockUnlink).toHaveBeenCalledWith('/tmp/ig.xlsx');
   expect(mockUnlink).toHaveBeenCalledWith('/tmp/tt.xlsx');
 });
-test('choose_menu option 11 reports ditbinmas incomplete users by division', async () => {
+test('choose_menu option 3 reports ditbinmas incomplete users by division', async () => {
   mockGetUsersSocialByClient.mockResolvedValue([
     { client_id: 'DITBINMAS', divisi: 'Div A', title: 'AKP', nama: 'Budi', insta: null, tiktok: 'x' },
     { client_id: 'DITBINMAS', divisi: 'Div A', title: 'IPTU', nama: 'Adi', insta: 'y', tiktok: null },
@@ -764,7 +764,7 @@ test('choose_menu option 11 reports ditbinmas incomplete users by division', asy
   const chatId = '444';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '11', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '3', waClient);
 
   expect(mockGetUsersSocialByClient).toHaveBeenCalledWith('DITBINMAS', 'ditbinmas');
   const msg = waClient.sendMessage.mock.calls[0][1];


### PR DESCRIPTION
## Summary
- reorder dirrequest menu numbers and groups
- adjust handler routing and tests for new menu order

## Testing
- `npm run lint`
- `npm test` *(fails: Jest worker encountered child process exceptions in cronDirRequestFetchSosmed.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c81c2ca2a8832783710a874d2b9ba1