### PR TITLE
feat: add satker update matrix recap menu

### DIFF
--- a/src/service/satkerUpdateMatrixService.js
+++ b/src/service/satkerUpdateMatrixService.js
@@ -1,0 +1,176 @@
+import { mkdir } from "fs/promises";
+import path from "path";
+import XLSX from "xlsx";
+import { getUsersSocialByClient, getClientsByRole } from "../model/userModel.js";
+import { findClientById } from "./clientService.js";
+
+const DIRECTORATE_ROLES = ["ditbinmas", "ditlantas", "bidhumas"];
+
+function sanitizeFilename(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[^\w.-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function toPercent(numerator, denominator) {
+  if (!denominator) {
+    return 0;
+  }
+  return Number(((numerator / denominator) * 100).toFixed(2));
+}
+
+export async function collectSatkerUpdateMatrix(clientId, roleFlag = null) {
+  const clientIdStr = String(clientId || "").trim();
+  if (!clientIdStr) {
+    throw new Error("Client tidak ditemukan.");
+  }
+
+  const normalizedClientId = clientIdStr.toLowerCase();
+  const client = await findClientById(normalizedClientId);
+  if (!client) {
+    throw new Error("Client tidak ditemukan.");
+  }
+
+  const filterRole = DIRECTORATE_ROLES.includes(roleFlag?.toLowerCase())
+    ? roleFlag
+    : null;
+
+  const clientType = client.client_type?.toLowerCase();
+  const isDirektoratView =
+    clientType === "direktorat" ||
+    DIRECTORATE_ROLES.includes(normalizedClientId) ||
+    (filterRole && DIRECTORATE_ROLES.includes(filterRole.toLowerCase()));
+
+  if (!isDirektoratView) {
+    throw new Error("Menu ini hanya tersedia untuk direktorat.");
+  }
+
+  const users = await getUsersSocialByClient(clientIdStr, filterRole);
+  const groups = new Map();
+  users.forEach((user) => {
+    const cid = String(user.client_id || "").toLowerCase();
+    if (!cid) return;
+    if (!groups.has(cid)) {
+      groups.set(cid, { total: 0, insta: 0, tiktok: 0 });
+    }
+    const stat = groups.get(cid);
+    stat.total += 1;
+    if (user.insta) stat.insta += 1;
+    if (user.tiktok) stat.tiktok += 1;
+  });
+
+  const roleName = (filterRole || clientIdStr).toLowerCase();
+  const clientIdsFromRole = (await getClientsByRole(roleName)) || [];
+  const allIds = new Set([
+    normalizedClientId,
+    ...clientIdsFromRole.map((id) => String(id || "").toLowerCase()).filter(Boolean),
+    ...groups.keys(),
+  ]);
+
+  const stats = await Promise.all(
+    [...allIds].map(async (cid) => {
+      const stat = groups.get(cid) || { total: 0, insta: 0, tiktok: 0 };
+      const clientInfo = await findClientById(cid);
+      const displayName = (clientInfo?.nama || cid || "-").toUpperCase();
+      const total = stat.total;
+      const instaFilled = stat.insta;
+      const tiktokFilled = stat.tiktok;
+      const instaEmpty = Math.max(total - instaFilled, 0);
+      const tiktokEmpty = Math.max(total - tiktokFilled, 0);
+      return {
+        cid,
+        name: displayName,
+        total,
+        instaFilled,
+        instaEmpty,
+        instaPercent: toPercent(instaFilled, total),
+        tiktokFilled,
+        tiktokEmpty,
+        tiktokPercent: toPercent(tiktokFilled, total),
+      };
+    })
+  );
+
+  const primary = stats.find((s) => s.cid === normalizedClientId);
+  const others = stats
+    .filter((s) => s.cid !== normalizedClientId)
+    .sort((a, b) => {
+      if (b.instaPercent !== a.instaPercent) return b.instaPercent - a.instaPercent;
+      if (b.tiktokPercent !== a.tiktokPercent) return b.tiktokPercent - a.tiktokPercent;
+      if (b.total !== a.total) return b.total - a.total;
+      return a.name.localeCompare(b.name, "id-ID", { sensitivity: "base" });
+    });
+
+  const orderedStats = primary ? [primary, ...others] : others;
+
+  const totals = orderedStats.reduce(
+    (acc, item) => {
+      acc.total += item.total;
+      acc.instaFilled += item.instaFilled;
+      acc.instaEmpty += item.instaEmpty;
+      acc.tiktokFilled += item.tiktokFilled;
+      acc.tiktokEmpty += item.tiktokEmpty;
+      return acc;
+    },
+    { total: 0, instaFilled: 0, instaEmpty: 0, tiktokFilled: 0, tiktokEmpty: 0 }
+  );
+
+  return {
+    clientName: client.nama || clientIdStr.toUpperCase(),
+    clientId: normalizedClientId,
+    stats: orderedStats,
+    totals,
+  };
+}
+
+export async function saveSatkerUpdateMatrixExcel({
+  clientId,
+  roleFlag = null,
+  username = "",
+} = {}) {
+  const { stats } = await collectSatkerUpdateMatrix(clientId, roleFlag);
+  if (!stats.length) {
+    throw new Error("Tidak ada data satker untuk direkap.");
+  }
+
+  const header = [
+    "Satker",
+    "Jumlah Personil",
+    "Sudah Update Instagram",
+    "Belum Update Instagram",
+    "Prosentase Sudah Update Instagram",
+    "Sudah Update Tiktok",
+    "Belum Update Tiktok",
+    "Prosentase Sudah Update Tiktok",
+  ];
+
+  const rows = stats.map((item) => [
+    item.name,
+    item.total,
+    item.instaFilled,
+    item.instaEmpty,
+    item.instaPercent,
+    item.tiktokFilled,
+    item.tiktokEmpty,
+    item.tiktokPercent,
+  ]);
+
+  const worksheet = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Rekap");
+
+  const exportDir = path.resolve("export_data/satker_update_matrix");
+  await mkdir(exportDir, { recursive: true });
+
+  const now = new Date();
+  const dateLabel = now.toISOString().slice(0, 10);
+  const safeUsername = sanitizeFilename(username) || "User";
+  const fileName = `Satker_${safeUsername}_Update_Rank_${dateLabel}.xlsx`;
+  const filePath = path.join(exportDir, fileName);
+
+  XLSX.writeFile(workbook, filePath);
+  return { filePath, fileName };
+}
+
+export default saveSatkerUpdateMatrixExcel;

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -676,6 +676,7 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
         role: du.role,
         client_ids: du.client_ids,
         dir_client_id: dirClientId,
+        username: du.username,
       });
       await dirRequestHandlers.main(getSession(chatId), chatId, "", waClient);
       return;

