### PR TITLE
Handle empty weekly comment recap exports

### DIFF
--- a/src/service/weeklyCommentRecapExcelService.js
+++ b/src/service/weeklyCommentRecapExcelService.js
@@ -83,6 +83,10 @@ export async function saveWeeklyCommentRecapExcel(clientId) {
     }
   }
 
+  if (Object.keys(grouped).length === 0) {
+    return null;
+  }
+
   const wb = XLSX.utils.book_new();
   Object.entries(grouped).forEach(([satker, usersMap]) => {
     const users = Object.values(usersMap);


### PR DESCRIPTION
## Summary
- return null when the weekly comment recap query produces no grouped records so callers can display "Tidak ada data."

## Testing
- npm run lint
- npm test *(fails: tests/satkerUpdateMatrixService.test.js expectation mismatch, tests/absensiKomentarDirektorat.test.js message format, tests/absensiKomentarDitbinmasReport.test.js due to jest worker OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68c9402d2804832784e2c8ad4bb87e1d