### PR TITLE
Set dirrequest menu to default DITBINMAS client

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -670,13 +670,25 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
       } catch (e) {
         // ignore lookup errors and fallback to dashboard user client_ids
       }
+      const defaultClientId = "DITBINMAS";
+      let defaultClientName = defaultClientId;
+      try {
+        const ditClient = await clientService.findClientById(defaultClientId);
+        if (ditClient?.nama) {
+          defaultClientName = ditClient.nama;
+        }
+      } catch (e) {
+        // ignore lookup errors and fallback to default label
+      }
       setSession(chatId, {
         menu: "dirrequest",
         step: "main",
         role: du.role,
-        client_ids: du.client_ids,
-        dir_client_id: dirClientId,
+        client_ids: [defaultClientId],
+        dir_client_id: defaultClientId,
         username: du.username,
+        selectedClientId: defaultClientId,
+        clientName: defaultClientName,
       });
       await dirRequestHandlers.main(getSession(chatId), chatId, "", waClient);
       return;


### PR DESCRIPTION
## Summary
- default dirrequest sessions to the DITBINMAS client to skip per-client prompts
- ensure the dirrequest menu always reuses the DITBINMAS context when re-rendering
- update the dirRequestHandlers test suite to reflect the new default selection logic

## Testing
- npm run lint
- npm test -- dirRequestHandlers.test.js
- npm test *(fails: jest worker terminated after long run)*
- npm test -- --runInBand *(fails: Node.js heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68cbebc26cdc8327a9cd6766f1c60721