### PR TITLE
Update NRP prompts for new user onboarding

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -76,7 +76,13 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
     session.step = "inputUserId";
     await waClient.sendMessage(
       chatId,
-      "Ketik NRP Anda untuk melihat data. (contoh: 75070206)"
+      [
+        "Untuk menampilkan data Anda, silakan ketik NRP Anda (hanya angka).",
+        "Ketik *batal* untuk keluar.",
+        "",
+        "Contoh:",
+        "87020990",
+      ].join("\n")
     );
   },
 

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -2201,8 +2201,9 @@ Ketik *angka* menu, atau *batal* untuk keluar.
         const msg =
           `${salam}! Nomor WhatsApp Anda belum terdaftar.` +
           clientInfoText +
-          "\n\nBalas pesan ini dengan memasukan NRP Anda," +
-          "\n\n*Contoh Pesan Balasan : 87020990*";
+          "\n\nUntuk menampilkan data Anda, balas dengan NRP (hanya angka)." +
+          "\nKetik *batal* untuk keluar." +
+          "\n\nContoh:\n87020990";
         await safeSendMessage(waClient, chatId, msg.trim());
         setMenuTimeout(chatId, waClient, true);
       }

--- a/tests/userMenuHandlersFlow.test.js
+++ b/tests/userMenuHandlersFlow.test.js
@@ -45,6 +45,26 @@ describe("userMenuHandlers conversational flow", () => {
     );
   });
 
+  it("informs unregistered users why NRP is needed and how to exit", async () => {
+    const session = {};
+    const userModel = {
+      findUserByWhatsApp: jest.fn().mockResolvedValue(null),
+    };
+
+    await userMenuHandlers.main(session, chatId, "", waClient, null, userModel);
+
+    expect(waClient.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      [
+        "Untuk menampilkan data Anda, silakan ketik NRP Anda (hanya angka).",
+        "Ketik *batal* untuk keluar.",
+        "",
+        "Contoh:",
+        "87020990",
+      ].join("\n")
+    );
+  });
+
   it("handles batal in confirmUserByWaIdentity", async () => {
     const session = {};
 


### PR DESCRIPTION
## Summary
- refresh the unregistered-user prompt in `userMenuHandlers.main` to explain why the NRP is needed, restrict input to digits, and add a clear *batal* escape instruction with a standalone sample number
- align the initial user menu template in `waService` with the same guidance so first-time chats show the updated instructions
- extend the menu handler flow test suite to cover the new prompt wording for users who are not yet bound to WhatsApp

## Testing
- npm run lint
- JWT_SECRET=test npm test -- userMenuHandlersFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cccec2c5d08327912cc66ae1097f40