### PR TITLE
Add monthly recap menus and Excel services

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -22,6 +22,8 @@ import { saveLikesRecapExcel } from "../../service/likesRecapExcelService.js";
 import { saveCommentRecapExcel } from "../../service/commentRecapExcelService.js";
 import { saveWeeklyLikesRecapExcel } from "../../service/weeklyLikesRecapExcelService.js";
 import { saveWeeklyCommentRecapExcel } from "../../service/weeklyCommentRecapExcelService.js";
+import { saveMonthlyLikesRecapExcel } from "../../service/monthlyLikesRecapExcelService.js";
+import { saveMonthlyCommentRecapExcel } from "../../service/monthlyCommentRecapExcelService.js";
 import { hariIndo } from "../../utils/constants.js";
 
 const dirRequestGroup = "120363419830216549@g.us";
@@ -750,6 +752,56 @@ async function performAction(action, clientId, waClient, chatId, roleFlag, userC
         msg = "✅ File Excel dikirim.";
         break;
       }
+      case "21": {
+        let filePath;
+        try {
+          filePath = await saveMonthlyLikesRecapExcel(clientId);
+          if (!filePath) {
+            msg = "Tidak ada data.";
+            break;
+          }
+          const buffer = await readFile(filePath);
+          await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          msg = "✅ File Excel dikirim.";
+        } catch (error) {
+          console.error("Gagal mengirim file Excel:", error);
+          msg = "❌ Gagal mengirim file Excel.";
+        } finally {
+          if (filePath) {
+            try {
+              await unlink(filePath);
+            } catch (err) {
+              console.error("Gagal menghapus file sementara:", err);
+            }
+          }
+        }
+        break;
+      }
+      case "22": {
+        let filePath;
+        try {
+          filePath = await saveMonthlyCommentRecapExcel(clientId);
+          if (!filePath) {
+            msg = "Tidak ada data.";
+            break;
+          }
+          const buffer = await readFile(filePath);
+          await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          msg = "✅ File Excel dikirim.";
+        } catch (error) {
+          console.error("Gagal mengirim file Excel:", error);
+          msg = "❌ Gagal mengirim file Excel.";
+        } finally {
+          if (filePath) {
+            try {
+              await unlink(filePath);
+            } catch (err) {
+              console.error("Gagal menghapus file sementara:", err);
+            }
+          }
+        }
+        break;
+      }
       default:
         msg = "Menu tidak dikenal.";
     }
@@ -869,6 +921,9 @@ export const dirRequestHandlers = {
         "📆 *Laporan Mingguan*\n" +
         "1️⃣9️⃣ Rekap file Instagram mingguan\n" +
         "2️⃣0️⃣ Rekap file Tiktok mingguan\n\n" +
+        "🗓️ *Laporan Bulanan*\n" +
+        "2️⃣1️⃣ Rekap file Instagram bulanan\n" +
+        "2️⃣2️⃣ Rekap file Tiktok bulanan\n\n" +
         "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -915,6 +970,8 @@ export const dirRequestHandlers = {
           "18",
           "19",
           "20",
+          "21",
+          "22",
         ].includes(choice)
     ) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");

