### PR TITLE
Add cron job for engagement ranking recap

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ const cronModules = [
   './src/cron/cronDirRequestRekapUpdate.js',
   './src/cron/cronDirRequestRekapAllSocmed.js',
   './src/cron/cronDirRequestSosmedRank.js',
+  './src/cron/cronDirRequestEngageRank.js',
   './src/cron/cronDirRequestDirektorat.js',
   './src/cron/cronDbBackup.js',
 ];

--- a/docs/activity_schedule.md
+++ b/docs/activity_schedule.md
@@ -14,6 +14,7 @@ This document summarizes the automated jobs ("activity") that run inside Cicero_
 | `cronAmplifyLinkMonthly.js` | `0 23 28-31 * *` | At 23:00 on the last day of each month. Generates monthly amplification link reports and sends an Excel file to each operator. |
 | `cronDirRequestRekapAllSocmed.js` | `0 0 15,18 * * *` & `0 30 20 * * *` | 15:00 & 18:00 send recaps to admins and group; 20:30 also sends to the rekap recipient. |
 | `cronDirRequestSosmedRank.js` | `7 15,18 * * *` & `32 20 * * *` | Executes menu 4 & 5 for DITBINMAS; 15:07 & 18:07 send to admins and group; 20:32 also sends to the rank recipient. |
+| `cronDirRequestEngageRank.js` | `7 15,18 * * *` & `40 20 * * *` | Runs menu 20 (engagement ranking) and sends the Excel plus narrative to the designated recipient at 15:07, 18:07, and 20:40. |
 
 Each job collects data from the database, interacts with RapidAPI or WhatsApp, and updates the system accordingly. The cron files are imported in `app.js` so no additional setup is required.
 

