### PR TITLE
Add engagement ranking report for dirrequest menu

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -24,6 +24,7 @@ import { saveWeeklyLikesRecapExcel } from "../../service/weeklyLikesRecapExcelSe
 import { saveWeeklyCommentRecapExcel } from "../../service/weeklyCommentRecapExcelService.js";
 import { saveMonthlyLikesRecapExcel } from "../../service/monthlyLikesRecapExcelService.js";
 import { saveSatkerUpdateMatrixExcel } from "../../service/satkerUpdateMatrixService.js";
+import { saveEngagementRankingExcel } from "../../service/engagementRankingExcelService.js";
 import { hariIndo } from "../../utils/constants.js";
 
 const dirRequestGroup = "120363419830216549@g.us";
@@ -769,6 +770,46 @@ async function performAction(
       case "20": {
         let filePath;
         try {
+          const { filePath: generatedPath } = await saveEngagementRankingExcel({
+            clientId,
+            roleFlag,
+          });
+          filePath = generatedPath;
+          const buffer = await readFile(filePath);
+          await sendWAFile(
+            waClient,
+            buffer,
+            basename(filePath),
+            chatId,
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          );
+          msg = "✅ File Excel dikirim.";
+        } catch (error) {
+          console.error("Gagal membuat rekap ranking engagement:", error);
+          if (
+            error?.message &&
+            (error.message.includes("direktorat") ||
+              error.message.includes("Client tidak ditemukan") ||
+              error.message.includes("Tidak ada data"))
+          ) {
+            msg = error.message;
+          } else {
+            msg = "❌ Gagal membuat rekap ranking engagement.";
+          }
+        } finally {
+          if (filePath) {
+            try {
+              await unlink(filePath);
+            } catch (err) {
+              console.error("Gagal menghapus file sementara:", err);
+            }
+          }
+        }
+        break;
+      }
+      case "21": {
+        let filePath;
+        try {
           filePath = await saveWeeklyLikesRecapExcel(clientId);
           if (!filePath) {
             msg = "Tidak ada data.";
@@ -791,7 +832,7 @@ async function performAction(
         }
         break;
       }
-      case "21": {
+      case "22": {
         let filePath;
         try {
           filePath = await saveWeeklyCommentRecapExcel(clientId);
@@ -816,7 +857,7 @@ async function performAction(
         }
         break;
       }
-      case "22": {
+      case "23": {
         let filePath;
         try {
           filePath = await saveMonthlyLikesRecapExcel(clientId);
@@ -958,12 +999,13 @@ export const dirRequestHandlers = {
         "1️⃣6️⃣ Laporan harian Instagram Ditbinmas\n" +
         "1️⃣7️⃣ Laporan harian TikTok Ditbinmas\n" +
         "1️⃣8️⃣ Rekap like Instagram (Excel)\n" +
-        "1️⃣9️⃣ Rekap gabungan semua sosmed\n\n" +
+        "1️⃣9️⃣ Rekap gabungan semua sosmed\n" +
+        "2️⃣0️⃣ Rekap ranking engagement jajaran\n\n" +
         "📆 *Laporan Mingguan*\n" +
-        "2️⃣0️⃣ Rekap file Instagram mingguan\n" +
-        "2️⃣1️⃣ Rekap file Tiktok mingguan\n\n" +
+        "2️⃣1️⃣ Rekap file Instagram mingguan\n" +
+        "2️⃣2️⃣ Rekap file Tiktok mingguan\n\n" +
         "🗓️ *Laporan Bulanan*\n" +
-        "2️⃣2️⃣ Rekap file Instagram bulanan\n\n" +
+        "2️⃣3️⃣ Rekap file Instagram bulanan\n\n" +
         "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -1012,6 +1054,7 @@ export const dirRequestHandlers = {
           "20",
           "21",
           "22",
+          "23",
         ].includes(choice)
     ) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");

--- a/src/service/engagementRankingExcelService.js
+++ b/src/service/engagementRankingExcelService.js
@@ -1,0 +1,321 @@
+import { mkdir } from "fs/promises";
+import path from "path";
+import XLSX from "xlsx";
+
+import { findClientById } from "./clientService.js";
+import { getShortcodesTodayByClient } from "../model/instaPostModel.js";
+import { getLikesSets, groupUsersByClientDivision, normalizeUsername } from "../utils/likesHelper.js";
+import { getPostsTodayByClient } from "../model/tiktokPostModel.js";
+import { getCommentsByVideoId } from "../model/tiktokCommentModel.js";
+import { computeDitbinmasLikesStats } from "../handler/fetchabsensi/insta/ditbinmasLikesUtils.js";
+import { hariIndo } from "../utils/constants.js";
+
+const EXPORT_DIR = path.resolve("export_data/engagement_ranking");
+
+function sanitizeFilename(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[^\w.-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function extractUsernamesFromComments(comments) {
+  return (comments || [])
+    .map((item) => {
+      if (!item) return "";
+      if (typeof item === "string") return item;
+      if (typeof item.username === "string") return item.username;
+      if (item.user && typeof item.user.unique_id === "string") {
+        return item.user.unique_id;
+      }
+      return "";
+    })
+    .map((username) => normalizeUsername(username))
+    .filter(Boolean);
+}
+
+function computeCommentSummary(users = [], commentSets = [], totalKonten = 0) {
+  const sets = Array.isArray(commentSets) ? commentSets : [];
+  return users.reduce(
+    (acc, user) => {
+      if (!user || typeof user !== "object") {
+        return acc;
+      }
+
+      acc.total += 1;
+      if (user.exception === true) {
+        acc.lengkap += 1;
+        return acc;
+      }
+
+      const username = normalizeUsername(user.tiktok);
+      if (!username) {
+        acc.noUsername += 1;
+        return acc;
+      }
+
+      let count = 0;
+      sets.forEach((set) => {
+        if (set && typeof set.has === "function" && set.has(username)) {
+          count += 1;
+        }
+      });
+
+      if (totalKonten > 0) {
+        if (count >= totalKonten) acc.lengkap += 1;
+        else if (count > 0) acc.kurang += 1;
+        else acc.belum += 1;
+      } else {
+        acc.belum += 1;
+      }
+
+      return acc;
+    },
+    { total: 0, lengkap: 0, kurang: 0, belum: 0, noUsername: 0 }
+  );
+}
+
+async function getClientInfoCached(cache, clientId) {
+  const key = String(clientId || "").toLowerCase();
+  if (!cache.has(key)) {
+    cache.set(key, await findClientById(key));
+  }
+  return cache.get(key);
+}
+
+export async function collectEngagementRanking(clientId, roleFlag = null) {
+  const clientIdStr = String(clientId || "").trim();
+  if (!clientIdStr) {
+    throw new Error("Client tidak ditemukan.");
+  }
+
+  const normalizedClientId = clientIdStr.toLowerCase();
+  const client = await findClientById(normalizedClientId);
+  if (!client) {
+    throw new Error("Client tidak ditemukan.");
+  }
+  if (client.client_type?.toLowerCase() !== "direktorat") {
+    throw new Error("Menu ini hanya tersedia untuk direktorat.");
+  }
+
+  const roleName = (roleFlag || normalizedClientId).toLowerCase();
+  const { polresIds, usersByClient } = await groupUsersByClientDivision(roleName);
+
+  const allIds = new Set(
+    [
+      ...polresIds.map((id) => String(id || "").toUpperCase()),
+      normalizedClientId.toUpperCase(),
+      ...Object.keys(usersByClient || {}),
+    ].filter(Boolean)
+  );
+
+  const shortcodes = await getShortcodesTodayByClient(roleName);
+  const likesSets = shortcodes.length ? await getLikesSets(shortcodes) : [];
+  const totalIgPosts = shortcodes.length;
+
+  const tiktokPosts = await getPostsTodayByClient(roleName);
+  const commentSets = [];
+  for (const post of tiktokPosts) {
+    try {
+      const { comments } = await getCommentsByVideoId(post.video_id);
+      commentSets.push(new Set(extractUsernamesFromComments(comments)));
+    } catch (error) {
+      console.error(
+        "Gagal mengambil komentar TikTok untuk",
+        post.video_id,
+        error
+      );
+      commentSets.push(new Set());
+    }
+  }
+  const totalTtPosts = tiktokPosts.length;
+
+  const clientCache = new Map();
+  const entries = [];
+  const totals = {
+    totalPersonil: 0,
+    igSudah: 0,
+    igBelum: 0,
+    igKosong: 0,
+    ttSudah: 0,
+    ttBelum: 0,
+    ttKosong: 0,
+  };
+
+  for (const cidRaw of allIds) {
+    const cidUpper = String(cidRaw || "").toUpperCase();
+    const users = usersByClient?.[cidUpper] || [];
+
+    const { summary: igSummary } = computeDitbinmasLikesStats(
+      users,
+      likesSets,
+      totalIgPosts
+    );
+    const ttSummary = computeCommentSummary(users, commentSets, totalTtPosts);
+
+    const totalPersonil = users.length;
+    const igSudah = (igSummary.lengkap || 0) + (igSummary.kurang || 0);
+    const igBelum = igSummary.belum || 0;
+    const igKosong = igSummary.noUsername || 0;
+    const ttSudah = (ttSummary.lengkap || 0) + (ttSummary.kurang || 0);
+    const ttBelum = ttSummary.belum || 0;
+    const ttKosong = ttSummary.noUsername || 0;
+
+    const info = await getClientInfoCached(clientCache, cidUpper);
+    const name = (info?.nama || cidUpper).toUpperCase();
+
+    const igPct = totalPersonil ? igSudah / totalPersonil : 0;
+    const ttPct = totalPersonil ? ttSudah / totalPersonil : 0;
+    const score = totalPersonil ? (igPct + ttPct) / 2 : 0;
+
+    entries.push({
+      cid: cidUpper.toLowerCase(),
+      name,
+      totalPersonil,
+      igSudah,
+      igBelum,
+      igKosong,
+      ttSudah,
+      ttBelum,
+      ttKosong,
+      igPct,
+      ttPct,
+      score,
+    });
+
+    totals.totalPersonil += totalPersonil;
+    totals.igSudah += igSudah;
+    totals.igBelum += igBelum;
+    totals.igKosong += igKosong;
+    totals.ttSudah += ttSudah;
+    totals.ttBelum += ttBelum;
+    totals.ttKosong += ttKosong;
+  }
+
+  if (!entries.length) {
+    throw new Error("Tidak ada data engagement untuk direkap.");
+  }
+
+  const primaryCid = normalizedClientId;
+  entries.sort((a, b) => {
+    if (a.cid === primaryCid && b.cid !== primaryCid) return -1;
+    if (b.cid === primaryCid && a.cid !== primaryCid) return 1;
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.igPct !== a.igPct) return b.igPct - a.igPct;
+    if (b.ttPct !== a.ttPct) return b.ttPct - a.ttPct;
+    if (b.totalPersonil !== a.totalPersonil) {
+      return b.totalPersonil - a.totalPersonil;
+    }
+    return a.name.localeCompare(b.name, "id-ID", { sensitivity: "base" });
+  });
+
+  return {
+    clientId: normalizedClientId,
+    clientName: client.nama || clientIdStr,
+    roleName,
+    entries,
+    totals,
+    igPostsCount: totalIgPosts,
+    ttPostsCount: totalTtPosts,
+  };
+}
+
+export async function saveEngagementRankingExcel({
+  clientId,
+  roleFlag = null,
+} = {}) {
+  const {
+    clientName,
+    entries,
+    totals,
+    igPostsCount,
+    ttPostsCount,
+  } = await collectEngagementRanking(clientId, roleFlag);
+
+  const now = new Date();
+  const hari = hariIndo[now.getDay()] || now.toLocaleDateString("id-ID", { weekday: "long" });
+  const tanggal = now.toLocaleDateString("id-ID", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+
+  const aoa = [
+    [`Rekap Ranking Engagement ${(clientName || "").toUpperCase()}`],
+    [`Hari, Tanggal: ${hari}, ${tanggal}`],
+    [`Jumlah Post Instagram: ${igPostsCount}`],
+    [`Jumlah Post TikTok: ${ttPostsCount}`],
+    [],
+    [
+      "Nama Satker",
+      "Jumlah Personil",
+      "Instagram",
+      null,
+      null,
+      "TikTok",
+      null,
+      null,
+    ],
+    [
+      null,
+      null,
+      "Sudah",
+      "Belum",
+      "Username Kosong",
+      "Sudah",
+      "Belum",
+      "Username Kosong",
+    ],
+  ];
+
+  entries.forEach((entry, idx) => {
+    aoa.push([
+      `${idx + 1}. ${entry.name}`,
+      entry.totalPersonil,
+      entry.igSudah,
+      entry.igBelum,
+      entry.igKosong,
+      entry.ttSudah,
+      entry.ttBelum,
+      entry.ttKosong,
+    ]);
+  });
+
+  aoa.push([
+    "TOTAL",
+    totals.totalPersonil,
+    totals.igSudah,
+    totals.igBelum,
+    totals.igKosong,
+    totals.ttSudah,
+    totals.ttBelum,
+    totals.ttKosong,
+  ]);
+
+  const worksheet = XLSX.utils.aoa_to_sheet(aoa);
+  worksheet["!merges"] = [
+    { s: { r: 0, c: 0 }, e: { r: 0, c: 7 } },
+    { s: { r: 1, c: 0 }, e: { r: 1, c: 7 } },
+    { s: { r: 2, c: 0 }, e: { r: 2, c: 7 } },
+    { s: { r: 3, c: 0 }, e: { r: 3, c: 7 } },
+    { s: { r: 5, c: 0 }, e: { r: 6, c: 0 } },
+    { s: { r: 5, c: 1 }, e: { r: 6, c: 1 } },
+    { s: { r: 5, c: 2 }, e: { r: 5, c: 4 } },
+    { s: { r: 5, c: 5 }, e: { r: 5, c: 7 } },
+  ];
+  worksheet["!freeze"] = { xSplit: 0, ySplit: 7 };
+
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Ranking Engagement");
+
+  await mkdir(EXPORT_DIR, { recursive: true });
+  const dateLabel = now.toISOString().slice(0, 10);
+  const clientSlug = sanitizeFilename(clientName || clientId || "Direktorat");
+  const fileName = `${clientSlug}_Rekap_Ranking_Engagement_${dateLabel}.xlsx`;
+  const filePath = path.join(EXPORT_DIR, fileName);
+
+  XLSX.writeFile(workbook, filePath);
+  return { filePath, fileName };
+}
+
+export default saveEngagementRankingExcel;

--- a/tests/engagementRankingExcelService.test.js
+++ b/tests/engagementRankingExcelService.test.js
@@ -1,0 +1,195 @@
+import { jest } from '@jest/globals';
+
+const mockFindClientById = jest.fn();
+const mockGetShortcodesTodayByClient = jest.fn();
+const mockGetLikesSets = jest.fn();
+const mockGroupUsersByClientDivision = jest.fn();
+const mockGetPostsTodayByClient = jest.fn();
+const mockGetCommentsByVideoId = jest.fn();
+const mockAoAToSheet = jest.fn();
+const mockBookNew = jest.fn();
+const mockBookAppendSheet = jest.fn();
+const mockWriteFile = jest.fn();
+const mockMkdir = jest.fn();
+
+jest.unstable_mockModule('../src/service/clientService.js', () => ({
+  findClientById: mockFindClientById,
+}));
+
+jest.unstable_mockModule('../src/model/instaPostModel.js', () => ({
+  getShortcodesTodayByClient: mockGetShortcodesTodayByClient,
+}));
+
+jest.unstable_mockModule('../src/utils/likesHelper.js', () => ({
+  getLikesSets: mockGetLikesSets,
+  groupUsersByClientDivision: mockGroupUsersByClientDivision,
+  normalizeUsername: (username) =>
+    (username || '')
+      .toString()
+      .trim()
+      .replace(/^@/, '')
+      .toLowerCase(),
+}));
+
+jest.unstable_mockModule('../src/model/tiktokPostModel.js', () => ({
+  getPostsTodayByClient: mockGetPostsTodayByClient,
+}));
+
+jest.unstable_mockModule('../src/model/tiktokCommentModel.js', () => ({
+  getCommentsByVideoId: mockGetCommentsByVideoId,
+}));
+
+jest.unstable_mockModule('fs/promises', () => ({
+  mkdir: mockMkdir,
+}));
+
+jest.unstable_mockModule('xlsx', () => ({
+  default: {
+    utils: {
+      aoa_to_sheet: mockAoAToSheet,
+      book_new: mockBookNew,
+      book_append_sheet: mockBookAppendSheet,
+    },
+    writeFile: mockWriteFile,
+  },
+}));
+
+describe('engagementRankingExcelService', () => {
+  let collectEngagementRanking;
+  let saveEngagementRankingExcel;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockFindClientById.mockReset();
+    mockGetShortcodesTodayByClient.mockReset();
+    mockGetLikesSets.mockReset();
+    mockGroupUsersByClientDivision.mockReset();
+    mockGetPostsTodayByClient.mockReset();
+    mockGetCommentsByVideoId.mockReset();
+    mockAoAToSheet.mockReset();
+    mockBookNew.mockReset();
+    mockBookAppendSheet.mockReset();
+    mockWriteFile.mockReset();
+    mockMkdir.mockReset();
+
+    mockBookNew.mockReturnValue({});
+    mockAoAToSheet.mockImplementation((aoa) => ({ aoa }));
+    mockBookAppendSheet.mockImplementation(() => {});
+    mockWriteFile.mockImplementation(() => {});
+    mockMkdir.mockResolvedValue();
+
+    mockFindClientById.mockImplementation(async (cid) => {
+      const map = {
+        ditbinmas: { nama: 'Direktorat Binmas', client_type: 'direktorat' },
+        polres_a: { nama: 'Polres A', client_type: 'org' },
+        polres_b: { nama: 'Polres B', client_type: 'org' },
+      };
+      return map[String(cid || '').toLowerCase()] || null;
+    });
+
+    mockGroupUsersByClientDivision.mockResolvedValue({
+      polresIds: ['DITBINMAS', 'POLRES_A', 'POLRES_B'],
+      usersByClient: {
+        DITBINMAS: [
+          { insta: '@dit1', tiktok: '@dit1', exception: false },
+          { insta: '', tiktok: '', exception: false },
+        ],
+        POLRES_A: [
+          { insta: '@userA', tiktok: '@userA', exception: false },
+          { insta: '@userB', tiktok: '', exception: true },
+        ],
+        POLRES_B: [{ insta: '@userC', tiktok: '@userC', exception: false }],
+      },
+    });
+
+    mockGetShortcodesTodayByClient.mockResolvedValue(['sc1', 'sc2']);
+    mockGetLikesSets.mockResolvedValue([
+      new Set(['dit1', 'usera', 'userc']),
+      new Set(['usera']),
+    ]);
+
+    mockGetPostsTodayByClient.mockResolvedValue([
+      { video_id: 'vid1' },
+      { video_id: 'vid2' },
+    ]);
+    mockGetCommentsByVideoId.mockResolvedValue({
+      comments: [
+        { username: '@userA' },
+        { user: { unique_id: 'userc' } },
+      ],
+    });
+
+    ({ collectEngagementRanking, saveEngagementRankingExcel } = await import(
+      '../src/service/engagementRankingExcelService.js'
+    ));
+  });
+
+  test('collectEngagementRanking aggregates stats per satker', async () => {
+    const result = await collectEngagementRanking('DITBINMAS', 'ditbinmas');
+
+    expect(mockGroupUsersByClientDivision).toHaveBeenCalledWith('ditbinmas');
+    expect(result.entries).toHaveLength(3);
+    const first = result.entries[0];
+    expect(first.name).toBe('DIREKTORAT BINMAS');
+    expect(first.igSudah).toBe(1);
+    expect(first.igBelum).toBe(0);
+    expect(first.ttSudah).toBe(0);
+    expect(first.ttKosong).toBe(1);
+
+    const totals = result.totals;
+    expect(totals.totalPersonil).toBe(5);
+    expect(totals.igSudah).toBeGreaterThan(0);
+    expect(result.igPostsCount).toBe(2);
+    expect(result.ttPostsCount).toBe(2);
+  });
+
+  test('saveEngagementRankingExcel writes workbook and returns file path', async () => {
+    const { filePath, fileName } = await saveEngagementRankingExcel({
+      clientId: 'DITBINMAS',
+      roleFlag: 'ditbinmas',
+    });
+
+    expect(mockAoAToSheet).toHaveBeenCalled();
+    const aoa = mockAoAToSheet.mock.calls[0][0];
+    expect(aoa[0][0]).toMatch(/Rekap Ranking Engagement/i);
+    expect(aoa[5]).toEqual([
+      'Nama Satker',
+      'Jumlah Personil',
+      'Instagram',
+      null,
+      null,
+      'TikTok',
+      null,
+      null,
+    ]);
+    expect(aoa[6]).toEqual([
+      null,
+      null,
+      'Sudah',
+      'Belum',
+      'Username Kosong',
+      'Sudah',
+      'Belum',
+      'Username Kosong',
+    ]);
+    expect(aoa[aoa.length - 1][0]).toBe('TOTAL');
+
+    expect(mockBookNew).toHaveBeenCalled();
+    expect(mockBookAppendSheet).toHaveBeenCalled();
+    expect(mockMkdir).toHaveBeenCalled();
+    expect(mockWriteFile).toHaveBeenCalled();
+    expect(filePath).toBeTruthy();
+    expect(fileName).toMatch(/Rekap_Ranking_Engagement/);
+  });
+
+  test('collectEngagementRanking rejects for non directorate client', async () => {
+    mockFindClientById.mockResolvedValueOnce({
+      nama: 'Polres A',
+      client_type: 'org',
+    });
+
+    await expect(collectEngagementRanking('POLRES_A')).rejects.toThrow(
+      /direktorat/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add an engagement ranking Excel generator that aggregates Instagram likes and TikTok comments per satker with report headers
- wire the new ranking report into dirrequest menu option 20 and shift downstream menu numbering
- expand automated tests for the new service and update dir request handler tests to cover the new menu entries

## Testing
- npm run lint
- npm test (fails: JavaScript heap out of memory)
- npm test -- tests/engagementRankingExcelService.test.js tests/dirRequestHandlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb473af6108327b957f666cb2302ee