### PR TITLE
Add period filters for engagement ranking recap submenu

### DIFF
--- a/src/model/tiktokPostModel.js
+++ b/src/model/tiktokPostModel.js
@@ -83,6 +83,37 @@ export async function getPostsByClientId(client_id) {
 
 export const findByClientId = getPostsByClientId;
 
+export async function getPostsByClientAndDateRange(client_id, startDate, endDate) {
+  if (!client_id) return [];
+  if (!startDate || !endDate) return [];
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return [];
+  }
+
+  const [startBound, endBound] =
+    start <= end ? [start, end] : [end, start];
+
+  const startStr = startBound.toLocaleDateString('en-CA', {
+    timeZone: 'Asia/Jakarta'
+  });
+  const endStr = endBound.toLocaleDateString('en-CA', {
+    timeZone: 'Asia/Jakarta'
+  });
+
+  const normalizedId = normalizeClientId(client_id);
+  const res = await query(
+    `SELECT * FROM tiktok_post
+     WHERE LOWER(TRIM(client_id)) = $1
+       AND (created_at AT TIME ZONE 'Asia/Jakarta')::date BETWEEN $2::date AND $3::date
+     ORDER BY created_at DESC`,
+    [normalizedId, startStr, endStr]
+  );
+  return res.rows;
+}
+
 export async function countPostsByClient(
   client_id,
   periode = 'harian',


### PR DESCRIPTION
## Summary
- add a WhatsApp submenu for engagement ranking that lets users pick daily, weekly, or monthly recap periods and delivers the Excel file accordingly
- extend engagement ranking data collection to support date ranges, including new Instagram/TikTok queries and cron broadcast improvements
- update automated tests for the new submenu flow, period handling, and cron recipient behavior

## Testing
- npm run lint
- npm test -- dirRequestHandlers.test.js engagementRankingExcelService.test.js cronDirRequestEngageRank.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cccaa748d88327aa7fe9dcd82b2a63