### PR TITLE
Swap Dirrequest comment menu order

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -514,10 +514,10 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
       break;
     }
     case "6":
-      msg = await absensiKomentarTiktok();
+      msg = await absensiKomentarDitbinmas();
       break;
     case "7":
-      msg = await absensiKomentarDitbinmas();
+      msg = await absensiKomentarTiktok();
       break;
     case "8": {
       const { fetchAndStoreInstaContent } = await import("../fetchpost/instaFetchPost.js");
@@ -838,8 +838,8 @@ export const dirRequestHandlers = {
         "📅 *Absensi*\n" +
         "4️⃣ Absensi like Ditbinmas\n" +
         "5️⃣ Absensi like Instagram\n" +
-        "6️⃣ Absensi komentar TikTok\n" +
-        "7️⃣ Absensi komentar Ditbinmas\n\n" +
+        "6️⃣ Absensi komentar Ditbinmas\n" +
+        "7️⃣ Absensi komentar TikTok\n\n" +
         "📥 *Pengambilan Data*\n" +
         "8️⃣ Ambil konten & like Instagram\n" +
         "9️⃣ Ambil like Instagram saja\n" +

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -265,8 +265,8 @@ test('choose_menu option 4 absensi likes ditbinmas', async () => {
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan');
 });
 
-test('choose_menu option 6 absensi komentar tiktok', async () => {
-  mockAbsensiKomentar.mockResolvedValue('laporan komentar');
+test('choose_menu option 6 absensi komentar ditbinmas detail', async () => {
+  mockAbsensiKomentarDitbinmasReport.mockResolvedValue('detail komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '333';
@@ -274,12 +274,12 @@ test('choose_menu option 6 absensi komentar tiktok', async () => {
 
   await dirRequestHandlers.choose_menu(session, chatId, '6', waClient);
 
-  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', { roleFlag: 'ditbinmas' });
-  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
+  expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'detail komentar');
 });
 
-test('choose_menu option 7 absensi komentar ditbinmas detail', async () => {
-  mockAbsensiKomentarDitbinmasReport.mockResolvedValue('detail komentar');
+test('choose_menu option 7 absensi komentar tiktok', async () => {
+  mockAbsensiKomentar.mockResolvedValue('laporan komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '444';
@@ -287,8 +287,8 @@ test('choose_menu option 7 absensi komentar ditbinmas detail', async () => {
 
   await dirRequestHandlers.choose_menu(session, chatId, '7', waClient);
 
-  expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
-  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'detail komentar');
+  expect(mockAbsensiKomentar).toHaveBeenCalledWith('DITBINMAS', { roleFlag: 'ditbinmas' });
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
 });
 
 test('choose_menu option 5 absensi likes uses ditbinmas data for all users', async () => {


### PR DESCRIPTION
## Summary
- swap menu items 6 and 7 in dirrequest menu to place "Absensi komentar Ditbinmas" before "Absensi komentar TikTok"
- adjust menu action mapping for the new order
- update DirRequest handler tests for reordered options

## Testing
- `npm run lint`
- `npm test` *(fails: Jest worker encountered child process exceptions in tests/cronDirRequestFetchSosmed.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c8207212508327a105ee12b4dbc6d8