### PR TITLE
Remove duplicate per-konten debug log

### DIFF
--- a/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
+++ b/src/handler/fetchabsensi/tiktok/absensiKomentarTiktok.js
@@ -181,12 +181,6 @@ export async function absensiKomentar(client_id, opts = {}) {
 
   sendDebug({
     tag: "ABSEN TTK",
-    msg: `Start per-konten absensi. Posts=${posts.length} users=${users.length}`,
-    client_id,
-  });
-
-  sendDebug({
-    tag: "ABSEN TTK",
     msg: `Start absensi komentar. Posts=${posts.length} users=${users.length}`,
     client_id,
   });


### PR DESCRIPTION
## Summary
- remove the extra per-konten debug log from `absensiKomentar` so it only reports the overall start message
- ensure the per-konten handler continues to log its own start message separately

## Testing
- `npm run lint`
- `npm test` *(fails: tests/cronDirRequestEngageRank.test.js expects a different recipient list; jest worker termination also aborted tests/absensiKomentarDitbinmasReport.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cc125da9848327978b0a11fba77565