### PR TITLE
Handle errors when sending weekly comment recap

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -793,11 +793,34 @@ async function performAction(
         break;
       }
       case "21": {
-        const filePath = await saveWeeklyCommentRecapExcel(clientId);
-        const buffer = await readFile(filePath);
-        await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        await unlink(filePath);
-        msg = "✅ File Excel dikirim.";
+        let filePath;
+        try {
+          filePath = await saveWeeklyCommentRecapExcel(clientId);
+          if (!filePath) {
+            msg = "Tidak ada data.";
+            break;
+          }
+          const buffer = await readFile(filePath);
+          await sendWAFile(
+            waClient,
+            buffer,
+            basename(filePath),
+            chatId,
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          );
+          msg = "✅ File Excel dikirim.";
+        } catch (error) {
+          console.error("Gagal mengirim file Excel:", error);
+          msg = "❌ Gagal mengirim file Excel.";
+        } finally {
+          if (filePath) {
+            try {
+              await unlink(filePath);
+            } catch (err) {
+              console.error("Gagal menghapus file sementara:", err);
+            }
+          }
+        }
         break;
       }
       case "22": {


### PR DESCRIPTION
## Summary
- wrap the weekly comment recap menu action in try/catch/finally so failures send an error message and temporary files are cleaned up

## Testing
- npm run lint
- npm test *(fails: existing test assertion mismatch and OOM in absensiKomentarDitbinmasReport suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c93f53325c8327b7d4f5ab72b9eb93