### PR TITLE
Allow directorate comment recap to include subordinate satker sheets

### DIFF
--- a/tests/tiktokCommentModel.test.js
+++ b/tests/tiktokCommentModel.test.js
@@ -32,10 +32,15 @@ test('getRekapKomentarByClient uses updated_at BETWEEN for date range', async ()
 
 test('getRekapKomentarByClient includes directorate role filter for ditbinmas', async () => {
   mockClientType('direktorat');
+  mockQuery.mockResolvedValueOnce({ rows: [{ client_id: 'polresa' }] });
   mockQuery.mockResolvedValueOnce({ rows: [] });
   await getRekapKomentarByClient('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   expect(mockQuery.mock.calls[0][0]).toContain('SELECT client_type FROM clients');
-  const sql = mockQuery.mock.calls[1][0];
+  expect(mockQuery.mock.calls[1][0]).toContain('dashboard_user_clients');
+  const sql = mockQuery.mock.calls[2][0];
   expect(sql).not.toContain('tiktok_post_roles');
-  expect(sql).toContain('user_roles');
+  expect(sql).toContain('LOWER(u.client_id) = ANY');
+  expect(sql).toContain('LOWER(r.role_name) = ANY');
+  const params = mockQuery.mock.calls[2][1];
+  expect(params.at(-1)).toEqual(['ditbinmas', 'polresa']);
 });


### PR DESCRIPTION
## Summary
- expand `getRekapKomentarByClient` so directorate queries accept role/client lists and fetch subordinate satker IDs
- refresh the weekly TikTok comment recap tests to simulate multiple Ditbinmas clients and assert workbook sheet coverage
- update the comment model unit test for the new filtering behaviour

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=4096 npm test *(fails: JavaScript heap out of memory even with expanded heap while running tests/absensiKomentarDitbinmasReport.test.js)*
- NODE_OPTIONS=--max-old-space-size=4096 node --experimental-vm-modules node_modules/jest/bin/jest.js tests/absensiKomentarDitbinmasReport.test.js *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2e07597c8327b25e9a40cd05d54e