### PR TITLE
Use simple Ditbinmas reports in directorate cron

### DIFF
--- a/src/cron/cronDirRequestDirektorat.js
+++ b/src/cron/cronDirRequestDirektorat.js
@@ -3,8 +3,10 @@ import dotenv from "dotenv";
 dotenv.config();
 
 import { waGatewayClient } from "../service/waService.js";
-import { absensiLikesDitbinmas } from "../handler/menu/dirRequestHandlers.js";
-import { absensiKomentarDitbinmasReport } from "../handler/fetchabsensi/tiktok/absensiKomentarTiktok.js";
+import {
+  absensiLikesDitbinmasSimple,
+  absensiKomentarDitbinmasSimple,
+} from "../handler/menu/dirRequestHandlers.js";
 import { safeSendMessage, getAdminWAIds } from "../utils/waHelper.js";
 import { sendDebug } from "../middleware/debugHandler.js";
 
@@ -17,8 +19,8 @@ function getRecipients() {
 export async function runCron() {
   sendDebug({ tag: "CRON DIRREQ DIREKTORAT", msg: "Mulai cron dirrequest direktorat" });
   try {
-    const likesMsg = await absensiLikesDitbinmas();
-    const komentarMsg = await absensiKomentarDitbinmasReport();
+    const likesMsg = await absensiLikesDitbinmasSimple();
+    const komentarMsg = await absensiKomentarDitbinmasSimple();
     const recipients = getRecipients();
     for (const wa of recipients) {
       await safeSendMessage(waGatewayClient, wa, likesMsg.trim());

--- a/tests/cronDirRequestDirektorat.test.js
+++ b/tests/cronDirRequestDirektorat.test.js
@@ -7,14 +7,9 @@ const mockSendDebug = jest.fn();
 
 jest.unstable_mockModule('../src/service/waService.js', () => ({ waGatewayClient: {} }));
 jest.unstable_mockModule('../src/handler/menu/dirRequestHandlers.js', () => ({
-  absensiLikesDitbinmas: mockAbsensi,
+  absensiLikesDitbinmasSimple: mockAbsensi,
+  absensiKomentarDitbinmasSimple: mockKomentar,
 }));
-jest.unstable_mockModule(
-  '../src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js',
-  () => ({
-    absensiKomentarDitbinmasReport: mockKomentar,
-  })
-);
 jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
   safeSendMessage: mockSafeSend,
   getAdminWAIds: () => ['123@c.us'],


### PR DESCRIPTION
## Summary
- update the directorate cron to send the Ditbinmas simple absensi like and comment reports
- adjust the cron unit test to mock the new simple report helpers

## Testing
- npm run lint
- npm test *(fails in this environment with Node heap OOM after suites finish running)*
- CI=1 npm test -- cronDirRequestDirektorat.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c90f5393048327af7c45ddfe39057a