--- a/src/service/monthlyCommentRecapExcelService.js
+++ b/src/service/monthlyCommentRecapExcelService.js
@@ -1,0 +1,190 @@
+import { mkdir } from 'fs/promises';
+import path from 'path';
+import XLSX from 'xlsx';
+import { hariIndo } from '../utils/constants.js';
+import { getRekapKomentarByClient } from '../model/tiktokCommentModel.js';
+import { countPostsByClient } from '../model/tiktokPostModel.js';
+
+const RANK_ORDER = [
+  'KOMISARIS BESAR POLISI',
+  'AKBP',
+  'KOMPOL',
+  'AKP',
+  'IPTU',
+  'IPDA',
+  'AIPTU',
+  'AIPDA',
+  'BRIPKA',
+  'BRIGPOL',
+  'BRIGADIR',
+  'BRIGADIR POLISI',
+  'BRIPTU',
+  'BRIPDA',
+];
+
+function rankWeight(rank) {
+  const idx = RANK_ORDER.indexOf(String(rank || '').toUpperCase());
+  return idx === -1 ? RANK_ORDER.length : idx;
+}
+
+export async function saveMonthlyCommentRecapExcel(clientId) {
+  const now = new Date();
+  const startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+  const endDate = new Date(now);
+
+  const formatIso = (d) => d.toISOString().slice(0, 10);
+  const formatDisplay = (d) =>
+    new Date(d).toLocaleDateString('id-ID', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+
+  const dateList = [];
+  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+    dateList.push(formatIso(d));
+  }
+
+  const grouped = {};
+  const dailyPosts = {};
+
+  for (const dateStr of dateList) {
+    const [rows, totalPosts] = await Promise.all([
+      getRekapKomentarByClient(clientId, 'harian', dateStr, undefined, undefined, 'ditbinmas'),
+      countPostsByClient(clientId, 'harian', dateStr),
+    ]);
+    dailyPosts[dateStr] = totalPosts;
+    for (const u of rows) {
+      const satker = u.client_name || '';
+      if (!grouped[satker]) grouped[satker] = {};
+      const key = `${u.title || ''}|${u.nama || ''}`;
+      if (!grouped[satker][key]) {
+        grouped[satker][key] = {
+          pangkat: u.title || '',
+          nama: u.nama || '',
+          satfung: u.divisi || '',
+          perDate: {},
+          totalKomentar: 0,
+        };
+      }
+      grouped[satker][key].perDate[dateStr] = {
+        komentar: u.jumlah_komentar || 0,
+      };
+      grouped[satker][key].totalKomentar += u.jumlah_komentar || 0;
+    }
+  }
+
+  if (Object.keys(grouped).length === 0) {
+    return null;
+  }
+
+  const wb = XLSX.utils.book_new();
+  Object.entries(grouped).forEach(([satker, usersMap]) => {
+    const users = Object.values(usersMap);
+    users.sort((a, b) => {
+      if (b.totalKomentar !== a.totalKomentar)
+        return b.totalKomentar - a.totalKomentar;
+      const rankA = rankWeight(a.pangkat);
+      const rankB = rankWeight(b.pangkat);
+      if (rankA !== rankB) return rankA - rankB;
+      return a.nama.localeCompare(b.nama);
+    });
+
+    const aoa = [];
+    const colCount = 4 + dateList.length * 3;
+    const title = `${satker} – Rekap Engagement Tiktok`;
+    const periodStr = `${formatDisplay(startDate)} - ${formatDisplay(endDate)}`;
+    const subtitle = `Rekap Komentar Tiktok Periode ${periodStr}`;
+    aoa.push([title]);
+    aoa.push([subtitle]);
+
+    const headerDates = ['No', 'Pangkat', 'Nama', 'Divisi / Satfung'];
+    const subHeader = ['', '', '', ''];
+    dateList.forEach((d) => {
+      const disp = formatDisplay(d);
+      headerDates.push(disp, '', '');
+      subHeader.push('Jumlah Post', 'Sudah Komentar', 'Belum Komentar');
+    });
+    aoa.push(headerDates);
+    aoa.push(subHeader);
+
+    users.forEach((u, idx) => {
+      const row = [idx + 1, u.pangkat || '', u.nama || '', u.satfung || ''];
+      dateList.forEach((d) => {
+        const komentar = u.perDate[d]?.komentar || 0;
+        const posts = dailyPosts[d] || 0;
+        row.push(posts, komentar, Math.max(posts - komentar, 0));
+      });
+      aoa.push(row);
+    });
+
+    const summaryRow = ['TOTAL', '', '', ''];
+    const startRow = 5;
+    const endRow = 4 + users.length;
+    dateList.forEach((_, i) => {
+      const postsCol = XLSX.utils.encode_col(4 + i * 3);
+      const sudahCol = XLSX.utils.encode_col(4 + i * 3 + 1);
+      const belumCol = XLSX.utils.encode_col(4 + i * 3 + 2);
+      summaryRow.push(
+        { f: `SUM(${postsCol}${startRow}:${postsCol}${endRow})` },
+        { f: `SUM(${sudahCol}${startRow}:${sudahCol}${endRow})` },
+        { f: `SUM(${belumCol}${startRow}:${belumCol}${endRow})` }
+      );
+    });
+    aoa.push(summaryRow);
+
+    const ws = XLSX.utils.aoa_to_sheet(aoa);
+
+    const merges = [
+      { s: { r: 0, c: 0 }, e: { r: 0, c: colCount - 1 } },
+      { s: { r: 1, c: 0 }, e: { r: 1, c: colCount - 1 } },
+    ];
+    dateList.forEach((_, i) => {
+      merges.push({
+        s: { r: 2, c: 4 + i * 3 },
+        e: { r: 2, c: 4 + i * 3 + 2 },
+      });
+    });
+    ws['!merges'] = merges;
+
+    ws['!freeze'] = { xSplit: 4, ySplit: 4 };
+
+    const lastDataRow = 4 + users.length;
+    ws['!autofilter'] = {
+      ref: XLSX.utils.encode_range({ r: 3, c: 0 }, { r: lastDataRow - 1, c: colCount - 1 }),
+    };
+
+    const green = { patternType: 'solid', fgColor: { rgb: 'C6EFCE' } };
+    const red = { patternType: 'solid', fgColor: { rgb: 'F8CBAD' } };
+    for (let r = 4; r <= lastDataRow; r++) {
+      dateList.forEach((_, i) => {
+        const sudahCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 1 });
+        const belumCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 2 });
+        if (ws[sudahCell]) ws[sudahCell].s = { fill: green };
+        if (ws[belumCell]) ws[belumCell].s = { fill: red };
+      });
+    }
+
+    XLSX.utils.book_append_sheet(wb, ws, satker);
+  });
+
+  const exportDir = path.resolve('export_data/monthly_comment');
+  await mkdir(exportDir, { recursive: true });
+
+  const hari = hariIndo[endDate.getDay()];
+  const tanggal = endDate.toLocaleDateString('id-ID');
+  const jam = now.toLocaleTimeString('id-ID', { hour12: false });
+  const dateSafe = tanggal.replace(/\//g, '-');
+  const timeSafe = jam.replace(/[:.]/g, '-');
+  const formattedClient = (clientId || '')
+    .toLowerCase()
+    .replace(/^./, (c) => c.toUpperCase());
+  const filePath = path.join(
+    exportDir,
+    `Rekap_Bulanan_Tiktok_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+  );
+  XLSX.writeFile(wb, filePath, { cellStyles: true });
+  return filePath;
+}
+
+export default saveMonthlyCommentRecapExcel;

--- a/src/service/monthlyLikesRecapExcelService.js
+++ b/src/service/monthlyLikesRecapExcelService.js
@@ -1,0 +1,202 @@
+import { mkdir } from 'fs/promises';
+import path from 'path';
+import XLSX from 'xlsx';
+import { hariIndo } from '../utils/constants.js';
+import { getRekapLikesByClient } from '../model/instaLikeModel.js';
+
+const RANK_ORDER = [
+  'KOMISARIS BESAR POLISI',
+  'AKBP',
+  'KOMPOL',
+  'AKP',
+  'IPTU',
+  'IPDA',
+  'AIPTU',
+  'AIPDA',
+  'BRIPKA',
+  'BRIGPOL',
+  'BRIGADIR',
+  'BRIGADIR POLISI',
+  'BRIPTU',
+  'BRIPDA',
+];
+
+function rankWeight(rank) {
+  const idx = RANK_ORDER.indexOf(String(rank || '').toUpperCase());
+  return idx === -1 ? RANK_ORDER.length : idx;
+}
+
+export async function saveMonthlyLikesRecapExcel(clientId) {
+  const now = new Date();
+  const startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+  const endDate = new Date(now);
+
+  const formatIso = (d) => d.toISOString().slice(0, 10);
+  const formatDisplay = (d) =>
+    new Date(d).toLocaleDateString('id-ID', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+
+  const dateList = [];
+  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+    dateList.push(formatIso(d));
+  }
+
+  const grouped = {};
+  const dailyPosts = {};
+
+  const results = await Promise.all(
+    dateList.map(async (dateStr) => {
+      const { rows, totalKonten } = await getRekapLikesByClient(
+        clientId,
+        'harian',
+        dateStr,
+        undefined,
+        undefined,
+        'ditbinmas'
+      );
+      return { dateStr, rows, totalKonten };
+    })
+  );
+
+  const resultMap = results.reduce((acc, { dateStr, rows, totalKonten }) => {
+    acc[dateStr] = { rows, totalKonten };
+    return acc;
+  }, {});
+
+  dateList.forEach((dateStr) => {
+    const { rows = [], totalKonten = 0 } = resultMap[dateStr] || {};
+    dailyPosts[dateStr] = totalKonten;
+    for (const u of rows) {
+      const satker = u.client_name || '';
+      if (!grouped[satker]) grouped[satker] = {};
+      const key = `${u.title || ''}|${u.nama || ''}`;
+      if (!grouped[satker][key]) {
+        grouped[satker][key] = {
+          pangkat: u.title || '',
+          nama: u.nama || '',
+          satfung: u.divisi || '',
+          perDate: {},
+          totalLikes: 0,
+        };
+      }
+      grouped[satker][key].perDate[dateStr] = { likes: u.jumlah_like || 0 };
+      grouped[satker][key].totalLikes += u.jumlah_like || 0;
+    }
+  });
+
+  if (Object.keys(grouped).length === 0) {
+    return null;
+  }
+
+  const wb = XLSX.utils.book_new();
+  Object.entries(grouped).forEach(([satker, usersMap]) => {
+    const users = Object.values(usersMap);
+    users.sort((a, b) => {
+      if (b.totalLikes !== a.totalLikes) return b.totalLikes - a.totalLikes;
+      const rankA = rankWeight(a.pangkat);
+      const rankB = rankWeight(b.pangkat);
+      if (rankA !== rankB) return rankA - rankB;
+      return a.nama.localeCompare(b.nama);
+    });
+
+    const aoa = [];
+    const colCount = 4 + dateList.length * 3;
+    const title = `${satker} – Rekap Engagement Instagram`;
+    const periodStr = `${formatDisplay(startDate)} - ${formatDisplay(endDate)}`;
+    const subtitle = `Rekap Likes Instagram Periode ${periodStr}`;
+    aoa.push([title]);
+    aoa.push([subtitle]);
+
+    const headerDates = ['No', 'Pangkat', 'Nama', 'Divisi / Satfung'];
+    const subHeader = ['', '', '', ''];
+    dateList.forEach((d) => {
+      const disp = formatDisplay(d);
+      headerDates.push(disp, '', '');
+      subHeader.push('Jumlah Post', 'Sudah Likes', 'Belum Likes');
+    });
+    aoa.push(headerDates);
+    aoa.push(subHeader);
+
+    users.forEach((u, idx) => {
+      const row = [idx + 1, u.pangkat || '', u.nama || '', u.satfung || ''];
+      dateList.forEach((d) => {
+        const likes = u.perDate[d]?.likes || 0;
+        const posts = dailyPosts[d] || 0;
+        row.push(posts, likes, Math.max(posts - likes, 0));
+      });
+      aoa.push(row);
+    });
+
+    const summaryRow = ['TOTAL', '', '', ''];
+    const startRow = 5;
+    const endRow = 4 + users.length;
+    dateList.forEach((_, i) => {
+      const postsCol = XLSX.utils.encode_col(4 + i * 3);
+      const sudahCol = XLSX.utils.encode_col(4 + i * 3 + 1);
+      const belumCol = XLSX.utils.encode_col(4 + i * 3 + 2);
+      summaryRow.push(
+        { f: `SUM(${postsCol}${startRow}:${postsCol}${endRow})` },
+        { f: `SUM(${sudahCol}${startRow}:${sudahCol}${endRow})` },
+        { f: `SUM(${belumCol}${startRow}:${belumCol}${endRow})` }
+      );
+    });
+    aoa.push(summaryRow);
+
+    const ws = XLSX.utils.aoa_to_sheet(aoa);
+
+    const merges = [
+      { s: { r: 0, c: 0 }, e: { r: 0, c: colCount - 1 } },
+      { s: { r: 1, c: 0 }, e: { r: 1, c: colCount - 1 } },
+    ];
+    dateList.forEach((_, i) => {
+      merges.push({
+        s: { r: 2, c: 4 + i * 3 },
+        e: { r: 2, c: 4 + i * 3 + 2 },
+      });
+    });
+    ws['!merges'] = merges;
+
+    ws['!freeze'] = { xSplit: 4, ySplit: 4 };
+
+    const lastDataRow = 4 + users.length;
+    ws['!autofilter'] = {
+      ref: XLSX.utils.encode_range({ r: 3, c: 0 }, { r: lastDataRow - 1, c: colCount - 1 }),
+    };
+
+    const green = { patternType: 'solid', fgColor: { rgb: 'C6EFCE' } };
+    const red = { patternType: 'solid', fgColor: { rgb: 'F8CBAD' } };
+    for (let r = 4; r <= lastDataRow; r++) {
+      dateList.forEach((_, i) => {
+        const sudahCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 1 });
+        const belumCell = XLSX.utils.encode_cell({ r, c: 4 + i * 3 + 2 });
+        if (ws[sudahCell]) ws[sudahCell].s = { fill: green };
+        if (ws[belumCell]) ws[belumCell].s = { fill: red };
+      });
+    }
+
+    XLSX.utils.book_append_sheet(wb, ws, satker);
+  });
+
+  const exportDir = path.resolve('export_data/monthly_likes');
+  await mkdir(exportDir, { recursive: true });
+
+  const hari = hariIndo[endDate.getDay()];
+  const tanggal = endDate.toLocaleDateString('id-ID');
+  const jam = now.toLocaleTimeString('id-ID', { hour12: false });
+  const dateSafe = tanggal.replace(/\//g, '-');
+  const timeSafe = jam.replace(/[:.]/g, '-');
+  const formattedClient = (clientId || '')
+    .toLowerCase()
+    .replace(/^./, (c) => c.toUpperCase());
+  const filePath = path.join(
+    exportDir,
+    `Rekap_Bulanan_Instagram_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+  );
+  XLSX.writeFile(wb, filePath, { cellStyles: true });
+  return filePath;
+}
+
+export default saveMonthlyLikesRecapExcel;

