### PR TITLE
Report TikTok users without usernames in Ditbinmas simple recap

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -472,10 +472,16 @@ export async function absensiKomentarDitbinmasSimple() {
     (u) => u.status === true && (u.client_id || "").toUpperCase() === "DITBINMAS"
   );
 
-  const totals = { total: allUsers.length, lengkap: 0, kurang: 0, belum: 0 };
+  const totals = {
+    total: allUsers.length,
+    lengkap: 0,
+    kurang: 0,
+    belum: 0,
+    tanpaUsername: 0,
+  };
   allUsers.forEach((u) => {
     if (!u.tiktok || u.tiktok.trim() === "") {
-      totals.belum++;
+      totals.tanpaUsername++;
       return;
     }
     const uname = normalizeUsername(u.tiktok);
@@ -498,7 +504,8 @@ export async function absensiKomentarDitbinmasSimple() {
     `*Jumlah Total Personil:* ${totals.total} pers\n` +
     `✅ *Melaksanakan Lengkap :* ${totals.lengkap} pers\n` +
     `⚠️ *Melaksanakan Kurang :* ${totals.kurang} pers\n` +
-    `❌ *Belum :* ${totals.belum} pers`;
+    `❌ *Belum :* ${totals.belum} pers\n` +
+    `⚠️❌ *Belum Input Username TikTok :* ${totals.tanpaUsername} pers`;
 
   if (failedVideoIds.length) {
     msg += `\n\n⚠️ Data komentar gagal diambil untuk konten: ${failedVideoIds.join(", ")}`;


### PR DESCRIPTION
## Summary
- track the number of Ditbinmas personnel without TikTok usernames in the simple recap
- include the missing-username count in the generated message

## Testing
- npm run lint
- JWT_SECRET=dummy npm test -- --runInBand *(fails: Redis client attempts to connect to localhost and exits after repeated ECONNREFUSED/timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a5a22304832780c503377314414b