### PR TITLE
Add WhatsApp group broadcast to DirRequest engage rank cron

### DIFF
--- a/docs/activity_schedule.md
+++ b/docs/activity_schedule.md
@@ -14,7 +14,7 @@ This document summarizes the automated jobs ("activity") that run inside Cicero_
 | `cronAmplifyLinkMonthly.js` | `0 23 28-31 * *` | At 23:00 on the last day of each month. Generates monthly amplification link reports and sends an Excel file to each operator. |
 | `cronDirRequestRekapAllSocmed.js` | `0 0 15,18 * * *` & `0 30 20 * * *` | 15:00 & 18:00 send recaps to admins and group; 20:30 also sends to the rekap recipient. |
 | `cronDirRequestSosmedRank.js` | `7 15,18 * * *` & `32 20 * * *` | Executes menu 4 & 5 for DITBINMAS; 15:07 & 18:07 send to admins and group; 20:32 also sends to the rank recipient. |
-| `cronDirRequestEngageRank.js` | `7 15,18 * * *` & `40 20 * * *` | Runs menu 20 (engagement ranking) and sends the Excel plus narrative to the designated recipient at 15:07, 18:07, and 20:40. |
+| `cronDirRequestEngageRank.js` | `7 15,18 * * *`, `40 20 * * *` & `45 20 * * *` | Runs menu 20 (engagement ranking) and sends the Excel plus narrative to the designated recipient at 15:07, 18:07, and 20:40, then re-sends to the Ditbinmas group (120363419830216549@g.us) at 20:45. |
 
 Each job collects data from the database, interacts with RapidAPI or WhatsApp, and updates the system accordingly. The cron files are imported in `app.js` so no additional setup is required.
 


### PR DESCRIPTION
## Summary
- support broadcasting engagement ranking reports to multiple WhatsApp targets and schedule a 20:45 job for the Ditbinmas group
- extend the cron unit test coverage for multi-recipient delivery
- document the updated cron schedule for engagement ranking reports

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc0a22accc8327a5ab11b1c981136a