--- a/tests/cronDirRequestFetchSosmed.test.js
+++ b/tests/cronDirRequestFetchSosmed.test.js
@@ -6,6 +6,8 @@ const mockFetchTiktok = jest.fn();
 const mockGenerateMsg = jest.fn();
 const mockSafeSend = jest.fn();
 const mockSendDebug = jest.fn();
+const mockGetInstaPostCount = jest.fn();
+const mockGetTiktokPostCount = jest.fn();
 
 jest.unstable_mockModule('../src/service/waService.js', () => ({ waGatewayClient: {} }));
 jest.unstable_mockModule('../src/handler/fetchpost/instaFetchPost.js', () => ({
@@ -27,13 +29,20 @@ jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
 jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
   sendDebug: mockSendDebug,
 }));
+jest.unstable_mockModule('../src/service/postCountService.js', () => ({
+  getInstaPostCount: mockGetInstaPostCount,
+  getTiktokPostCount: mockGetTiktokPostCount,
+}));
 
 let runCron;
 
 beforeEach(async () => {
   jest.resetModules();
   jest.clearAllMocks();
+  process.env.JWT_SECRET = 'test-secret';
   mockGenerateMsg.mockResolvedValue({ text: 'msg', igCount: 1, tiktokCount: 1 });
+  mockGetInstaPostCount.mockResolvedValue(0);
+  mockGetTiktokPostCount.mockResolvedValue(0);
   ({ runCron } = await import('../src/cron/cronDirRequestFetchSosmed.js'));
 });
 

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -20,9 +20,11 @@ const mockLapharTiktokDitbinmas = jest.fn();
 const mockCollectLikesRecap = jest.fn();
 const mockSaveLikesRecapExcel = jest.fn();
 const mockSaveWeeklyLikesRecapExcel = jest.fn();
