### PR TITLE
Add weekly TikTok recap option for DirRequest menu

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -21,6 +21,7 @@ import { join, basename } from "path";
 import { saveLikesRecapExcel } from "../../service/likesRecapExcelService.js";
 import { saveCommentRecapExcel } from "../../service/commentRecapExcelService.js";
 import { saveWeeklyLikesRecapExcel } from "../../service/weeklyLikesRecapExcelService.js";
+import { saveWeeklyCommentRecapExcel } from "../../service/weeklyCommentRecapExcelService.js";
 import { saveMonthlyLikesRecapExcel } from "../../service/monthlyLikesRecapExcelService.js";
 import { saveSatkerUpdateMatrixExcel } from "../../service/satkerUpdateMatrixService.js";
 import { hariIndo } from "../../utils/constants.js";
@@ -790,6 +791,31 @@ async function performAction(
         }
         break;
       }
+      case "21": {
+        let filePath;
+        try {
+          filePath = await saveWeeklyCommentRecapExcel(clientId);
+          if (!filePath) {
+            msg = "Tidak ada data.";
+            break;
+          }
+          const buffer = await readFile(filePath);
+          await sendWAFile(waClient, buffer, basename(filePath), chatId, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+          msg = "✅ File Excel dikirim.";
+        } catch (error) {
+          console.error("Gagal mengirim file Excel:", error);
+          msg = "❌ Gagal mengirim file Excel.";
+        } finally {
+          if (filePath) {
+            try {
+              await unlink(filePath);
+            } catch (err) {
+              console.error("Gagal menghapus file sementara:", err);
+            }
+          }
+        }
+        break;
+      }
       case "22": {
         let filePath;
         try {
@@ -934,7 +960,8 @@ export const dirRequestHandlers = {
         "1️⃣8️⃣ Rekap like Instagram (Excel)\n" +
         "1️⃣9️⃣ Rekap gabungan semua sosmed\n\n" +
         "📆 *Laporan Mingguan*\n" +
-        "2️⃣0️⃣ Rekap file Instagram mingguan\n\n" +
+        "2️⃣0️⃣ Rekap file Instagram mingguan\n" +
+        "2️⃣1️⃣ Rekap file Tiktok mingguan\n\n" +
         "🗓️ *Laporan Bulanan*\n" +
         "2️⃣2️⃣ Rekap file Instagram bulanan\n\n" +
         "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n" +
@@ -983,6 +1010,7 @@ export const dirRequestHandlers = {
           "18",
           "19",
           "20",
+          "21",
           "22",
         ].includes(choice)
     ) {

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -736,20 +736,45 @@ test('choose_menu option 20 sends no data message when service returns null', as
   );
 });
 
-test('choose_menu option 21 is no longer available', async () => {
+test('choose_menu option 21 generates weekly comment recap excel and sends file', async () => {
+  mockSaveWeeklyCommentRecapExcel.mockResolvedValue('/tmp/weekly-comments.xlsx');
+  mockReadFile.mockResolvedValue(Buffer.from('excel'));
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '790';
   const waClient = { sendMessage: jest.fn() };
 
   await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
 
-  expect(mockSaveWeeklyCommentRecapExcel).not.toHaveBeenCalled();
+  expect(mockSaveWeeklyCommentRecapExcel).toHaveBeenCalledWith('ditbinmas');
+  expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly-comments.xlsx');
+  expect(mockSendWAFile).toHaveBeenCalledWith(
+    waClient,
+    expect.any(Buffer),
+    path.basename('/tmp/weekly-comments.xlsx'),
+    chatId,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  expect(mockUnlink).toHaveBeenCalledWith('/tmp/weekly-comments.xlsx');
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('File Excel dikirim')
+  );
+});
+
+test('choose_menu option 21 sends no data message when service returns null', async () => {
+  mockSaveWeeklyCommentRecapExcel.mockResolvedValue(null);
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '792';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
+
   expect(mockReadFile).not.toHaveBeenCalled();
   expect(mockSendWAFile).not.toHaveBeenCalled();
   expect(mockUnlink).not.toHaveBeenCalled();
   expect(waClient.sendMessage).toHaveBeenCalledWith(
     chatId,
-    expect.stringMatching(/Pilihan tidak valid/i)
+    expect.stringMatching(/tidak ada data/i)
   );
 });
 


### PR DESCRIPTION
## Summary
- add the weekly TikTok recap option to the DirRequest menu and allowed actions
- reuse the weekly Excel flow for the new option with `saveWeeklyCommentRecapExcel`
- cover the new WhatsApp menu handling with success and no-data tests

## Testing
- npm run lint
- npm test -- dirRequestHandlers.test.js
- npm test *(fails: JavaScript heap out of memory when running the full suite even with --runInBand)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8d93647c8327b54f70bd35ff05b3