--- a/tests/satkerUpdateMatrixService.test.js
+++ b/tests/satkerUpdateMatrixService.test.js
@@ -1,0 +1,150 @@
+import { jest } from '@jest/globals';
+
+const mockGetUsersSocialByClient = jest.fn();
+const mockGetClientsByRole = jest.fn();
+const mockFindClientById = jest.fn();
+const mockAoAToSheet = jest.fn();
+const mockBookNew = jest.fn();
+const mockBookAppendSheet = jest.fn();
+const mockWriteFile = jest.fn();
+
+jest.unstable_mockModule('../src/model/userModel.js', () => ({
+  getUsersSocialByClient: mockGetUsersSocialByClient,
+  getClientsByRole: mockGetClientsByRole,
+}));
+
+jest.unstable_mockModule('../src/service/clientService.js', () => ({
+  findClientById: mockFindClientById,
+}));
+
+jest.unstable_mockModule('xlsx', () => ({
+  default: {
+    utils: {
+      aoa_to_sheet: mockAoAToSheet,
+      book_new: mockBookNew,
+      book_append_sheet: mockBookAppendSheet,
+    },
+    writeFile: mockWriteFile,
+  },
+}));
+
+describe('satkerUpdateMatrixService', () => {
+  let collectSatkerUpdateMatrix;
+  let saveSatkerUpdateMatrixExcel;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockGetUsersSocialByClient.mockReset();
+    mockGetClientsByRole.mockReset();
+    mockFindClientById.mockReset();
+    mockAoAToSheet.mockReset();
+    mockBookNew.mockReset();
+    mockBookAppendSheet.mockReset();
+    mockWriteFile.mockReset();
+
+    mockBookNew.mockReturnValue({});
+    mockAoAToSheet.mockImplementation((aoa) => ({ aoa }));
+    mockBookAppendSheet.mockImplementation(() => {});
+    mockWriteFile.mockImplementation(() => {});
+
+    mockFindClientById.mockImplementation(async (cid) => {
+      const key = String(cid || '').toLowerCase();
+      const map = {
+        ditbinmas: { nama: 'Direktorat Binmas', client_type: 'direktorat' },
+        polres_a: { nama: 'Polres A', client_type: 'org' },
+        polres_b: { nama: 'Polres B', client_type: 'org' },
+      };
+      return map[key] || { nama: key.toUpperCase(), client_type: 'org' };
+    });
+
+    ({ collectSatkerUpdateMatrix, saveSatkerUpdateMatrixExcel } = await import(
+      '../src/service/satkerUpdateMatrixService.js'
+    ));
+  });
+
+  test('collectSatkerUpdateMatrix sorts satker with directorate first and computes stats', async () => {
+    mockGetUsersSocialByClient.mockResolvedValue([
+      { client_id: 'DITBINMAS', insta: 'ig', tiktok: 'tt' },
+      { client_id: 'POLRES_A', insta: 'user1', tiktok: 'tk1' },
+      { client_id: 'POLRES_A', insta: '', tiktok: '' },
+      { client_id: 'POLRES_B', insta: 'user2', tiktok: 'tt2' },
+      { client_id: 'POLRES_B', insta: 'user3', tiktok: '' },
+    ]);
+    mockGetClientsByRole.mockResolvedValue(['polres_a', 'polres_b']);
+
+    const result = await collectSatkerUpdateMatrix('DITBINMAS', 'ditbinmas');
+
+    expect(result.stats).toHaveLength(3);
+    expect(result.stats[0].cid).toBe('ditbinmas');
+    expect(result.stats[0].instaPercent).toBe(100);
+    expect(result.stats[1].cid).toBe('polres_b');
+    expect(result.stats[1].instaPercent).toBe(100);
+    expect(result.stats[1].tiktokPercent).toBe(50);
+    expect(result.stats[2].cid).toBe('polres_a');
+    expect(result.stats[2].instaPercent).toBe(50);
+    expect(result.totals).toMatchObject({ total: 5, instaFilled: 4, tiktokFilled: 3 });
+  });
+
+  test('collectSatkerUpdateMatrix rejects for non directorate client', async () => {
+    mockFindClientById.mockImplementationOnce(async () => ({
+      nama: 'Polres A',
+      client_type: 'org',
+    }));
+    await expect(collectSatkerUpdateMatrix('POLRES_A')).rejects.toThrow(
+      /direktorat/
+    );
+  });
+
+  test('saveSatkerUpdateMatrixExcel writes workbook with sanitized username', async () => {
+    mockGetUsersSocialByClient.mockResolvedValue([
+      { client_id: 'DITBINMAS', insta: 'ig', tiktok: 'tt' },
+      { client_id: 'POLRES_A', insta: '', tiktok: '' },
+    ]);
+    mockGetClientsByRole.mockResolvedValue(['polres_a']);
+
+    const { filePath } = await saveSatkerUpdateMatrixExcel({
+      clientId: 'DITBINMAS',
+      roleFlag: 'ditbinmas',
+      username: 'Admin 01',
+    });
+
+    expect(mockBookNew).toHaveBeenCalledTimes(1);
+    expect(mockAoAToSheet).toHaveBeenCalledTimes(1);
+    const aoa = mockAoAToSheet.mock.calls[0][0];
+    expect(aoa[0]).toEqual([
+      'Satker',
+      'Jumlah Personil',
+      'Sudah Update Instagram',
+      'Belum Update Instagram',
+      'Prosentase Sudah Update Instagram',
+      'Sudah Update Tiktok',
+      'Belum Update Tiktok',
+      'Prosentase Sudah Update Tiktok',
+    ]);
+    expect(aoa[1]).toEqual([
+      'DIREKTORAT BINMAS',
+      1,
+      1,
+      0,
+      100,
+      1,
+      0,
+      100,
+    ]);
+    expect(aoa[2]).toEqual([
+      'POLRES A',
+      1,
+      0,
+      1,
+      0,
+      0,
+      1,
+      0,
+    ]);
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const savedPath = mockWriteFile.mock.calls[0][1];
+    expect(savedPath).toContain('Satker_Admin_01_Update_Rank_');
+    expect(filePath).toBe(savedPath);
+  });
+});


### PR DESCRIPTION
## Summary
- add a satker update matrix Excel generator that aggregates directorate data and sorts by Instagram/TikTok completion rates
- wire the new generator into the DirRequest menu, renumber existing menu entries, and propagate dashboard usernames for file naming
- extend the DirRequest test suite and add dedicated service tests to cover the new matrix export

## Testing
- npm run lint
- NODE_OPTIONS=--max_old_space_size=4096 npm test -- tests/dirRequestHandlers.test.js tests/satkerUpdateMatrixService.test.js
- ⚠️ NODE_OPTIONS=--max_old_space_size=4096 npm test -- --runInBand (terminated due to prolonged execution of absensiKomentarDitbinmasReport.test.js)

------
https://chatgpt.com/codex/tasks/task_e_68c8e68962e48327bf3b46dae69fddfa