### PR TITLE
Remove TikTok recap menus from dirrequest

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -21,9 +21,7 @@ import { join, basename } from "path";
 import { saveLikesRecapExcel } from "../../service/likesRecapExcelService.js";
 import { saveCommentRecapExcel } from "../../service/commentRecapExcelService.js";
 import { saveWeeklyLikesRecapExcel } from "../../service/weeklyLikesRecapExcelService.js";
-import { saveWeeklyCommentRecapExcel } from "../../service/weeklyCommentRecapExcelService.js";
 import { saveMonthlyLikesRecapExcel } from "../../service/monthlyLikesRecapExcelService.js";
-import { saveMonthlyCommentRecapExcel } from "../../service/monthlyCommentRecapExcelService.js";
 import { saveSatkerUpdateMatrixExcel } from "../../service/satkerUpdateMatrixService.js";
 import { hariIndo } from "../../utils/constants.js";
 
@@ -792,66 +790,10 @@ async function performAction(
         }
         break;
       }
-      case "21": {
-        let filePath;
-        try {
-          filePath = await saveWeeklyCommentRecapExcel(clientId);
-          if (!filePath) {
-            msg = "Tidak ada data.";
-            break;
-          }
-          const buffer = await readFile(filePath);
-          await sendWAFile(
-            waClient,
-            buffer,
-            basename(filePath),
-            chatId,
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-          );
-          msg = "✅ File Excel dikirim.";
-        } catch (error) {
-          console.error("Gagal mengirim file Excel:", error);
-          msg = "❌ Gagal mengirim file Excel.";
-        } finally {
-          if (filePath) {
-            try {
-              await unlink(filePath);
-            } catch (err) {
-              console.error("Gagal menghapus file sementara:", err);
-            }
-          }
-        }
-        break;
-      }
       case "22": {
         let filePath;
         try {
           filePath = await saveMonthlyLikesRecapExcel(clientId);
-          if (!filePath) {
-            msg = "Tidak ada data.";
-            break;
-          }
-          const buffer = await readFile(filePath);
-          await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-          msg = "✅ File Excel dikirim.";
-        } catch (error) {
-          console.error("Gagal mengirim file Excel:", error);
-          msg = "❌ Gagal mengirim file Excel.";
-        } finally {
-          if (filePath) {
-            try {
-              await unlink(filePath);
-            } catch (err) {
-              console.error("Gagal menghapus file sementara:", err);
-            }
-          }
-        }
-        break;
-      }
-      case "23": {
-        let filePath;
-        try {
-          filePath = await saveMonthlyCommentRecapExcel(clientId);
           if (!filePath) {
             msg = "Tidak ada data.";
             break;
@@ -992,11 +934,9 @@ export const dirRequestHandlers = {
         "1️⃣8️⃣ Rekap like Instagram (Excel)\n" +
         "1️⃣9️⃣ Rekap gabungan semua sosmed\n\n" +
         "📆 *Laporan Mingguan*\n" +
-        "2️⃣0️⃣ Rekap file Instagram mingguan\n" +
-        "2️⃣1️⃣ Rekap file Tiktok mingguan\n\n" +
+        "2️⃣0️⃣ Rekap file Instagram mingguan\n\n" +
         "🗓️ *Laporan Bulanan*\n" +
-        "2️⃣2️⃣ Rekap file Instagram bulanan\n" +
-        "2️⃣3️⃣ Rekap file Tiktok bulanan\n\n" +
+        "2️⃣2️⃣ Rekap file Instagram bulanan\n\n" +
         "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -1043,9 +983,7 @@ export const dirRequestHandlers = {
           "18",
           "19",
           "20",
-          "21",
           "22",
-          "23",
         ].includes(choice)
     ) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -736,28 +736,20 @@ test('choose_menu option 20 sends no data message when service returns null', as
   );
 });
 
-test('choose_menu option 21 generates weekly tiktok recap excel and sends file', async () => {
-  mockSaveWeeklyCommentRecapExcel.mockResolvedValue('/tmp/weekly-tt.xlsx');
-  mockReadFile.mockResolvedValue(Buffer.from('excel'));
+test('choose_menu option 21 is no longer available', async () => {
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '790';
   const waClient = { sendMessage: jest.fn() };
 
   await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
 
-  expect(mockSaveWeeklyCommentRecapExcel).toHaveBeenCalledWith('ditbinmas');
-  expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly-tt.xlsx');
-  expect(mockSendWAFile).toHaveBeenCalledWith(
-    waClient,
-    expect.any(Buffer),
-    path.basename('/tmp/weekly-tt.xlsx'),
-    chatId,
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-  );
-  expect(mockUnlink).toHaveBeenCalledWith('/tmp/weekly-tt.xlsx');
+  expect(mockSaveWeeklyCommentRecapExcel).not.toHaveBeenCalled();
+  expect(mockReadFile).not.toHaveBeenCalled();
+  expect(mockSendWAFile).not.toHaveBeenCalled();
+  expect(mockUnlink).not.toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(
     chatId,
-    expect.stringContaining('File Excel dikirim')
+    expect.stringMatching(/Pilihan tidak valid/i)
   );
 });
 
@@ -803,45 +795,20 @@ test('choose_menu option 22 reports no data when service returns null', async ()
   );
 });
 
-test('choose_menu option 23 generates monthly tiktok recap excel and sends file', async () => {
-  mockSaveMonthlyCommentRecapExcel.mockResolvedValue('/tmp/monthly-tt.xlsx');
-  mockReadFile.mockResolvedValue(Buffer.from('excel'));
+test('choose_menu option 23 is no longer available', async () => {
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '993';
   const waClient = { sendMessage: jest.fn() };
 
   await dirRequestHandlers.choose_menu(session, chatId, '23', waClient);
 
-  expect(mockSaveMonthlyCommentRecapExcel).toHaveBeenCalledWith('ditbinmas');
-  expect(mockReadFile).toHaveBeenCalledWith('/tmp/monthly-tt.xlsx');
-  expect(mockSendWAFile).toHaveBeenCalledWith(
-    waClient,
-    expect.any(Buffer),
-    path.basename('/tmp/monthly-tt.xlsx'),
-    chatId,
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-  );
-  expect(mockUnlink).toHaveBeenCalledWith('/tmp/monthly-tt.xlsx');
-  expect(waClient.sendMessage).toHaveBeenCalledWith(
-    chatId,
-    expect.stringContaining('File Excel dikirim')
-  );
-});
-
-test('choose_menu option 23 reports no data when service returns null', async () => {
-  mockSaveMonthlyCommentRecapExcel.mockResolvedValue(null);
-  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
-  const chatId = '994';
-  const waClient = { sendMessage: jest.fn() };
-
-  await dirRequestHandlers.choose_menu(session, chatId, '23', waClient);
-
+  expect(mockSaveMonthlyCommentRecapExcel).not.toHaveBeenCalled();
   expect(mockReadFile).not.toHaveBeenCalled();
   expect(mockSendWAFile).not.toHaveBeenCalled();
   expect(mockUnlink).not.toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(
     chatId,
-    expect.stringMatching(/tidak ada data/i)
+    expect.stringMatching(/Pilihan tidak valid/i)
   );
 });
 


### PR DESCRIPTION
## Summary
- remove the TikTok weekly and monthly recap options from the dirrequest menu and allowed selections
- delete the associated dirrequest action handlers and adjust tests to confirm the options are unavailable

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=4096 npm test *(fails: absensiKomentarDitbinmasReport exits due to Node.js heap exhaustion)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8a0c4bc883278df56c693dbbc4d3