### PR TITLE
Adjust engagement ranking export header styling

### DIFF
--- a/src/service/engagementRankingExcelService.js
+++ b/src/service/engagementRankingExcelService.js
@@ -247,24 +247,24 @@ export async function saveEngagementRankingExcel({
     [`Jumlah Post TikTok: ${ttPostsCount}`],
     [],
     [
-      "Nama Satker",
-      "Jumlah Personil",
-      "Instagram",
+      "NAMA SATKER",
+      "JUMLAH PERSONIL",
+      "INSTAGRAM",
       null,
       null,
-      "TikTok",
+      "TIKTOK",
       null,
       null,
     ],
     [
       null,
       null,
-      "Sudah",
-      "Belum",
-      "Username Kosong",
-      "Sudah",
-      "Belum",
-      "Username Kosong",
+      "SUDAH",
+      "BELUM",
+      "USERNAME KOSONG",
+      "SUDAH",
+      "BELUM",
+      "USERNAME KOSONG",
     ],
   ];
 
@@ -349,8 +349,8 @@ export async function saveEngagementRankingExcel({
         top: row === tableHeaderRows[0] ? mediumBorder : thinBorder,
         bottom:
           row === tableEndRow || row === headerBottomRow ? mediumBorder : thinBorder,
-        left: col === 0 ? mediumBorder : thinBorder,
-        right: col === columnCount - 1 ? mediumBorder : thinBorder,
+        left: mediumBorder,
+        right: mediumBorder,
       };
 
       if (tableHeaderRows.includes(row)) {

--- a/tests/engagementRankingExcelService.test.js
+++ b/tests/engagementRankingExcelService.test.js
@@ -153,24 +153,24 @@ describe('engagementRankingExcelService', () => {
     const aoa = mockAoAToSheet.mock.calls[0][0];
     expect(aoa[0][0]).toMatch(/Rekap Ranking Engagement/i);
     expect(aoa[5]).toEqual([
-      'Nama Satker',
-      'Jumlah Personil',
-      'Instagram',
+      'NAMA SATKER',
+      'JUMLAH PERSONIL',
+      'INSTAGRAM',
       null,
       null,
-      'TikTok',
+      'TIKTOK',
       null,
       null,
     ]);
     expect(aoa[6]).toEqual([
       null,
       null,
-      'Sudah',
-      'Belum',
-      'Username Kosong',
-      'Sudah',
-      'Belum',
-      'Username Kosong',
+      'SUDAH',
+      'BELUM',
+      'USERNAME KOSONG',
+      'SUDAH',
+      'BELUM',
+      'USERNAME KOSONG',
     ]);
     expect(aoa[aoa.length - 1][0]).toBe('TOTAL');
 


### PR DESCRIPTION
## Summary
- render the engagement ranking header and sub-header labels in uppercase
- apply medium borders to all table columns in the engagement ranking export
- update tests to reflect the new header text formatting

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbb42f43fc8327981c2fc4dd36a790