### PR TITLE
Add batal option handling to user menu handlers

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -55,17 +55,17 @@ export const userMenuHandlers = {
       if (session.identityConfirmed && session.user_id === userByWA.user_id) {
         const msgText = `${salam}, Bapak/Ibu\n${formatUserReport(
           userByWA
-        )}\n\nApakah Anda ingin melakukan perubahan data?\nBalas *ya* jika ingin update data, atau *tidak* untuk keluar.`;
+        )}\n\nApakah Anda ingin melakukan perubahan data?\nBalas *ya* jika ingin update data, *tidak* untuk keluar, atau *batal* untuk menutup sesi.`;
         session.step = "tanyaUpdateMyData";
         await waClient.sendMessage(chatId, msgText.trim());
         return;
       }
-      const msgText = `
+    const msgText = `
 ${salam}, Bapak/Ibu
 ${formatUserReport(userByWA)}
 
 Apakah data di atas benar milik Anda?
-Balas *ya* jika benar, atau *tidak* jika bukan.
+Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
 `.trim();
       session.step = "confirmUserByWaIdentity";
       session.user_id = userByWA.user_id;
@@ -82,46 +82,61 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
 
   // --- Konfirmasi identitas (lihat data)
   confirmUserByWaIdentity: async (session, chatId, text, waClient, pool, userModel) => {
-    if (text.trim().toLowerCase() === "ya") {
+    const answer = text.trim().toLowerCase();
+    if (answer === "ya") {
       session.identityConfirmed = true;
       session.step = "tanyaUpdateMyData";
       await waClient.sendMessage(
         chatId,
-        "Apakah Anda ingin melakukan perubahan data?\nBalas *ya* jika ingin update data, atau *tidak* untuk keluar."
+        "Apakah Anda ingin melakukan perubahan data?\nBalas *ya* jika ingin update data, *tidak* untuk keluar, atau *batal* untuk menutup sesi."
       );
-    } else if (text.trim().toLowerCase() === "tidak") {
+    } else if (answer === "tidak") {
       session.exit = true;
       await waClient.sendMessage(
         chatId,
-        "Baik, terima kasih. Ketik *userrequest* untuk memulai lagi."
+        "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
+      );
+    } else if (answer === "batal") {
+      session.exit = true;
+      await waClient.sendMessage(
+        chatId,
+        "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
       );
     } else {
       await waClient.sendMessage(
         chatId,
-        "Jawaban tidak dikenali. Balas *ya* jika benar data Anda, atau *tidak* jika bukan."
+        "Jawaban tidak dikenali. Balas *ya* jika benar data Anda, *tidak* jika bukan, atau *batal* untuk menutup sesi."
       );
     }
   },
 
   // --- Konfirmasi identitas untuk update data
   confirmUserByWaUpdate: async (session, chatId, text, waClient, pool, userModel) => {
-    if (text.trim().toLowerCase() === "ya") {
+    const answer = text.trim().toLowerCase();
+    if (answer === "ya") {
       session.identityConfirmed = true;
       session.updateUserId = session.user_id;
       session.step = "updateAskField";
       await waClient.sendMessage(chatId, formatFieldList(session.isDitbinmas));
       return;
-    } else if (text.trim().toLowerCase() === "tidak") {
+    } else if (answer === "tidak") {
       session.exit = true;
       await waClient.sendMessage(
         chatId,
-        "Baik, terima kasih. Ketik *userrequest* untuk memulai lagi."
+        "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
+      );
+      return;
+    } else if (answer === "batal") {
+      session.exit = true;
+      await waClient.sendMessage(
+        chatId,
+        "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
       );
       return;
     }
     await waClient.sendMessage(
       chatId,
-      "Jawaban tidak dikenali. Balas *ya* jika benar data Anda, atau *tidak* jika bukan."
+      "Jawaban tidak dikenali. Balas *ya* jika benar data Anda, *tidak* jika bukan, atau *batal* untuk menutup sesi."
     );
   },
 
@@ -457,7 +472,8 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
   },
 
   tanyaUpdateMyData: async (session, chatId, text, waClient, pool, userModel) => {
-    if (text.trim().toLowerCase() === "ya") {
+    const answer = text.trim().toLowerCase();
+    if (answer === "ya") {
       session.step = "confirmUserByWaUpdate";
       await userMenuHandlers.confirmUserByWaUpdate(
         session,
@@ -468,14 +484,24 @@ Balas *ya* jika benar, atau *tidak* jika bukan.
         userModel
       );
       return;
-    } else if (text.trim().toLowerCase() === "tidak") {
+    } else if (answer === "tidak") {
       session.exit = true;
-      await waClient.sendMessage(chatId, "Terima kasih. Ketik *userrequest* bila membutuhkan lagi.");
+      await waClient.sendMessage(
+        chatId,
+        "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
+      );
+      return;
+    } else if (answer === "batal") {
+      session.exit = true;
+      await waClient.sendMessage(
+        chatId,
+        "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
+      );
       return;
     }
     await waClient.sendMessage(
       chatId,
-      "Balas *ya* jika ingin update data, atau *tidak* untuk kembali."
+      "Balas *ya* jika ingin update data, *tidak* untuk kembali, atau *batal* untuk menutup sesi."
     );
   },
 };

--- a/tests/userMenuHandlersFlow.test.js
+++ b/tests/userMenuHandlersFlow.test.js
@@ -1,0 +1,158 @@
+import { jest } from "@jest/globals";
+import { userMenuHandlers } from "../src/handler/menu/userMenuHandlers.js";
+
+describe("userMenuHandlers conversational flow", () => {
+  const chatId = "628111222333@c.us";
+  let waClient;
+
+  beforeEach(() => {
+    waClient = {
+      sendMessage: jest.fn().mockResolvedValue(),
+    };
+  });
+
+  it("mentions batal option when showing update prompt on main handler", async () => {
+    const session = { identityConfirmed: true, user_id: "123" };
+    const userModel = {
+      findUserByWhatsApp: jest.fn().mockResolvedValue({
+        user_id: "123",
+        nama: "Bripka Seno",
+      }),
+    };
+
+    await userMenuHandlers.main(session, chatId, "", waClient, null, userModel);
+
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.stringContaining("atau *batal* untuk menutup sesi.")
+    );
+  });
+
+  it("mentions batal option when confirming identity in main handler", async () => {
+    const session = { identityConfirmed: false };
+    const userModel = {
+      findUserByWhatsApp: jest.fn().mockResolvedValue({
+        user_id: "999",
+        nama: "Bripka Seno",
+      }),
+    };
+
+    await userMenuHandlers.main(session, chatId, "", waClient, null, userModel);
+
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.stringContaining("atau *batal* untuk menutup sesi.")
+    );
+  });
+
+  it("handles batal in confirmUserByWaIdentity", async () => {
+    const session = {};
+
+    await userMenuHandlers.confirmUserByWaIdentity(
+      session,
+      chatId,
+      "batal",
+      waClient,
+      null,
+      null
+    );
+
+    expect(session.exit).toBe(true);
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
+    );
+  });
+
+  it("reminds available answers when confirmUserByWaIdentity receives unknown input", async () => {
+    const session = {};
+
+    await userMenuHandlers.confirmUserByWaIdentity(
+      session,
+      chatId,
+      "mungkin",
+      waClient,
+      null,
+      null
+    );
+
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.stringContaining("*batal* untuk menutup sesi.")
+    );
+  });
+
+  it("handles batal in confirmUserByWaUpdate", async () => {
+    const session = {};
+
+    await userMenuHandlers.confirmUserByWaUpdate(
+      session,
+      chatId,
+      "batal",
+      waClient,
+      null,
+      null
+    );
+
+    expect(session.exit).toBe(true);
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
+    );
+  });
+
+  it("reminds available answers when confirmUserByWaUpdate receives unknown input", async () => {
+    const session = {};
+
+    await userMenuHandlers.confirmUserByWaUpdate(
+      session,
+      chatId,
+      "mungkin",
+      waClient,
+      null,
+      null
+    );
+
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.stringContaining("*batal* untuk menutup sesi.")
+    );
+  });
+
+  it("handles batal in tanyaUpdateMyData", async () => {
+    const session = {};
+
+    await userMenuHandlers.tanyaUpdateMyData(
+      session,
+      chatId,
+      "batal",
+      waClient,
+      null,
+      null
+    );
+
+    expect(session.exit).toBe(true);
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      "Terima kasih. Sesi ditutup. Ketik *userrequest* untuk memulai lagi."
+    );
+  });
+
+  it("reminds available answers when tanyaUpdateMyData receives unknown input", async () => {
+    const session = {};
+
+    await userMenuHandlers.tanyaUpdateMyData(
+      session,
+      chatId,
+      "mungkin",
+      waClient,
+      null,
+      null
+    );
+
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      "Balas *ya* jika ingin update data, *tidak* untuk kembali, atau *batal* untuk menutup sesi."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- mention the *batal* option across user menu prompts and close sessions consistently when it is chosen
- expand user menu handlers to respond to *batal* inputs and update error messaging to cover all three choices
- add conversational flow tests that simulate the new *batal* handling paths

## Testing
- npm run lint
- npm test *(fails: existing suites such as tests/cronDirRequestEngageRank.test.js and tests/absensiKomentarDitbinmasReport.test.js fail and trigger OOM)*
- JWT_SECRET=test npm test -- userMenuHandlersFlow.test.js


------
https://chatgpt.com/codex/tasks/task_e_68cccdad12fc83278bb3a617f6ebca15