### PR TITLE
Optimize weekly comment recap data fetch

### DIFF
--- a/src/service/weeklyCommentRecapExcelService.js
+++ b/src/service/weeklyCommentRecapExcelService.js
@@ -49,19 +49,33 @@ export async function saveWeeklyCommentRecapExcel(clientId) {
   const dailyPosts = {};
 
   for (const dateStr of dateList) {
-    const rows = await getRekapKomentarByClient(
-      clientId,
-      'harian',
-      dateStr,
-      undefined,
-      undefined,
-      'ditbinmas'
-    );
-    const totalPosts = await countPostsByClient(
-      clientId,
-      'harian',
-      dateStr
-    );
+    let rows;
+    let totalPosts;
+    try {
+      [rows, totalPosts] = await Promise.all([
+        getRekapKomentarByClient(
+          clientId,
+          'harian',
+          dateStr,
+          undefined,
+          undefined,
+          'ditbinmas'
+        ),
+        countPostsByClient(clientId, 'harian', dateStr),
+      ]);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      if (error instanceof Error) {
+        throw new Error(
+          `Gagal mengambil data rekap mingguan untuk tanggal ${dateStr}: ${errorMessage}`,
+          { cause: error }
+        );
+      }
+      throw new Error(
+        `Gagal mengambil data rekap mingguan untuk tanggal ${dateStr}: ${errorMessage}`
+      );
+    }
     dailyPosts[dateStr] = totalPosts;
     for (const u of rows) {
       const satker = u.client_name || '';


### PR DESCRIPTION
## Summary
- fetch weekly weekly comment recap rows and post counts concurrently
- add explicit error handling around the aggregated fetch to surface failures per date

## Testing
- npm run lint
- npm test *(fails: existing failures in tests/satkerUpdateMatrixService.test.js, tests/absensiKomentarDirektorat.test.js, tests/absensiKomentarDitbinmasReport.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c944fda97483278bcb077911f3dabf