--- a/src/cron/cronDirRequestEngageRank.js
+++ b/src/cron/cronDirRequestEngageRank.js
@@ -1,0 +1,107 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import { readFile, unlink } from "fs/promises";
+import { basename } from "path";
+
+import { waGatewayClient } from "../service/waService.js";
+import { saveEngagementRankingExcel } from "../service/engagementRankingExcelService.js";
+import { safeSendMessage, sendWAFile } from "../utils/waHelper.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+
+const RECIPIENT = process.env.DIRREQUEST_ENGAGE_RANK_RECIPIENT || "6281234560377@c.us";
+const CLIENT_ID = "DITBINMAS";
+const ROLE_FLAG = "ditbinmas";
+
+function getJakartaDate() {
+  return new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Jakarta" }));
+}
+
+function formatGreeting(date) {
+  const hour = date.getHours();
+  if (hour >= 4 && hour < 10) return "Selamat Pagi";
+  if (hour >= 10 && hour < 15) return "Selamat Siang";
+  if (hour >= 15 && hour < 18) return "Selamat Sore";
+  return "Selamat Malam";
+}
+
+function buildNarrative(now = getJakartaDate()) {
+  const greeting = formatGreeting(now);
+  const hari = now.toLocaleDateString("id-ID", {
+    weekday: "long",
+    timeZone: "Asia/Jakarta",
+  });
+  const tanggal = now.toLocaleDateString("id-ID", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+    timeZone: "Asia/Jakarta",
+  });
+  const jam = new Intl.DateTimeFormat("id-ID", {
+    timeZone: "Asia/Jakarta",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+    .format(now)
+    .replace(":", ".");
+
+  return (
+    `${greeting},` +
+    "\n\n" +
+    "Mohon Ijin Komandan," +
+    "\n" +
+    "Mengirimkan Ranking Jajaran tugas pelaksanaan likes dan komentar Konten Instagram dan Tiktok pada akun Official Ditbinmas Polda Jatim, pada " +
+    `${hari}, ${tanggal}, pukul ${jam} WIB.`
+  );
+}
+
+export async function runCron() {
+  sendDebug({
+    tag: "CRON DIRREQ ENGAGE RANK",
+    msg: "Mulai cron dirrequest engage rank",
+  });
+
+  let filePath = null;
+
+  try {
+    const { filePath: generatedPath } = await saveEngagementRankingExcel({
+      clientId: CLIENT_ID,
+      roleFlag: ROLE_FLAG,
+    });
+    filePath = generatedPath;
+
+    const buffer = await readFile(filePath);
+    const narrative = buildNarrative();
+
+    await safeSendMessage(waGatewayClient, RECIPIENT, narrative.trim());
+    await sendWAFile(
+      waGatewayClient,
+      buffer,
+      basename(filePath),
+      RECIPIENT,
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+
+    sendDebug({
+      tag: "CRON DIRREQ ENGAGE RANK",
+      msg: "Laporan ranking engagement dikirim",
+    });
+  } catch (err) {
+    sendDebug({
+      tag: "CRON DIRREQ ENGAGE RANK",
+      msg: `[ERROR] ${err.message || err}`,
+    });
+  } finally {
+    if (filePath) {
+      await unlink(filePath).catch(() => {});
+    }
+  }
+}
+
+cron.schedule("7 15 * * *", runCron, { timezone: "Asia/Jakarta" });
+cron.schedule("7 18 * * *", runCron, { timezone: "Asia/Jakarta" });
+cron.schedule("40 20 * * *", runCron, { timezone: "Asia/Jakarta" });
+
+export default null;

--- a/tests/cronDirRequestEngageRank.test.js
+++ b/tests/cronDirRequestEngageRank.test.js
@@ -1,0 +1,74 @@
+import { jest } from '@jest/globals';
+import { tmpdir } from 'os';
+import { join, basename } from 'path';
+import { writeFile, access } from 'fs/promises';
+
+const mockSaveEngagementRankingExcel = jest.fn();
+const mockSafeSendMessage = jest.fn();
+const mockSendWAFile = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/service/waService.js', () => ({ waGatewayClient: {} }));
+jest.unstable_mockModule('../src/service/engagementRankingExcelService.js', () => ({
+  saveEngagementRankingExcel: mockSaveEngagementRankingExcel,
+}));
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  safeSendMessage: mockSafeSendMessage,
+  sendWAFile: mockSendWAFile,
+}));
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let runCron;
+
+beforeAll(async () => {
+  ({ runCron } = await import('../src/cron/cronDirRequestEngageRank.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSafeSendMessage.mockResolvedValue(true);
+  mockSendWAFile.mockResolvedValue();
+});
+
+test('runCron generates excel, sends narrative and file, then cleans up', async () => {
+  const filePath = join(tmpdir(), `engage-rank-${Date.now()}.xlsx`);
+  await writeFile(filePath, 'dummy');
+  mockSaveEngagementRankingExcel.mockResolvedValue({
+    filePath,
+    fileName: basename(filePath),
+  });
+
+  await runCron();
+
+  expect(mockSaveEngagementRankingExcel).toHaveBeenCalledWith({
+    clientId: 'DITBINMAS',
+    roleFlag: 'ditbinmas',
+  });
+
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    {},
+    '6281234560377@c.us',
+    expect.stringContaining('Mengirimkan Ranking Jajaran')
+  );
+
+  expect(mockSendWAFile).toHaveBeenCalledWith(
+    {},
+    expect.any(Buffer),
+    basename(filePath),
+    '6281234560377@c.us',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+
+  await expect(access(filePath)).rejects.toThrow();
+
+  expect(mockSendDebug).toHaveBeenCalledWith({
+    tag: 'CRON DIRREQ ENGAGE RANK',
+    msg: 'Mulai cron dirrequest engage rank',
+  });
+  expect(mockSendDebug).toHaveBeenCalledWith({
+    tag: 'CRON DIRREQ ENGAGE RANK',
+    msg: 'Laporan ranking engagement dikirim',
+  });
+});


### PR DESCRIPTION
## Summary
- add a new cronDirRequestEngageRank job that builds the engagement ranking Excel, crafts the required WhatsApp narrative, and sends both to the Ditbinmas recipient at 15:07, 18:07, and 20:40 WIB
- register the cron loader and document the schedule so the job starts with the rest of the background tasks
- cover the cron with unit tests to verify Excel generation, messaging, and cleanup

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=4096 npm test -- --runInBand *(execution halted after extended runtime; see console log)*
- NODE_OPTIONS=--max-old-space-size=4096 node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath tests/cronDirRequestEngageRank.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cbb7f07afc83279dffddb23d6c5170