### PR TITLE
Refactor TikTok comment fetching to run in parallel

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -386,11 +386,12 @@ export async function absensiKomentarDitbinmasSimple() {
     (p) => `https://www.tiktok.com/@${mainUsername}/video/${p.video_id}`
   );
 
-  const commentSets = [];
-  for (const p of posts) {
-    const { comments } = await getCommentsByVideoId(p.video_id);
-    commentSets.push(new Set(extractUsernamesFromComments(comments)));
-  }
+  const commentSets = await Promise.all(
+    posts.map(async (p) => {
+      const { comments } = await getCommentsByVideoId(p.video_id);
+      return new Set(extractUsernamesFromComments(comments));
+    })
+  );
 
   const allUsersRaw = await getUsersByDirektorat(roleName, "DITBINMAS");
   const allUsers = allUsersRaw.filter(
@@ -444,11 +445,12 @@ export async function absensiKomentarDitbinmasReport() {
     (p) => `https://www.tiktok.com/@${mainUsername}/video/${p.video_id}`
   );
 
-  const commentSets = [];
-  for (const p of posts) {
-    const { comments } = await getCommentsByVideoId(p.video_id);
-    commentSets.push(new Set(extractUsernamesFromComments(comments)));
-  }
+  const commentSets = await Promise.all(
+    posts.map(async (p) => {
+      const { comments } = await getCommentsByVideoId(p.video_id);
+      return new Set(extractUsernamesFromComments(comments));
+    })
+  );
 
   const allUsersRaw = await getUsersByDirektorat(roleName, "DITBINMAS");
   const allUsers = allUsersRaw.filter(


### PR DESCRIPTION
## Summary
- fetch TikTok comment sets for Ditbinmas simple/report absensi in parallel with Promise.all
- continue returning Sets so existing membership checks remain unchanged

## Testing
- npm run lint
- npm test *(fails: `tests/cronDirRequestFetchSosmed.test.js` exits via envalid cleanEnv due to missing env config)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a29717c883278545f81d8f848821