### PR TITLE
Add DSP data to satker matrix export

### DIFF
--- a/src/data/satkerDspMap.js
+++ b/src/data/satkerDspMap.js
@@ -1,0 +1,72 @@
+const rawSatkerDspEntries = [
+  ["DIREKTORAT BINMAS", 102],
+  ["POLRES LAMONGAN", 335],
+  ["POLRES BOJONEGORO", 297],
+  ["POLRES PROBOLINGGO", 131],
+  ["POLRES NGAWI", 231],
+  ["POLRES MADIUN", 193],
+  ["POLRES PACITAN", 117],
+  ["POLRES BONDOWOSO", 85],
+  ["POLRES SITUBONDO", null],
+  ["POLRES MOJOKERTO", 248],
+  ["POLRES KEDIRI", 241],
+  ["POLRES KEDIRI KOTA", 120],
+  ["POLRESTA MALANG KOTA", 68],
+  ["POLRES MADIUN KOTA", 68],
+  ["POLRES MAGETAN", 244],
+  ["POLRES PONOROGO", 246],
+  ["POLRES BLITAR", 183],
+  ["POLRES JEMBER", 260],
+  ["POLRES MOJOKERTO KOTA", 96],
+  ["POLRES SUMENEP", 119],
+  ["POLRES NGANJUK", 300],
+  ["POLRES TULUNGAGUNG", 284],
+  ["POLRES JOMBANG", 239],
+  ["POLRES LUMAJANG", 95],
+  ["POLRES MALANG", 45],
+  ["POLRES TUBAN", 183],
+  ["POLRES BLITAR KOTA", 108],
+  ["POLRES GRESIK", 234],
+  ["POLRES PROBOLINGGO KOTA", 56],
+  ["POLRES PAMEKASAN", null],
+  ["POLRESTA BANYUWANGI", null],
+  ["POLRESTABES SURABAYA", 151],
+  ["POLRES PASURUAN KOTA", 68],
+  ["POLRES TRENGGALEK", null],
+  ["POLRES KP3 TANJUNG PERAK", 33],
+  ["POLRES PASURUAN", 165],
+  ["POLRESTA SIDOARJO", 241],
+  ["POLRES SAMPANG", null],
+  ["POLRES BANGKALAN", 60],
+  ["POLRES BATU", 69],
+];
+
+function normalizeKey(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[_\s]+/g, " ")
+    .trim()
+    .toUpperCase();
+}
+
+const satkerDspMap = new Map();
+for (const [label, count] of rawSatkerDspEntries) {
+  const key = normalizeKey(label);
+  if (!key) continue;
+  satkerDspMap.set(key, typeof count === "number" ? count : null);
+}
+
+export function getSatkerDspCount(...keys) {
+  for (const key of keys) {
+    const normalized = normalizeKey(key);
+    if (!normalized) continue;
+    if (satkerDspMap.has(normalized)) {
+      return satkerDspMap.get(normalized);
+    }
+  }
+  return null;
+}
+
+export const SATKER_DSP_MAP = satkerDspMap;
+
+export default satkerDspMap;

--- a/tests/satkerUpdateMatrixService.test.js
+++ b/tests/satkerUpdateMatrixService.test.js
@@ -75,13 +75,18 @@ describe('satkerUpdateMatrixService', () => {
     const result = await collectSatkerUpdateMatrix('DITBINMAS', 'ditbinmas');
 
     expect(result.stats).toHaveLength(3);
-    expect(result.stats[0].cid).toBe('ditbinmas');
-    expect(result.stats[0].instaPercent).toBe(100);
-    expect(result.stats[1].cid).toBe('polres_b');
-    expect(result.stats[1].instaPercent).toBe(100);
-    expect(result.stats[1].tiktokPercent).toBe(50);
-    expect(result.stats[2].cid).toBe('polres_a');
-    expect(result.stats[2].instaPercent).toBe(50);
+    expect(result.stats[0]).toMatchObject({
+      cid: 'ditbinmas',
+      instaPercent: 100,
+      jumlahDsp: 102,
+    });
+    expect(result.stats[1]).toMatchObject({
+      cid: 'polres_b',
+      instaPercent: 100,
+      tiktokPercent: 50,
+      jumlahDsp: null,
+    });
+    expect(result.stats[2]).toMatchObject({ cid: 'polres_a', instaPercent: 50, jumlahDsp: null });
     expect(result.totals).toMatchObject({ total: 5, instaFilled: 4, tiktokFilled: 3 });
   });
 
@@ -113,26 +118,30 @@ describe('satkerUpdateMatrixService', () => {
     const aoa = mockAoAToSheet.mock.calls[0][0];
     expect(aoa[0]).toEqual([
       'Satker',
+      'Jumlah DSP',
       'Jumlah Personil',
-      'Sudah Update Instagram',
-      'Belum Update Instagram',
-      'Prosentase Sudah Update Instagram',
-      'Sudah Update Tiktok',
-      'Belum Update Tiktok',
-      'Prosentase Sudah Update Tiktok',
+      'Data Update Instagram',
+      null,
+      null,
+      'Data Update Tiktok',
+      null,
+      null,
     ]);
-    expect(aoa[1]).toEqual([
-      'DIREKTORAT BINMAS',
-      1,
-      1,
-      0,
-      100,
-      1,
-      0,
-      100,
-    ]);
+    expect(aoa[1]).toEqual([null, null, null, 'Sudah', 'Belum', 'Prosentase', 'Sudah', 'Belum', 'Prosentase']);
     expect(aoa[2]).toEqual([
+      'DIREKTORAT BINMAS',
+      102,
+      1,
+      1,
+      0,
+      100,
+      1,
+      0,
+      100,
+    ]);
+    expect(aoa[3]).toEqual([
       'POLRES A',
+      null,
       1,
       0,
       1,
@@ -140,6 +149,15 @@ describe('satkerUpdateMatrixService', () => {
       0,
       1,
       0,
+    ]);
+
+    const worksheet = mockAoAToSheet.mock.results[0].value;
+    expect(worksheet['!merges']).toEqual([
+      { s: { r: 0, c: 0 }, e: { r: 1, c: 0 } },
+      { s: { r: 0, c: 1 }, e: { r: 1, c: 1 } },
+      { s: { r: 0, c: 2 }, e: { r: 1, c: 2 } },
+      { s: { r: 0, c: 3 }, e: { r: 0, c: 5 } },
+      { s: { r: 0, c: 6 }, e: { r: 0, c: 8 } },
     ]);
 
     expect(mockWriteFile).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- add a satker DSP data map and helper to resolve counts by satker name
- include the DSP column plus grouped Instagram/TikTok sub-columns when exporting the satker update matrix
- adjust the satker matrix service tests to cover the new headers, DSP values, and worksheet merges

## Testing
- npm run lint
- npm test *(fails: JavaScript heap out of memory)*
- npm test -- --runInBand *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c919f5b4e48327a9acbc61af2825bd