### PR TITLE
Remove exception auto pass from TikTok recap

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -263,9 +263,7 @@ export async function absensiKomentar(client_id, opts = {}) {
         };
       const g = groups[cid];
       g.total++;
-      if (u.exception === true) {
-        g.sudah++;
-      } else if (!u.tiktok || u.tiktok.trim() === "") {
+      if (!u.tiktok || u.tiktok.trim() === "") {
         g.noUsername++;
       } else if (u.count >= Math.ceil(totalKonten / 2)) {
         g.sudah++;
@@ -356,9 +354,7 @@ export async function absensiKomentar(client_id, opts = {}) {
   let sudah = [], belum = [];
 
   Object.values(userStats).forEach((u) => {
-    if (u.exception === true) {
-      sudah.push(u);
-    } else if (
+    if (
       u.tiktok &&
       u.tiktok.trim() !== "" &&
       u.count >= Math.ceil(totalKonten / 2)
@@ -368,9 +364,6 @@ export async function absensiKomentar(client_id, opts = {}) {
       belum.push(u);
     }
   });
-
-  // Hapus user exception dari list belum!
-  belum = belum.filter(u => !u.exception);
 
   sendDebug({
     tag: "ABSEN TTK",

--- a/tests/absensiKomentarDirektorat.test.js
+++ b/tests/absensiKomentarDirektorat.test.js
@@ -59,26 +59,45 @@ test('sorts satker reports with Ditbinmas first and by percentage and count', as
     return { rows: [{ nama: cid, client_tiktok: '', client_type: 'org' }] };
   });
   mockGetPostsTodayByClient.mockResolvedValueOnce([{ video_id: 'v1' }]);
-  mockGetCommentsByVideoId.mockResolvedValueOnce({ comments: [] });
 
-  function createUsers(clientId, total, sudah) {
-    return Array.from({ length: total }, (_, i) => ({
-      user_id: `${clientId}-${i}`,
-      client_id: clientId,
-      tiktok: `user${clientId}${i}`,
-      status: true,
-      exception: i < sudah,
-    }));
+  function createUsers(clientId, total) {
+    const normalizedId = clientId.toLowerCase();
+    return Array.from({ length: total }, (_, i) => {
+      const username = `user${normalizedId}${i}`;
+      return {
+        user_id: `${clientId}-${i}`,
+        client_id: clientId,
+        tiktok: username,
+        status: true,
+        exception: false,
+      };
+    });
   }
 
   const users = [
-    ...createUsers('DITBINMAS', 2, 1),
-    ...createUsers('POLRES_A', 100, 80),
-    ...createUsers('POLRES_B', 100, 50),
-    ...createUsers('POLRES_C', 99, 70),
-    ...createUsers('POLRES_D', 99, 75),
+    ...createUsers('DITBINMAS', 2),
+    ...createUsers('POLRES_A', 100),
+    ...createUsers('POLRES_B', 100),
+    ...createUsers('POLRES_C', 99),
+    ...createUsers('POLRES_D', 99),
   ];
   mockGetUsersByDirektorat.mockResolvedValueOnce(users);
+
+  const commentUsernames = [];
+  function addComments(clientId, sudah) {
+    const normalizedId = clientId.toLowerCase();
+    for (let i = 0; i < sudah; i += 1) {
+      commentUsernames.push({ username: `user${normalizedId}${i}` });
+    }
+  }
+
+  addComments('DITBINMAS', 1);
+  addComments('POLRES_A', 80);
+  addComments('POLRES_B', 50);
+  addComments('POLRES_C', 70);
+  addComments('POLRES_D', 75);
+
+  mockGetCommentsByVideoId.mockResolvedValueOnce({ comments: commentUsernames });
 
   const msg = await absensiKomentar('DITBINMAS', { roleFlag: 'ditbinmas' });
 


### PR DESCRIPTION
## Summary
- stop treating TikTok exception users as automatically selesai inside the absensiKomentar recap message
- update the directorate recap test to generate comment data instead of relying on the exception flag when asserting ordering

## Testing
- npm run lint
- npm test *(fails in this environment with V8 heap OOM even with increased --max-old-space-size; see logs in conversation)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4c2cd1748327a831fbafbd13141e