### PR TITLE
Align TikTok weekly recap with Jakarta week window

### DIFF
--- a/src/service/weeklyCommentRecapExcelService.js
+++ b/src/service/weeklyCommentRecapExcelService.js
@@ -23,6 +23,28 @@ const RANK_ORDER = [
   'BRIPDA',
 ];
 
+const JAKARTA_TZ = 'Asia/Jakarta';
+const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const jakartaIsoFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: JAKARTA_TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const jakartaDisplayFormatter = new Intl.DateTimeFormat('id-ID', {
+  timeZone: JAKARTA_TZ,
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+});
+
+const jakartaWeekdayFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: JAKARTA_TZ,
+  weekday: 'short',
+});
+
 function rankWeight(rank) {
   const idx = RANK_ORDER.indexOf(String(rank || '').toUpperCase());
   return idx === -1 ? RANK_ORDER.length : idx;
@@ -30,38 +52,40 @@ function rankWeight(rank) {
 
 export async function saveWeeklyCommentRecapExcel(clientId) {
   const today = new Date();
-  const dayOfWeek = today.getDay();
+  const isoToday = jakartaIsoFormatter.format(today);
+  const weekdayIdx = WEEKDAY_ABBR.indexOf(jakartaWeekdayFormatter.format(today));
+  const dayOfWeek = weekdayIdx === -1 ? today.getUTCDay() : weekdayIdx;
+  const todayJakarta = new Date(`${isoToday}T00:00:00Z`);
   let weekStart;
   let weekEnd;
 
   if (dayOfWeek === 0) {
-    weekEnd = new Date(today);
-    weekStart = new Date(today);
-    weekStart.setDate(today.getDate() - 6);
-  } else {
-    weekEnd = new Date(today);
-    weekEnd.setDate(today.getDate() - dayOfWeek);
+    weekEnd = new Date(todayJakarta);
     weekStart = new Date(weekEnd);
-    weekStart.setDate(weekEnd.getDate() - 6);
+    weekStart.setUTCDate(weekStart.getUTCDate() - 6);
+  } else {
+    weekEnd = new Date(todayJakarta);
+    weekEnd.setUTCDate(weekEnd.getUTCDate() - dayOfWeek);
+    weekStart = new Date(weekEnd);
+    weekStart.setUTCDate(weekStart.getUTCDate() - 6);
   }
 
-  const formatIso = (d) => d.toISOString().slice(0, 10);
-  const formatDisplay = (d) =>
-    new Date(d).toLocaleDateString('id-ID', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    });
+  const ensureDate = (value) => {
+    if (value instanceof Date) return new Date(value);
+    if (typeof value === 'string') return new Date(`${value}T00:00:00Z`);
+    return new Date(value);
+  };
+
+  const formatIso = (d) => jakartaIsoFormatter.format(ensureDate(d));
+  const formatDisplay = (d) => jakartaDisplayFormatter.format(ensureDate(d));
   const formatHeaderDate = (d) => {
-    const dateObj = new Date(d);
-    const hari =
-      hariIndo[dateObj.getDay()] ||
-      dateObj.toLocaleDateString('id-ID', { weekday: 'long' });
-    return `${hari}, ${formatDisplay(dateObj)}`;
+    const dateObj = ensureDate(d);
+    const hari = hariIndo[dateObj.getUTCDay()];
+    return `${hari || ''}, ${formatDisplay(dateObj)}`.trim().replace(/^,\s*/, '');
   };
 
   const dateList = [];
-  for (let d = new Date(weekStart); d <= weekEnd; d.setDate(d.getDate() + 1)) {
+  for (let d = new Date(weekStart); d <= weekEnd; d.setUTCDate(d.getUTCDate() + 1)) {
     dateList.push(formatIso(d));
   }
 


### PR DESCRIPTION
## Summary
- align the TikTok weekly comment recap period calculation with the last full week in Asia/Jakarta time
- reuse localized helpers so header dates and file naming stay consistent with Jakarta formatting while keeping Ditbinmas role filtering intact

## Testing
- npm run lint
- NODE_OPTIONS=--max_old_space_size=4096 npm test *(fails: a jest worker was terminated; see console for SIGTERM details)*

------
https://chatgpt.com/codex/tasks/task_e_68ca291fa9248327a9bd3a93a45a503a