### PR TITLE
feat: add simple absensi menus

### DIFF
--- a/src/handler/fetchabsensi/insta/absensiLikesInsta.js
+++ b/src/handler/fetchabsensi/insta/absensiLikesInsta.js
@@ -410,6 +410,55 @@ export async function rekapLikesIG(client_id) {
   return msg.trim();
 }
 
+export async function absensiLikesDitbinmasSimple() {
+  const roleName = "ditbinmas";
+  const now = new Date();
+  const hari = hariIndo[now.getDay()];
+  const tanggal = now.toLocaleDateString("id-ID");
+  const jam = now.toLocaleTimeString("id-ID", { hour12: false });
+
+  const shortcodes = await getShortcodesTodayByClient(roleName);
+  if (!shortcodes.length)
+    return "*Belum ada konten Instagram terbaru pada akun official DIREKTORAT BINMAS pada hari ini.*";
+
+  const kontenLinks = shortcodes.map((sc) => `https://www.instagram.com/p/${sc}`);
+  const likesSets = await getLikesSets(shortcodes);
+  const { usersByClient } = await groupUsersByClientDivision(roleName, {
+    clientFilter: "DITBINMAS",
+  });
+  const allUsers = usersByClient["DITBINMAS"] || [];
+  const totals = { total: allUsers.length, lengkap: 0, kurang: 0, belum: 0 };
+  allUsers.forEach((u) => {
+    if (!u.insta || u.insta.trim() === "") {
+      totals.belum++;
+      return;
+    }
+    const uname = normalizeUsername(u.insta);
+    let count = 0;
+    likesSets.forEach((set) => {
+      if (set.has(uname)) count += 1;
+    });
+    if (count === shortcodes.length) totals.lengkap++;
+    else if (count > 0) totals.kurang++;
+    else totals.belum++;
+  });
+
+  let msg =
+    `Mohon ijin Komandan,\n\n` +
+    `📋 Rekap Akumulasi Likes Instagram (Simple)\n` +
+    `*DIREKTORAT BINMAS*\n` +
+    `${hari}, ${tanggal}\n` +
+    `Jam: ${jam}\n\n` +
+    `*Jumlah Konten:* ${shortcodes.length}\n` +
+    `*Daftar Link Konten:*\n${kontenLinks.join("\n")}\n\n` +
+    `*Jumlah Total Personil:* ${totals.total} pers\n` +
+    `✅ *Melaksanakan Lengkap :* ${totals.lengkap} pers\n` +
+    `⚠️ *Melaksanakan Kurang :* ${totals.kurang} pers\n` +
+    `❌ *Belum :* ${totals.belum} pers`;
+
+  return msg.trim();
+}
+
 export async function absensiLikesDitbinmasReport() {
   const roleName = "ditbinmas";
   const now = new Date();

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -4,12 +4,14 @@ import {
   lapharDitbinmas,
   absensiLikesDitbinmasReport,
   collectLikesRecap,
+  absensiLikesDitbinmasSimple as absensiLikesDitbinmasSimpleReport,
 } from "../fetchabsensi/insta/absensiLikesInsta.js";
 import {
   lapharTiktokDitbinmas,
   collectKomentarRecap,
   absensiKomentarDitbinmasReport,
   absensiKomentar,
+  absensiKomentarDitbinmasSimple as absensiKomentarDitbinmasSimpleReport,
 } from "../fetchabsensi/tiktok/absensiKomentarTiktok.js";
 import { findClientById } from "../../service/clientService.js";
 import { getGreeting, sortDivisionKeys, formatNama } from "../../utils/utilsHelper.js";
@@ -234,12 +236,17 @@ async function formatRekapUserData(clientId, roleFlag = null) {
 async function absensiLikesDitbinmas() {
   return await absensiLikesDitbinmasReport();
 }
+async function absensiLikesDitbinmasSimple() {
+  return await absensiLikesDitbinmasSimpleReport();
+}
 async function absensiKomentarTiktok() {
   return await absensiKomentar("DITBINMAS", { roleFlag: "ditbinmas" });
-
+}
+async function absensiKomentarDitbinmasSimple() {
+  return await absensiKomentarDitbinmasSimpleReport();
 }
 async function absensiKomentarDitbinmas() {
-    return await absensiKomentarDitbinmasReport();
+  return await absensiKomentarDitbinmasReport();
 }
 async function formatRekapBelumLengkapDitbinmas() {
   const users = await getUsersSocialByClient("DITBINMAS", "ditbinmas");
@@ -500,251 +507,257 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
     case "3":
       msg = await formatRekapBelumLengkapDitbinmas();
       break;
-    case "4":
-      msg = await absensiLikesDitbinmas();
-      break;
-    case "5": {
-      const normalizedId = (clientId || "").toUpperCase();
-      if (normalizedId !== "DITBINMAS") {
-        msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
+      case "4":
+        msg = await absensiLikesDitbinmas();
         break;
-      }
-      const opts = { mode: "all", roleFlag: "ditbinmas" };
-      msg = await absensiLikes("DITBINMAS", opts);
-      break;
-    }
-    case "6":
-      msg = await absensiKomentarDitbinmas();
-      break;
-    case "7":
-      msg = await absensiKomentarTiktok();
-      break;
-    case "8": {
-      const { fetchAndStoreInstaContent } = await import("../fetchpost/instaFetchPost.js");
-      const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
-      const { rekapLikesIG } = await import("../fetchabsensi/insta/absensiLikesInsta.js");
-      await fetchAndStoreInstaContent(["shortcode", "caption", "like_count", "timestamp"], waClient, chatId, "DITBINMAS");
-      await handleFetchLikesInstagram(null, null, "DITBINMAS");
-      const rekapMsg = await rekapLikesIG("DITBINMAS");
-      msg = rekapMsg || "Tidak ada konten IG untuk DIREKTORAT BINMAS hari ini.";
-      break;
-    }
-    case "9": {
-      const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
-      await handleFetchLikesInstagram(waClient, chatId, "DITBINMAS");
-      msg = "✅ Selesai fetch likes Instagram DITBINMAS.";
-      break;
-    }
-    case "10": {
-      const normalizedId = (clientId || "").toUpperCase();
-      if (normalizedId !== "DITBINMAS") {
-        msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
+      case "5":
+        msg = await absensiLikesDitbinmasSimple();
         break;
-      }
-      const { fetchAndStoreTiktokContent } = await import("../fetchpost/tiktokFetchPost.js");
-      const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
-      await fetchAndStoreTiktokContent("DITBINMAS", waClient, chatId);
-      await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
-      const rekapTiktok = await absensiKomentarDitbinmasReport(userType === "org" ? { clientFilter: userClientId } : {});
-      msg = rekapTiktok || "Tidak ada konten TikTok untuk DIREKTORAT BINMAS hari ini.";
-      break;
-    }
-    case "11": {
-      const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
-      await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
-      msg = "✅ Selesai fetch komentar TikTok DITBINMAS.";
-      break;
-    }
-    case "12": {
-      const { fetchAndStoreInstaContent } = await import("../fetchpost/instaFetchPost.js");
-      const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
-      const { fetchAndStoreTiktokContent } = await import("../fetchpost/tiktokFetchPost.js");
-      const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
-      const { generateSosmedTaskMessage } = await import("../fetchabsensi/sosmedTask.js");
-      const targetId = (clientId || "").toUpperCase();
-      const fetchErrors = [];
-      try {
-        await fetchAndStoreInstaContent(["shortcode", "caption", "like_count", "timestamp"], waClient, chatId, targetId);
-      } catch (err) {
-        console.error("Error fetching Instagram content:", err);
-        fetchErrors.push("Instagram content");
-      }
-      try {
-        await handleFetchLikesInstagram(null, null, targetId);
-      } catch (err) {
-        console.error("Error fetching Instagram likes:", err);
-        fetchErrors.push("Instagram likes");
-      }
-      try {
-        await fetchAndStoreTiktokContent(targetId, waClient, chatId);
-      } catch (err) {
-        console.error("Error fetching TikTok content:", err);
-        fetchErrors.push("TikTok content");
-      }
-      try {
-        await handleFetchKomentarTiktokBatch(null, null, targetId);
-      } catch (err) {
-        console.error("Error fetching TikTok comments:", err);
-        fetchErrors.push("TikTok comments");
-      }
-      try {
-        ({ text: msg } = await generateSosmedTaskMessage(targetId, { skipTiktokFetch: true, skipLikesFetch: true }));
-      } catch (err) {
-        console.error("Error generating sosmed task message:", err);
-        msg = "Gagal membuat pesan tugas.";
-        fetchErrors.push("task message");
-      }
-      if (fetchErrors.length) {
-        msg = `${msg}\n\n⚠️ Sebagian data gagal diambil.`.trim();
-      }
-      break;
-    }
-    case "13": {
-      const { text, filename, narrative, textBelum, filenameBelum } = await lapharDitbinmas();
-      const dirPath = "laphar";
-      await mkdir(dirPath, { recursive: true });
-      if (narrative) {
-        await waClient.sendMessage(chatId, narrative.trim());
-      }
-      if (text && filename) {
-        const buffer = Buffer.from(text, "utf-8");
-        const filePath = join(dirPath, filename);
-        await writeFile(filePath, buffer);
-        await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
-      }
-      if (textBelum && filenameBelum) {
-        const bufferBelum = Buffer.from(textBelum, "utf-8");
-        const filePathBelum = join(dirPath, filenameBelum);
-        await writeFile(filePathBelum, bufferBelum);
-        await sendWAFile(waClient, bufferBelum, filenameBelum, chatId, "text/plain");
-      }
-      const recapData = await collectLikesRecap(clientId);
-      if (recapData.shortcodes.length) {
-        const excelPath = await saveLikesRecapExcel(recapData, clientId);
-        const bufferExcel = await readFile(excelPath);
-        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        await unlink(excelPath);
-      }
-      return;
-    }
-    case "14": {
-      const { text, filename, narrative, textBelum, filenameBelum } = await lapharTiktokDitbinmas();
-      const dirPath = "laphar";
-      await mkdir(dirPath, { recursive: true });
-      if (narrative) {
-        await waClient.sendMessage(chatId, narrative.trim());
-      }
-      if (text && filename) {
-        const buffer = Buffer.from(text, "utf-8");
-        const filePath = join(dirPath, filename);
-        await writeFile(filePath, buffer);
-        await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
-      }
-      if (textBelum && filenameBelum) {
-        const bufferBelum = Buffer.from(textBelum, "utf-8");
-        const filePathBelum = join(dirPath, filenameBelum);
-        await writeFile(filePathBelum, bufferBelum);
-        await sendWAFile(waClient, bufferBelum, filenameBelum, chatId, "text/plain");
-      }
-      const recapData = await collectKomentarRecap(clientId);
-      if (recapData.videoIds.length) {
-        const excelPath = await saveCommentRecapExcel(recapData, clientId);
-        const bufferExcel = await readFile(excelPath);
-        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        await unlink(excelPath);
-      }
-      return;
-    }
-    case "15": {
-      const data = await collectLikesRecap(clientId);
-      if (!data.shortcodes.length) {
-        msg = `Tidak ada konten IG untuk *${clientId}* hari ini.`;
-        break;
-      }
-      const filePath = await saveLikesRecapExcel(data, clientId);
-      const buffer = await readFile(filePath);
-      await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-      await unlink(filePath);
-      msg = "✅ File Excel dikirim.";
-      break;
-    }
-    case "16": {
-      const dirPath = "laphar";
-      await mkdir(dirPath, { recursive: true });
-      const [ig, tt] = await Promise.all([lapharDitbinmas(), lapharTiktokDitbinmas()]);
-      const narrative = formatRekapAllSosmed(ig.narrative, tt.narrative);
-      if (narrative) {
-        await waClient.sendMessage(chatId, narrative);
-      }
-      if (ig.text && ig.filename) {
-        const buffer = Buffer.from(ig.text, "utf-8");
-        const filePath = join(dirPath, ig.filename);
-        await writeFile(filePath, buffer);
-        await sendWAFile(waClient, buffer, ig.filename, chatId, "text/plain");
-      }
-      const igRecap = await collectLikesRecap(clientId);
-      if (igRecap.shortcodes.length) {
-        const excelPath = await saveLikesRecapExcel(igRecap, clientId);
-        const bufferExcel = await readFile(excelPath);
-        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        await unlink(excelPath);
-      }
-      if (tt.text && tt.filename) {
-        const buffer = Buffer.from(tt.text, "utf-8");
-        const filePath = join(dirPath, tt.filename);
-        await writeFile(filePath, buffer);
-        await sendWAFile(waClient, buffer, tt.filename, chatId, "text/plain");
-      }
-      const ttRecap = await collectKomentarRecap(clientId);
-      if (ttRecap.videoIds.length) {
-        const excelPath = await saveCommentRecapExcel(ttRecap, clientId);
-        const bufferExcel = await readFile(excelPath);
-        await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        await unlink(excelPath);
-      }
-      return;
-    }
-    case "17": {
-      let filePath;
-      try {
-        filePath = await saveWeeklyLikesRecapExcel(clientId);
-        if (!filePath) {
-          msg = "Tidak ada data.";
+      case "6": {
+        const normalizedId = (clientId || "").toUpperCase();
+        if (normalizedId !== "DITBINMAS") {
+          msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
           break;
         }
+        const opts = { mode: "all", roleFlag: "ditbinmas" };
+        msg = await absensiLikes("DITBINMAS", opts);
+        break;
+      }
+      case "7":
+        msg = await absensiKomentarTiktok();
+        break;
+      case "8":
+        msg = await absensiKomentarDitbinmasSimple();
+        break;
+      case "9":
+        msg = await absensiKomentarDitbinmas();
+        break;
+      case "10": {
+        const { fetchAndStoreInstaContent } = await import("../fetchpost/instaFetchPost.js");
+        const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
+        const { rekapLikesIG } = await import("../fetchabsensi/insta/absensiLikesInsta.js");
+        await fetchAndStoreInstaContent(["shortcode", "caption", "like_count", "timestamp"], waClient, chatId, "DITBINMAS");
+        await handleFetchLikesInstagram(null, null, "DITBINMAS");
+        const rekapMsg = await rekapLikesIG("DITBINMAS");
+        msg = rekapMsg || "Tidak ada konten IG untuk DIREKTORAT BINMAS hari ini.";
+        break;
+      }
+      case "11": {
+        const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
+        await handleFetchLikesInstagram(waClient, chatId, "DITBINMAS");
+        msg = "✅ Selesai fetch likes Instagram DITBINMAS.";
+        break;
+      }
+      case "12": {
+        const normalizedId = (clientId || "").toUpperCase();
+        if (normalizedId !== "DITBINMAS") {
+          msg = "Menu ini hanya tersedia untuk client DITBINMAS.";
+          break;
+        }
+        const { fetchAndStoreTiktokContent } = await import("../fetchpost/tiktokFetchPost.js");
+        const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
+        await fetchAndStoreTiktokContent("DITBINMAS", waClient, chatId);
+        await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
+        const rekapTiktok = await absensiKomentarDitbinmasReport(userType === "org" ? { clientFilter: userClientId } : {});
+        msg = rekapTiktok || "Tidak ada konten TikTok untuk DIREKTORAT BINMAS hari ini.";
+        break;
+      }
+      case "13": {
+        const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
+        await handleFetchKomentarTiktokBatch(waClient, chatId, "DITBINMAS");
+        msg = "✅ Selesai fetch komentar TikTok DITBINMAS.";
+        break;
+      }
+      case "14": {
+        const { fetchAndStoreInstaContent } = await import("../fetchpost/instaFetchPost.js");
+        const { handleFetchLikesInstagram } = await import("../fetchengagement/fetchLikesInstagram.js");
+        const { fetchAndStoreTiktokContent } = await import("../fetchpost/tiktokFetchPost.js");
+        const { handleFetchKomentarTiktokBatch } = await import("../fetchengagement/fetchCommentTiktok.js");
+        const { generateSosmedTaskMessage } = await import("../fetchabsensi/sosmedTask.js");
+        const targetId = (clientId || "").toUpperCase();
+        const fetchErrors = [];
+        try {
+          await fetchAndStoreInstaContent(["shortcode", "caption", "like_count", "timestamp"], waClient, chatId, targetId);
+        } catch (err) {
+          console.error("Error fetching Instagram content:", err);
+          fetchErrors.push("Instagram content");
+        }
+        try {
+          await handleFetchLikesInstagram(null, null, targetId);
+        } catch (err) {
+          console.error("Error fetching Instagram likes:", err);
+          fetchErrors.push("Instagram likes");
+        }
+        try {
+          await fetchAndStoreTiktokContent(targetId, waClient, chatId);
+        } catch (err) {
+          console.error("Error fetching TikTok content:", err);
+          fetchErrors.push("TikTok content");
+        }
+        try {
+          await handleFetchKomentarTiktokBatch(null, null, targetId);
+        } catch (err) {
+          console.error("Error fetching TikTok comments:", err);
+          fetchErrors.push("TikTok comments");
+        }
+        try {
+          ({ text: msg } = await generateSosmedTaskMessage(targetId, { skipTiktokFetch: true, skipLikesFetch: true }));
+        } catch (err) {
+          console.error("Error generating sosmed task message:", err);
+          msg = "Gagal membuat pesan tugas.";
+          fetchErrors.push("task message");
+        }
+        if (fetchErrors.length) {
+          msg = `${msg}\n\n⚠️ Sebagian data gagal diambil.`.trim();
+        }
+        break;
+      }
+      case "15": {
+        const { text, filename, narrative, textBelum, filenameBelum } = await lapharDitbinmas();
+        const dirPath = "laphar";
+        await mkdir(dirPath, { recursive: true });
+        if (narrative) {
+          await waClient.sendMessage(chatId, narrative.trim());
+        }
+        if (text && filename) {
+          const buffer = Buffer.from(text, "utf-8");
+          const filePath = join(dirPath, filename);
+          await writeFile(filePath, buffer);
+          await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
+        }
+        if (textBelum && filenameBelum) {
+          const bufferBelum = Buffer.from(textBelum, "utf-8");
+          const filePathBelum = join(dirPath, filenameBelum);
+          await writeFile(filePathBelum, bufferBelum);
+          await sendWAFile(waClient, bufferBelum, filenameBelum, chatId, "text/plain");
+        }
+        const recapData = await collectLikesRecap(clientId);
+        if (recapData.shortcodes.length) {
+          const excelPath = await saveLikesRecapExcel(recapData, clientId);
+          const bufferExcel = await readFile(excelPath);
+          await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          await unlink(excelPath);
+        }
+        return;
+      }
+      case "16": {
+        const { text, filename, narrative, textBelum, filenameBelum } = await lapharTiktokDitbinmas();
+        const dirPath = "laphar";
+        await mkdir(dirPath, { recursive: true });
+        if (narrative) {
+          await waClient.sendMessage(chatId, narrative.trim());
+        }
+        if (text && filename) {
+          const buffer = Buffer.from(text, "utf-8");
+          const filePath = join(dirPath, filename);
+          await writeFile(filePath, buffer);
+          await sendWAFile(waClient, buffer, filename, chatId, "text/plain");
+        }
+        if (textBelum && filenameBelum) {
+          const bufferBelum = Buffer.from(textBelum, "utf-8");
+          const filePathBelum = join(dirPath, filenameBelum);
+          await writeFile(filePathBelum, bufferBelum);
+          await sendWAFile(waClient, bufferBelum, filenameBelum, chatId, "text/plain");
+        }
+        const recapData = await collectKomentarRecap(clientId);
+        if (recapData.videoIds.length) {
+          const excelPath = await saveCommentRecapExcel(recapData, clientId);
+          const bufferExcel = await readFile(excelPath);
+          await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          await unlink(excelPath);
+        }
+        return;
+      }
+      case "17": {
+        const data = await collectLikesRecap(clientId);
+        if (!data.shortcodes.length) {
+          msg = `Tidak ada konten IG untuk *${clientId}* hari ini.`;
+          break;
+        }
+        const filePath = await saveLikesRecapExcel(data, clientId);
         const buffer = await readFile(filePath);
         await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        await unlink(filePath);
         msg = "✅ File Excel dikirim.";
-      } catch (error) {
-        console.error("Gagal mengirim file Excel:", error);
-        msg = "❌ Gagal mengirim file Excel.";
-      } finally {
-        if (filePath) {
-          try {
-            await unlink(filePath);
-          } catch (err) {
-            console.error("Gagal menghapus file sementara:", err);
+        break;
+      }
+      case "18": {
+        const dirPath = "laphar";
+        await mkdir(dirPath, { recursive: true });
+        const [ig, tt] = await Promise.all([lapharDitbinmas(), lapharTiktokDitbinmas()]);
+        const narrative = formatRekapAllSosmed(ig.narrative, tt.narrative);
+        if (narrative) {
+          await waClient.sendMessage(chatId, narrative);
+        }
+        if (ig.text && ig.filename) {
+          const buffer = Buffer.from(ig.text, "utf-8");
+          const filePath = join(dirPath, ig.filename);
+          await writeFile(filePath, buffer);
+          await sendWAFile(waClient, buffer, ig.filename, chatId, "text/plain");
+        }
+        const igRecap = await collectLikesRecap(clientId);
+        if (igRecap.shortcodes.length) {
+          const excelPath = await saveLikesRecapExcel(igRecap, clientId);
+          const bufferExcel = await readFile(excelPath);
+          await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          await unlink(excelPath);
+        }
+        if (tt.text && tt.filename) {
+          const buffer = Buffer.from(tt.text, "utf-8");
+          const filePath = join(dirPath, tt.filename);
+          await writeFile(filePath, buffer);
+          await sendWAFile(waClient, buffer, tt.filename, chatId, "text/plain");
+        }
+        const ttRecap = await collectKomentarRecap(clientId);
+        if (ttRecap.videoIds.length) {
+          const excelPath = await saveCommentRecapExcel(ttRecap, clientId);
+          const bufferExcel = await readFile(excelPath);
+          await sendWAFile(waClient, bufferExcel, basename(excelPath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          await unlink(excelPath);
+        }
+        return;
+      }
+      case "19": {
+        let filePath;
+        try {
+          filePath = await saveWeeklyLikesRecapExcel(clientId);
+          if (!filePath) {
+            msg = "Tidak ada data.";
+            break;
+          }
+          const buffer = await readFile(filePath);
+          await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          msg = "✅ File Excel dikirim.";
+        } catch (error) {
+          console.error("Gagal mengirim file Excel:", error);
+          msg = "❌ Gagal mengirim file Excel.";
+        } finally {
+          if (filePath) {
+            try {
+              await unlink(filePath);
+            } catch (err) {
+              console.error("Gagal menghapus file sementara:", err);
+            }
           }
         }
+        break;
       }
-      break;
+      case "20": {
+        const filePath = await saveWeeklyCommentRecapExcel(clientId);
+        const buffer = await readFile(filePath);
+        await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        await unlink(filePath);
+        msg = "✅ File Excel dikirim.";
+        break;
+      }
+      default:
+        msg = "Menu tidak dikenal.";
     }
-    case "18": {
-      const filePath = await saveWeeklyCommentRecapExcel(clientId);
-      const buffer = await readFile(filePath);
-      await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-      await unlink(filePath);
-      msg = "✅ File Excel dikirim.";
-      break;
+    await waClient.sendMessage(chatId, msg.trim());
+    if (action === "10" || action === "12" || action === "14") {
+      await safeSendMessage(waClient, dirRequestGroup, msg.trim());
     }
-    default:
-      msg = "Menu tidak dikenal.";
   }
-  await waClient.sendMessage(chatId, msg.trim());
-  if (action === "8" || action === "10" || action === "12") {
-    await safeSendMessage(waClient, dirRequestGroup, msg.trim());
-  }
-}
 
 export const dirRequestHandlers = {
   async choose_dash_user(session, chatId, text, waClient) {
@@ -837,23 +850,25 @@ export const dirRequestHandlers = {
         "3️⃣ Rekap data belum lengkap Ditbinmas\n\n" +
         "📅 *Absensi*\n" +
         "4️⃣ Absensi like Ditbinmas\n" +
-        "5️⃣ Absensi like Instagram\n" +
-        "6️⃣ Absensi komentar Ditbinmas\n" +
-        "7️⃣ Absensi komentar TikTok\n\n" +
+        "5️⃣ Absensi like Ditbinmas Simple\n" +
+        "6️⃣ Absensi like Instagram\n" +
+        "7️⃣ Absensi komentar TikTok\n" +
+        "8️⃣ Absensi komentar Ditbinmas Simple\n" +
+        "9️⃣ Absensi komentar Ditbinmas\n\n" +
         "📥 *Pengambilan Data*\n" +
-        "8️⃣ Ambil konten & like Instagram\n" +
-        "9️⃣ Ambil like Instagram saja\n" +
-        "🔟 Ambil konten & komentar TikTok\n" +
-        "1️⃣1️⃣ Ambil komentar TikTok saja\n" +
-        "1️⃣2️⃣ Ambil semua sosmed & buat tugas\n\n" +
+        "1️⃣0️⃣ Ambil konten & like Instagram\n" +
+        "1️⃣1️⃣ Ambil like Instagram saja\n" +
+        "1️⃣2️⃣ Ambil konten & komentar TikTok\n" +
+        "1️⃣3️⃣ Ambil komentar TikTok saja\n" +
+        "1️⃣4️⃣ Ambil semua sosmed & buat tugas\n\n" +
         "📝 *Laporan*\n" +
-        "1️⃣3️⃣ Laporan harian Instagram Ditbinmas\n" +
-        "1️⃣4️⃣ Laporan harian TikTok Ditbinmas\n" +
-        "1️⃣5️⃣ Rekap like Instagram (Excel)\n" +
-        "1️⃣6️⃣ Rekap gabungan semua sosmed\n\n" +
+        "1️⃣5️⃣ Laporan harian Instagram Ditbinmas\n" +
+        "1️⃣6️⃣ Laporan harian TikTok Ditbinmas\n" +
+        "1️⃣7️⃣ Rekap like Instagram (Excel)\n" +
+        "1️⃣8️⃣ Rekap gabungan semua sosmed\n\n" +
         "📆 *Laporan Mingguan*\n" +
-        "1️⃣7️⃣ Rekap file Instagram mingguan\n" +
-        "1️⃣8️⃣ Rekap file Tiktok mingguan\n\n" +
+        "1️⃣9️⃣ Rekap file Instagram mingguan\n" +
+        "2️⃣0️⃣ Rekap file Tiktok mingguan\n\n" +
         "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -879,26 +894,28 @@ export const dirRequestHandlers = {
   async choose_menu(session, chatId, text, waClient) {
     const choice = text.trim();
     if (
-      ![
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12",
-        "13",
-        "14",
-        "15",
-        "16",
-        "17",
-        "18",
-      ].includes(choice)
+        ![
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "16",
+          "17",
+          "18",
+          "19",
+          "20",
+        ].includes(choice)
     ) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
       return;
@@ -927,7 +944,9 @@ export const dirRequestHandlers = {
 export {
   formatRekapUserData,
   absensiLikesDitbinmas,
+  absensiLikesDitbinmasSimple,
   absensiKomentarDitbinmas,
+  absensiKomentarDitbinmasSimple,
   absensiKomentarTiktok,
   formatExecutiveSummary,
   formatRekapBelumLengkapDitbinmas,

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -7,8 +7,10 @@ const mockGetUsersSocialByClient = jest.fn();
 const mockGetClientsByRole = jest.fn();
 const mockAbsensiLikes = jest.fn();
 const mockAbsensiLikesDitbinmasReport = jest.fn();
+const mockAbsensiLikesDitbinmasSimple = jest.fn();
 const mockAbsensiKomentar = jest.fn();
 const mockAbsensiKomentarDitbinmasReport = jest.fn();
+const mockAbsensiKomentarDitbinmasSimple = jest.fn();
 const mockFindClientById = jest.fn();
 const mockFetchAndStoreInstaContent = jest.fn();
 const mockHandleFetchLikesInstagram = jest.fn();
@@ -40,6 +42,7 @@ jest.unstable_mockModule('../src/handler/fetchabsensi/insta/absensiLikesInsta.js
   rekapLikesIG: mockRekapLikesIG,
   lapharDitbinmas: mockLapharDitbinmas,
   absensiLikesDitbinmasReport: mockAbsensiLikesDitbinmasReport,
+  absensiLikesDitbinmasSimple: mockAbsensiLikesDitbinmasSimple,
   collectLikesRecap: mockCollectLikesRecap,
 }));
 jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js', () => ({
@@ -47,6 +50,7 @@ jest.unstable_mockModule('../src/handler/fetchabsensi/tiktok/absensiKomentarTikt
   lapharTiktokDitbinmas: mockLapharTiktokDitbinmas,
   collectKomentarRecap: mockCollectKomentarRecap,
   absensiKomentarDitbinmasReport: mockAbsensiKomentarDitbinmasReport,
+  absensiKomentarDitbinmasSimple: mockAbsensiKomentarDitbinmasSimple,
 }));
 jest.unstable_mockModule('../src/service/clientService.js', () => ({
   findClientById: mockFindClientById,
@@ -265,14 +269,27 @@ test('choose_menu option 4 absensi likes ditbinmas', async () => {
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan');
 });
 
-test('choose_menu option 6 absensi komentar ditbinmas detail', async () => {
+test('choose_menu option 5 absensi likes ditbinmas simple', async () => {
+  mockAbsensiLikesDitbinmasSimple.mockResolvedValue('simple laporan');
+
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '322';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
+
+  expect(mockAbsensiLikesDitbinmasSimple).toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'simple laporan');
+});
+
+test('choose_menu option 9 absensi komentar ditbinmas detail', async () => {
   mockAbsensiKomentarDitbinmasReport.mockResolvedValue('detail komentar');
 
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '333';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '6', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '9', waClient);
 
   expect(mockAbsensiKomentarDitbinmasReport).toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'detail komentar');
@@ -291,7 +308,20 @@ test('choose_menu option 7 absensi komentar tiktok', async () => {
   expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'laporan komentar');
 });
 
-test('choose_menu option 5 absensi likes uses ditbinmas data for all users', async () => {
+test('choose_menu option 8 absensi komentar ditbinmas simple', async () => {
+  mockAbsensiKomentarDitbinmasSimple.mockResolvedValue('komentar simple');
+
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '445';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '8', waClient);
+
+  expect(mockAbsensiKomentarDitbinmasSimple).toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(chatId, 'komentar simple');
+});
+
+test('choose_menu option 6 absensi likes uses ditbinmas data for all users', async () => {
   mockAbsensiLikes.mockResolvedValue('laporan');
   mockFindClientById.mockResolvedValue({ client_type: 'org', nama: 'POLRES A' });
 
@@ -304,7 +334,7 @@ test('choose_menu option 5 absensi likes uses ditbinmas data for all users', asy
   const chatId = '999';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '6', waClient);
 
   expect(mockAbsensiLikes).toHaveBeenCalledWith('DITBINMAS', {
     mode: 'all',
@@ -312,7 +342,7 @@ test('choose_menu option 5 absensi likes uses ditbinmas data for all users', asy
   });
 });
 
-test('choose_menu option 5 skips ketika client bukan ditbinmas', async () => {
+test('choose_menu option 6 skips ketika client bukan ditbinmas', async () => {
   mockAbsensiLikes.mockResolvedValue('laporan');
 
   const session = {
@@ -323,7 +353,7 @@ test('choose_menu option 5 skips ketika client bukan ditbinmas', async () => {
   const chatId = '555';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '5', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '6', waClient);
 
   expect(mockAbsensiLikes).not.toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(
@@ -333,7 +363,7 @@ test('choose_menu option 5 skips ketika client bukan ditbinmas', async () => {
 });
 
 
-test('choose_menu option 8 fetch insta returns rekap likes report', async () => {
+test('choose_menu option 10 fetch insta returns rekap likes report', async () => {
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();
   mockRekapLikesIG.mockResolvedValue('laporan likes');
@@ -348,7 +378,7 @@ test('choose_menu option 8 fetch insta returns rekap likes report', async () => 
   const chatId = '777';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '8', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '10', waClient);
 
   expect(mockFetchAndStoreInstaContent).toHaveBeenCalledWith(
     ['shortcode', 'caption', 'like_count', 'timestamp'],
@@ -366,7 +396,7 @@ test('choose_menu option 8 fetch insta returns rekap likes report', async () => 
   );
 });
 
-test('choose_menu option 10 fetch tiktok returns komentar report', async () => {
+test('choose_menu option 12 fetch tiktok returns komentar report', async () => {
   mockFetchAndStoreTiktokContent.mockResolvedValue();
   mockHandleFetchKomentarTiktokBatch.mockResolvedValue();
   mockAbsensiKomentarDitbinmasReport.mockResolvedValue('laporan tiktok');
@@ -382,7 +412,7 @@ test('choose_menu option 10 fetch tiktok returns komentar report', async () => {
   const chatId = '888';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '10', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '12', waClient);
 
   expect(mockFetchAndStoreTiktokContent).toHaveBeenCalledWith(
     'DITBINMAS',
@@ -403,7 +433,7 @@ test('choose_menu option 10 fetch tiktok returns komentar report', async () => {
   );
 });
 
-test('choose_menu option 12 fetch sosial media sends combined task', async () => {
+test('choose_menu option 14 fetch sosial media sends combined task', async () => {
   mockFetchAndStoreInstaContent.mockResolvedValue();
   mockHandleFetchLikesInstagram.mockResolvedValue();
   mockFetchAndStoreTiktokContent.mockResolvedValue();
@@ -425,7 +455,7 @@ test('choose_menu option 12 fetch sosial media sends combined task', async () =>
   const chatId = '1001';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '12', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '14', waClient);
 
   expect(mockFetchAndStoreInstaContent).toHaveBeenCalledWith(
     ['shortcode', 'caption', 'like_count', 'timestamp'],
@@ -452,7 +482,7 @@ test('choose_menu option 12 fetch sosial media sends combined task', async () =>
   );
 });
 
-test('choose_menu option 13 sends laphar file, narrative, and likes recap excel', async () => {
+test('choose_menu option 15 sends laphar file, narrative, and likes recap excel', async () => {
   mockLapharDitbinmas.mockResolvedValue({
     text: 'lap',
     filename: 'lap.txt',
@@ -468,7 +498,7 @@ test('choose_menu option 13 sends laphar file, narrative, and likes recap excel'
   const chatId = '999';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '13', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '15', waClient);
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
   expect(mockCollectLikesRecap).toHaveBeenCalledWith('ditbinmas');
@@ -517,7 +547,7 @@ test('choose_menu option 13 sends laphar file, narrative, and likes recap excel'
   );
 });
 
-test('choose_menu option 14 sends tiktok laphar file narrative and recap excel', async () => {
+test('choose_menu option 16 sends tiktok laphar file narrative and recap excel', async () => {
   mockLapharTiktokDitbinmas.mockResolvedValue({
     text: 'lap',
     filename: 'lap.txt',
@@ -535,7 +565,7 @@ test('choose_menu option 14 sends tiktok laphar file narrative and recap excel',
   const chatId = '555';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '14', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
 
   expect(mockLapharTiktokDitbinmas).toHaveBeenCalled();
   expect(mockCollectKomentarRecap).toHaveBeenCalledWith('ditbinmas');
@@ -584,7 +614,7 @@ test('choose_menu option 14 sends tiktok laphar file narrative and recap excel',
   expect(waClient.sendMessage.mock.calls[0][1]).toBe('narasi');
 });
 
-test('choose_menu option 15 generates likes recap excel and sends file', async () => {
+test('choose_menu option 17 generates likes recap excel and sends file', async () => {
   mockCollectLikesRecap.mockResolvedValue({
     shortcodes: ['sc1'],
     recap: { POLRES_A: [{ pangkat: 'AKP', nama: 'Budi', satfung: 'SAT A', sc1: 1 }] },
@@ -595,7 +625,7 @@ test('choose_menu option 15 generates likes recap excel and sends file', async (
   const chatId = '777';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '15', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '17', waClient);
 
   expect(mockCollectLikesRecap).toHaveBeenCalledWith('ditbinmas');
   expect(mockSaveLikesRecapExcel).toHaveBeenCalledWith({
@@ -617,14 +647,14 @@ test('choose_menu option 15 generates likes recap excel and sends file', async (
   );
 });
 
-test('choose_menu option 17 generates weekly likes recap excel and sends file', async () => {
+test('choose_menu option 19 generates weekly likes recap excel and sends file', async () => {
   mockSaveWeeklyLikesRecapExcel.mockResolvedValue('/tmp/weekly.xlsx');
   mockReadFile.mockResolvedValue(Buffer.from('excel'));
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '789';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '17', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '19', waClient);
 
   expect(mockSaveWeeklyLikesRecapExcel).toHaveBeenCalledWith('ditbinmas');
   expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly.xlsx');
@@ -642,13 +672,13 @@ test('choose_menu option 17 generates weekly likes recap excel and sends file', 
   );
 });
 
-test('choose_menu option 17 sends no data message when service returns null', async () => {
+test('choose_menu option 19 sends no data message when service returns null', async () => {
   mockSaveWeeklyLikesRecapExcel.mockResolvedValue(null);
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '791';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '17', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '19', waClient);
 
   expect(mockReadFile).not.toHaveBeenCalled();
   expect(mockSendWAFile).not.toHaveBeenCalled();
@@ -659,14 +689,14 @@ test('choose_menu option 17 sends no data message when service returns null', as
   );
 });
 
-test('choose_menu option 18 generates weekly tiktok recap excel and sends file', async () => {
+test('choose_menu option 20 generates weekly tiktok recap excel and sends file', async () => {
   mockSaveWeeklyCommentRecapExcel.mockResolvedValue('/tmp/weekly-tt.xlsx');
   mockReadFile.mockResolvedValue(Buffer.from('excel'));
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '790';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '18', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '20', waClient);
 
   expect(mockSaveWeeklyCommentRecapExcel).toHaveBeenCalledWith('ditbinmas');
   expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly-tt.xlsx');
@@ -684,7 +714,7 @@ test('choose_menu option 18 generates weekly tiktok recap excel and sends file',
   );
 });
 
-test('choose_menu option 16 sends combined sosmed recap and files', async () => {
+test('choose_menu option 18 sends combined sosmed recap and files', async () => {
   mockLapharDitbinmas.mockResolvedValue({
     text: 'ig',
     filename: 'ig.txt',
@@ -708,7 +738,7 @@ test('choose_menu option 16 sends combined sosmed recap and files', async () => 
   const chatId = '888';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '16', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '18', waClient);
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
   expect(mockLapharTiktokDitbinmas).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add simple recap menus for Ditbinmas likes and TikTok comments
- renumber DirRequest menu options and update handlers
- cover new menu paths in tests

## Testing
- `npm run lint`
- `npm test` *(fails: Jest worker encountered 4 child process exceptions, exceeding retry limit)*

------
https://chatgpt.com/codex/tasks/task_e_68c82520fcc48327950478a9a1b30c0d