+const mockSaveMonthlyLikesRecapExcel = jest.fn();
 const mockCollectKomentarRecap = jest.fn();
 const mockSaveCommentRecapExcel = jest.fn();
 const mockSaveWeeklyCommentRecapExcel = jest.fn();
+const mockSaveMonthlyCommentRecapExcel = jest.fn();
 const mockWriteFile = jest.fn();
 const mockMkdir = jest.fn();
 const mockReadFile = jest.fn();
@@ -89,12 +91,18 @@ jest.unstable_mockModule('../src/service/commentRecapExcelService.js', () => ({
 jest.unstable_mockModule('../src/service/weeklyLikesRecapExcelService.js', () => ({
   saveWeeklyLikesRecapExcel: mockSaveWeeklyLikesRecapExcel,
 }));
+jest.unstable_mockModule('../src/service/monthlyLikesRecapExcelService.js', () => ({
+  saveMonthlyLikesRecapExcel: mockSaveMonthlyLikesRecapExcel,
+}));
 jest.unstable_mockModule(
   '../src/service/weeklyCommentRecapExcelService.js',
   () => ({
     saveWeeklyCommentRecapExcel: mockSaveWeeklyCommentRecapExcel,
   })
 );
+jest.unstable_mockModule('../src/service/monthlyCommentRecapExcelService.js', () => ({
+  saveMonthlyCommentRecapExcel: mockSaveMonthlyCommentRecapExcel,
+}));
 jest.unstable_mockModule('../src/utils/utilsHelper.js', () => ({
   getGreeting: () => 'Selamat malam',
   sortDivisionKeys: (arr) => arr.sort(),
@@ -711,6 +719,90 @@ test('choose_menu option 20 generates weekly tiktok recap excel and sends file',
   expect(waClient.sendMessage).toHaveBeenCalledWith(
     chatId,
     expect.stringContaining('File Excel dikirim')
+  );
+});
+
+test('choose_menu option 21 generates monthly likes recap excel and sends file', async () => {
+  mockSaveMonthlyLikesRecapExcel.mockResolvedValue('/tmp/monthly.xlsx');
+  mockReadFile.mockResolvedValue(Buffer.from('excel'));
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '991';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
+
+  expect(mockSaveMonthlyLikesRecapExcel).toHaveBeenCalledWith('ditbinmas');
+  expect(mockReadFile).toHaveBeenCalledWith('/tmp/monthly.xlsx');
+  expect(mockSendWAFile).toHaveBeenCalledWith(
+    waClient,
+    expect.any(Buffer),
+    path.basename('/tmp/monthly.xlsx'),
+    chatId,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  expect(mockUnlink).toHaveBeenCalledWith('/tmp/monthly.xlsx');
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('File Excel dikirim')
+  );
+});
+
+test('choose_menu option 21 reports no data when service returns null', async () => {
+  mockSaveMonthlyLikesRecapExcel.mockResolvedValue(null);
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '992';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
+
+  expect(mockReadFile).not.toHaveBeenCalled();
+  expect(mockSendWAFile).not.toHaveBeenCalled();
+  expect(mockUnlink).not.toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringMatching(/tidak ada data/i)
+  );
+});
+
+test('choose_menu option 22 generates monthly tiktok recap excel and sends file', async () => {
+  mockSaveMonthlyCommentRecapExcel.mockResolvedValue('/tmp/monthly-tt.xlsx');
+  mockReadFile.mockResolvedValue(Buffer.from('excel'));
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '993';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '22', waClient);
+
+  expect(mockSaveMonthlyCommentRecapExcel).toHaveBeenCalledWith('ditbinmas');
+  expect(mockReadFile).toHaveBeenCalledWith('/tmp/monthly-tt.xlsx');
+  expect(mockSendWAFile).toHaveBeenCalledWith(
+    waClient,
+    expect.any(Buffer),
+    path.basename('/tmp/monthly-tt.xlsx'),
+    chatId,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  expect(mockUnlink).toHaveBeenCalledWith('/tmp/monthly-tt.xlsx');
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('File Excel dikirim')
+  );
+});
+
+test('choose_menu option 22 reports no data when service returns null', async () => {
+  mockSaveMonthlyCommentRecapExcel.mockResolvedValue(null);
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '994';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '22', waClient);
+
+  expect(mockReadFile).not.toHaveBeenCalled();
+  expect(mockSendWAFile).not.toHaveBeenCalled();
+  expect(mockUnlink).not.toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringMatching(/tidak ada data/i)
   );
 });
 

--- a/tests/monthlyCommentRecapExcelService.test.js
+++ b/tests/monthlyCommentRecapExcelService.test.js
@@ -1,0 +1,77 @@
+import { jest } from '@jest/globals';
+import { unlink } from 'fs/promises';
+import XLSX from 'xlsx';
+
+process.env.TZ = 'Asia/Jakarta';
+
+const mockGetRekapKomentarByClient = jest.fn();
+const mockCountPostsByClient = jest.fn();
+
+jest.unstable_mockModule('../src/model/tiktokCommentModel.js', () => ({
+  getRekapKomentarByClient: mockGetRekapKomentarByClient,
+}));
+
+jest.unstable_mockModule('../src/model/tiktokPostModel.js', () => ({
+  countPostsByClient: mockCountPostsByClient,
+}));
+
+const { saveMonthlyCommentRecapExcel } = await import(
+  '../src/service/monthlyCommentRecapExcelService.js'
+);
+
+test('saveMonthlyCommentRecapExcel creates formatted monthly recap', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-15T00:00:00Z'));
+
+  mockGetRekapKomentarByClient.mockReset();
+  mockCountPostsByClient.mockReset();
+  mockGetRekapKomentarByClient.mockImplementation(async () => [
+    {
+      client_name: 'POLRES A',
+      title: 'AKP',
+      nama: 'Budi',
+      divisi: 'Sat A',
+      jumlah_komentar: 2,
+    },
+  ]);
+  mockCountPostsByClient.mockResolvedValue(3);
+
+  const filePath = await saveMonthlyCommentRecapExcel('DITBINMAS');
+  expect(filePath).toBeTruthy();
+  const wb = XLSX.readFile(filePath);
+  const sheet = wb.Sheets['POLRES A'];
+  const aoa = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+
+  expect(aoa[0][0]).toBe('POLRES A – Rekap Engagement Tiktok');
+  expect(aoa[1][0]).toBe(
+    'Rekap Komentar Tiktok Periode 01/04/2024 - 15/04/2024'
+  );
+  expect(aoa[2].slice(0, 4)).toEqual([
+    'No',
+    'Pangkat',
+    'Nama',
+    'Divisi / Satfung',
+  ]);
+  const lastIdx = aoa[2].length - 3;
+  expect(aoa[3].slice(lastIdx, lastIdx + 3)).toEqual([
+    'Jumlah Post',
+    'Sudah Komentar',
+    'Belum Komentar',
+  ]);
+  expect(aoa[4].slice(0, 4)).toEqual([1, 'AKP', 'Budi', 'Sat A']);
+  expect(aoa[4].slice(lastIdx, lastIdx + 3)).toEqual([3, 2, 1]);
+
+  await unlink(filePath);
+  jest.useRealTimers();
+});
+
+test('saveMonthlyCommentRecapExcel returns null when no data', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-15T00:00:00Z'));
+  mockGetRekapKomentarByClient.mockReset();
+  mockCountPostsByClient.mockReset();
+  mockGetRekapKomentarByClient.mockResolvedValue([]);
+  mockCountPostsByClient.mockResolvedValue(0);
+
+  const filePath = await saveMonthlyCommentRecapExcel('DITBINMAS');
+  expect(filePath).toBeNull();
+  jest.useRealTimers();
+});

