### PR TITLE
Aggregate Ditbinmas TikTok post counts in recaps

### DIFF
--- a/src/service/monthlyCommentRecapExcelService.js
+++ b/src/service/monthlyCommentRecapExcelService.js
@@ -48,11 +48,28 @@ export async function saveMonthlyCommentRecapExcel(clientId) {
 
   const grouped = {};
   const dailyPosts = {};
+  const normalizedClientId =
+    typeof clientId === 'string' ? clientId.toLowerCase() : '';
+  const roleFilter = normalizedClientId === 'ditbinmas' ? 'ditbinmas' : undefined;
 
   for (const dateStr of dateList) {
     const [rows, totalPosts] = await Promise.all([
-      getRekapKomentarByClient(clientId, 'harian', dateStr, undefined, undefined, 'ditbinmas'),
-      countPostsByClient(clientId, 'harian', dateStr),
+      getRekapKomentarByClient(
+        clientId,
+        'harian',
+        dateStr,
+        undefined,
+        undefined,
+        roleFilter
+      ),
+      countPostsByClient(
+        clientId,
+        'harian',
+        dateStr,
+        undefined,
+        undefined,
+        roleFilter
+      ),
     ]);
     dailyPosts[dateStr] = totalPosts;
     for (const u of rows) {


### PR DESCRIPTION
## Summary
- make the TikTok post counting query aware of directorate roles so Ditbinmas pulls aggregate counts across its satkers
- update the weekly and monthly recap services to rely on the aggregate Ditbinmas totals and extend their Ditbinmas-specific test coverage

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=6144 npm test -- --runInBand *(fails: JavaScript heap out of memory even after raising the limit)*

------
https://chatgpt.com/codex/tasks/task_e_68caad8e27908327933c4b5a3b047dd2