### PR TITLE
Include satker without TikTok usernames in comment recap

### DIFF
--- a/src/model/tiktokCommentModel.js
+++ b/src/model/tiktokCommentModel.js
@@ -157,9 +157,8 @@ export async function getRekapKomentarByClient(
     FROM "user" u
     JOIN clients cl ON cl.client_id = u.client_id
     LEFT JOIN comment_counts cc
-      ON lower(replace(trim(u.tiktok), '@', '')) = cc.username
+      ON lower(replace(trim(coalesce(u.tiktok, '')), '@', '')) = cc.username
     WHERE u.status = true
-      AND u.tiktok IS NOT NULL
       AND ${userWhere}
     ORDER BY jumlah_komentar DESC, u.nama ASC`,
     params


### PR DESCRIPTION
## Summary
- include users without TikTok handles when aggregating comment counts by normalizing the join key
- add a weekly recap test that ensures a satker with missing handles still produces an Excel worksheet

## Testing
- npm run lint
- npm test *(fails: cronDirRequestSosmedRank.test.js expectation mismatch; absensiKomentarDitbinmasReport.test.js terminated due to worker SIGTERM / OOM)*
- npm test -- tests/weeklyCommentRecapExcelService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ca96c93800832797b66beab4747a55