--- a/tests/monthlyLikesRecapExcelService.test.js
+++ b/tests/monthlyLikesRecapExcelService.test.js
@@ -1,0 +1,70 @@
+import { jest } from '@jest/globals';
+import { unlink } from 'fs/promises';
+import XLSX from 'xlsx';
+
+process.env.TZ = 'Asia/Jakarta';
+
+const mockGetRekapLikesByClient = jest.fn();
+
+jest.unstable_mockModule('../src/model/instaLikeModel.js', () => ({
+  getRekapLikesByClient: mockGetRekapLikesByClient,
+}));
+
+const { saveMonthlyLikesRecapExcel } = await import(
+  '../src/service/monthlyLikesRecapExcelService.js'
+);
+
+test('saveMonthlyLikesRecapExcel creates formatted monthly recap', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-15T00:00:00Z'));
+  mockGetRekapLikesByClient.mockReset();
+  mockGetRekapLikesByClient.mockImplementation(async () => ({
+    rows: [
+      {
+        client_name: 'POLRES A',
+        title: 'AKP',
+        nama: 'Budi',
+        divisi: 'Sat A',
+        jumlah_like: 2,
+      },
+    ],
+    totalKonten: 3,
+  }));
+
+  const filePath = await saveMonthlyLikesRecapExcel('DITBINMAS');
+  expect(filePath).toBeTruthy();
+  const wb = XLSX.readFile(filePath);
+  const sheet = wb.Sheets['POLRES A'];
+  const aoa = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+
+  expect(aoa[0][0]).toBe('POLRES A – Rekap Engagement Instagram');
+  expect(aoa[1][0]).toBe(
+    'Rekap Likes Instagram Periode 01/04/2024 - 15/04/2024'
+  );
+  expect(aoa[2].slice(0, 4)).toEqual([
+    'No',
+    'Pangkat',
+    'Nama',
+    'Divisi / Satfung',
+  ]);
+  const lastIdx = aoa[2].length - 3;
+  expect(aoa[3].slice(lastIdx, lastIdx + 3)).toEqual([
+    'Jumlah Post',
+    'Sudah Likes',
+    'Belum Likes',
+  ]);
+  expect(aoa[4].slice(0, 4)).toEqual([1, 'AKP', 'Budi', 'Sat A']);
+  expect(aoa[4].slice(lastIdx, lastIdx + 3)).toEqual([3, 2, 1]);
+
+  await unlink(filePath);
+  jest.useRealTimers();
+});
+
+test('saveMonthlyLikesRecapExcel returns null when no data', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-15T00:00:00Z'));
+  mockGetRekapLikesByClient.mockReset();
+  mockGetRekapLikesByClient.mockResolvedValue({ rows: [], totalKonten: 0 });
+
+  const filePath = await saveMonthlyLikesRecapExcel('DITBINMAS');
+  expect(filePath).toBeNull();
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- add Instagram and Tiktok monthly recap options to the dirrequest WhatsApp menu and hook them to new handlers
- implement monthly Excel recap generators for Instagram likes and Tiktok comments
- extend unit tests to cover the new services and menu actions while updating cron fetch tests to mock redis-dependent modules

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=8192 npm test *(terminates before completion; cronDirRequestFetchSosmed suite verified separately)*
- npm test -- cronDirRequestFetchSosmed.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8a906acc88327a674e63ab4a04522