### PR TITLE
Style engagement ranking header

### DIFF
--- a/src/service/engagementRankingExcelService.js
+++ b/src/service/engagementRankingExcelService.js
@@ -347,14 +347,26 @@ export async function saveEngagementRankingExcel({
 
   const headerBottomRow = tableHeaderRows[tableHeaderRows.length - 1];
 
+  for (let row = 0; row <= 4; row += 1) {
+    const cell = ensureCell(worksheet, row, 0);
+    const style = { ...(cell.s || {}) };
+    style.font = { ...(style.font || {}), bold: true };
+    style.alignment = {
+      ...(style.alignment || {}),
+      horizontal: "center",
+      vertical: "center",
+      wrapText: true,
+    };
+    cell.s = style;
+  }
+
   for (let row = 6; row <= tableEndRow; row += 1) {
     for (let col = 0; col < columnCount; col += 1) {
       const cell = ensureCell(worksheet, row, col);
       const style = { ...(cell.s || {}) };
       style.border = {
-        top: row === tableHeaderRows[0] ? mediumBorder : thinBorder,
-        bottom:
-          row === tableEndRow || row === headerBottomRow ? mediumBorder : thinBorder,
+        top: mediumBorder,
+        bottom: mediumBorder,
         left: mediumBorder,
         right: mediumBorder,
       };


### PR DESCRIPTION
## Summary
- bold and center the introductory rows in the engagement ranking Excel export
- ensure all table cells use medium borders for a consistent header design

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe455f9948327b0b40dde309ab6a6