### PR TITLE
Adjust weekly recap role filter for non directorate

### DIFF
--- a/src/service/weeklyCommentRecapExcelService.js
+++ b/src/service/weeklyCommentRecapExcelService.js
@@ -67,6 +67,9 @@ export async function saveWeeklyCommentRecapExcel(clientId) {
 
   const grouped = {};
   const dailyPosts = {};
+  const normalizedClientId =
+    typeof clientId === 'string' ? clientId.toLowerCase() : '';
+  const roleFilter = normalizedClientId === 'ditbinmas' ? 'ditbinmas' : undefined;
 
   const fetchResults = await Promise.all(
     dateList.map(async (dateStr) => {
@@ -78,7 +81,7 @@ export async function saveWeeklyCommentRecapExcel(clientId) {
             dateStr,
             undefined,
             undefined,
-            'ditbinmas'
+            roleFilter
           ),
           countPostsByClient(clientId, 'harian', dateStr),
         ]);


### PR DESCRIPTION
## Summary
- ensure the weekly comment recap only applies the Ditbinmas role filter when the client ID actually matches Ditbinmas
- extend the weekly comment recap service test suite with coverage for Ditbinmas and non-Ditbinmas clients to verify worksheet creation

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=4096 npm test -- --runInBand *(fails: heap out of memory after >70 suites; previously 75/76 suites completed before worker termination)*
- NODE_OPTIONS=--max-old-space-size=4096 npm test -- weeklyCommentRecapExcelService.test.js


------
https://chatgpt.com/codex/tasks/task_e_68ca24abb55483278f36d7a8c991594a