### PR TITLE
Fix TikTok weekly recap sheet grouping

### DIFF
--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -151,8 +151,10 @@ export async function getRekapKomentarByClient(
       u.nama,
       u.tiktok AS username,
       u.divisi,
+      cl.nama AS client_name,
       COALESCE(cc.jumlah_komentar, 0) AS jumlah_komentar
     FROM "user" u
+    JOIN clients cl ON cl.client_id = u.client_id
     LEFT JOIN comment_counts cc
       ON lower(replace(trim(u.tiktok), '@', '')) = cc.username
     WHERE u.status = true

--- a/src/service/monthlyCommentRecapExcelService.js
+++ b/src/service/monthlyCommentRecapExcelService.js
@@ -4,6 +4,7 @@ import XLSX from 'xlsx';
 import { hariIndo } from '../utils/constants.js';
 import { getRekapKomentarByClient } from '../model/tiktokCommentModel.js';
 import { countPostsByClient } from '../model/tiktokPostModel.js';
+import { generateSheetName } from '../utils/excelHelper.js';
 
 const RANK_ORDER = [
   'KOMISARIS BESAR POLISI',
@@ -55,7 +56,7 @@ export async function saveMonthlyCommentRecapExcel(clientId) {
     ]);
     dailyPosts[dateStr] = totalPosts;
     for (const u of rows) {
-      const satker = u.client_name || '';
+      const satker = u.client_name || u.client_id || 'Tanpa Nama';
       if (!grouped[satker]) grouped[satker] = {};
       const key = `${u.title || ''}|${u.nama || ''}`;
       if (!grouped[satker][key]) {
@@ -79,6 +80,7 @@ export async function saveMonthlyCommentRecapExcel(clientId) {
   }
 
   const wb = XLSX.utils.book_new();
+  const usedSheetNames = new Set();
   Object.entries(grouped).forEach(([satker, usersMap]) => {
     const users = Object.values(usersMap);
     users.sort((a, b) => {
@@ -165,7 +167,8 @@ export async function saveMonthlyCommentRecapExcel(clientId) {
       });
     }
 
-    XLSX.utils.book_append_sheet(wb, ws, satker);
+    const sheetName = generateSheetName(satker, usedSheetNames);
+    XLSX.utils.book_append_sheet(wb, ws, sheetName);
   });
 
   const exportDir = path.resolve('export_data/monthly_comment');

--- a/src/service/weeklyCommentRecapExcelService.js
+++ b/src/service/weeklyCommentRecapExcelService.js
@@ -4,6 +4,7 @@ import XLSX from 'xlsx';
 import { hariIndo } from '../utils/constants.js';
 import { getRekapKomentarByClient } from '../model/tiktokCommentModel.js';
 import { countPostsByClient } from '../model/tiktokPostModel.js';
+import { generateSheetName } from '../utils/excelHelper.js';
 
 const RANK_ORDER = [
   'KOMISARIS BESAR POLISI',
@@ -101,7 +102,7 @@ export async function saveWeeklyCommentRecapExcel(clientId) {
   fetchResults.forEach(({ dateStr, rows = [], totalPosts = 0 }) => {
     dailyPosts[dateStr] = totalPosts;
     for (const u of rows) {
-      const satker = u.client_name || '';
+      const satker = u.client_name || u.client_id || 'Tanpa Nama';
       if (!grouped[satker]) grouped[satker] = {};
       const key = `${u.title || ''}|${u.nama || ''}`;
       if (!grouped[satker][key]) {
@@ -125,6 +126,7 @@ export async function saveWeeklyCommentRecapExcel(clientId) {
   }
 
   const wb = XLSX.utils.book_new();
+  const usedSheetNames = new Set();
   Object.entries(grouped).forEach(([satker, usersMap]) => {
     const users = Object.values(usersMap);
     users.sort((a, b) => {
@@ -211,7 +213,8 @@ export async function saveWeeklyCommentRecapExcel(clientId) {
       });
     }
 
-    XLSX.utils.book_append_sheet(wb, ws, satker);
+    const sheetName = generateSheetName(satker, usedSheetNames);
+    XLSX.utils.book_append_sheet(wb, ws, sheetName);
   });
 
   const exportDir = path.resolve('export_data/weekly_comment');

--- a/src/utils/excelHelper.js
+++ b/src/utils/excelHelper.js
@@ -1,0 +1,39 @@
+const MAX_SHEET_NAME_LENGTH = 31;
+const INVALID_SHEET_CHARS = new RegExp('[\\\\/?*\\[\\]:]', 'g');
+
+function normalizeBaseName(rawName) {
+  const cleaned = String(rawName ?? '')
+    .replace(INVALID_SHEET_CHARS, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned.length ? cleaned : 'Sheet';
+}
+
+export function generateSheetName(rawName, usedNames) {
+  if (!usedNames || typeof usedNames.has !== 'function') {
+    throw new Error('generateSheetName requires a Set-like usedNames parameter');
+  }
+
+  const normalized = normalizeBaseName(rawName);
+  const base = normalized.slice(0, MAX_SHEET_NAME_LENGTH).trim() || 'Sheet';
+
+  let candidate = base;
+  let suffix = 1;
+  while (usedNames.has(candidate)) {
+    const suffixStr = `_${suffix++}`;
+    const maxBaseLength = Math.max(
+      MAX_SHEET_NAME_LENGTH - suffixStr.length,
+      1
+    );
+    const truncated = base.slice(0, maxBaseLength).trim();
+    const basePortion = truncated.length
+      ? truncated
+      : base.slice(0, maxBaseLength).trim();
+    candidate = `${basePortion || 'Sheet'.slice(0, maxBaseLength)}${suffixStr}`;
+  }
+
+  usedNames.add(candidate);
+  return candidate;
+}
+
+export default generateSheetName;


### PR DESCRIPTION
## Summary
- join client metadata when building TikTok comment recap data so each satker keeps its client name
- add shared Excel sheet naming helper and use it to group weekly and monthly TikTok recap exports per client safely

## Testing
- npm run lint
- npm test *(fails: JavaScript heap out of memory during Jest run)*
- NODE_OPTIONS=--max_old_space_size=4096 npm test -- --runInBand *(fails: JavaScript heap out of memory during Jest run)*

------
https://chatgpt.com/codex/tasks/task_e_68c9fd1a79bc8327966be538eb717078