### PR TITLE
Keep user menu session active on invalid NRP

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -169,7 +169,11 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
     try {
       const user = await userModel.findUserById(user_id);
       if (!user) {
-        await waClient.sendMessage(chatId, `❌ NRP *${user_id}* tidak ditemukan. Jika yakin benar, hubungi Opr Humas Polres Anda.`);
+        await waClient.sendMessage(
+          chatId,
+          `❌ NRP *${user_id}* tidak ditemukan. Jika yakin benar, hubungi Opr Humas Polres Anda.`
+        );
+        await waClient.sendMessage(chatId, "Silakan masukkan NRP lain atau ketik *batal* untuk keluar.");
       } else {
         session.step = "confirmBindUser";
         session.bindUserId = user_id;
@@ -183,9 +187,8 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
       }
     } catch (err) {
       await waClient.sendMessage(chatId, `❌ Gagal mengambil data: ${err.message}`);
+      await waClient.sendMessage(chatId, "Silakan masukkan NRP lain atau ketik *batal* untuk keluar.");
     }
-    session.exit = true;
-    await waClient.sendMessage(chatId, "Ketik *userrequest* untuk memulai lagi.");
   },
 
   confirmBindUser: async (session, chatId, text, waClient, pool, userModel) => {
@@ -233,9 +236,11 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
     }
     const user = await userModel.findUserById(nrp);
     if (!user) {
-      await waClient.sendMessage(chatId, `❌ NRP *${nrp}* tidak ditemukan. Jika yakin benar, hubungi Opr Humas Polres Anda.`);
-      session.exit = true;
-      await waClient.sendMessage(chatId, "Ketik *userrequest* untuk memulai lagi.");
+      await waClient.sendMessage(
+        chatId,
+        `❌ NRP *${nrp}* tidak ditemukan. Jika yakin benar, hubungi Opr Humas Polres Anda.`
+      );
+      await waClient.sendMessage(chatId, "Silakan masukkan NRP lain atau ketik *batal* untuk keluar.");
       return;
     }
     session.updateUserId = nrp;

--- a/tests/userMenuHandlersFlow.test.js
+++ b/tests/userMenuHandlersFlow.test.js
@@ -139,6 +139,64 @@ describe("userMenuHandlers conversational flow", () => {
     );
   });
 
+  it("keeps session active after inputUserId receives unknown NRP", async () => {
+    const session = { step: "inputUserId" };
+    const userModel = {
+      findUserById: jest.fn().mockResolvedValue(null),
+    };
+
+    await userMenuHandlers.inputUserId(
+      session,
+      chatId,
+      "123456",
+      waClient,
+      null,
+      userModel
+    );
+
+    expect(session.exit).toBeUndefined();
+    expect(session.step).toBe("inputUserId");
+    expect(waClient.sendMessage).toHaveBeenNthCalledWith(
+      1,
+      chatId,
+      "❌ NRP *123456* tidak ditemukan. Jika yakin benar, hubungi Opr Humas Polres Anda."
+    );
+    expect(waClient.sendMessage).toHaveBeenNthCalledWith(
+      2,
+      chatId,
+      "Silakan masukkan NRP lain atau ketik *batal* untuk keluar."
+    );
+  });
+
+  it("keeps session active after updateAskUserId receives unknown NRP", async () => {
+    const session = { step: "updateAskUserId" };
+    const userModel = {
+      findUserById: jest.fn().mockResolvedValue(null),
+    };
+
+    await userMenuHandlers.updateAskUserId(
+      session,
+      chatId,
+      "654321",
+      waClient,
+      null,
+      userModel
+    );
+
+    expect(session.exit).toBeUndefined();
+    expect(session.step).toBe("updateAskUserId");
+    expect(waClient.sendMessage).toHaveBeenNthCalledWith(
+      1,
+      chatId,
+      "❌ NRP *654321* tidak ditemukan. Jika yakin benar, hubungi Opr Humas Polres Anda."
+    );
+    expect(waClient.sendMessage).toHaveBeenNthCalledWith(
+      2,
+      chatId,
+      "Silakan masukkan NRP lain atau ketik *batal* untuk keluar."
+    );
+  });
+
   it("handles batal in tanyaUpdateMyData", async () => {
     const session = {};
 


### PR DESCRIPTION
## Summary
- keep inputUserId and updateAskUserId sessions active when an NRP lookup fails and re-prompt users to try again or cancel
- add follow-up guidance messages after lookup errors and data fetch failures
- add flow tests covering the unchanged session state when invalid NRP values are entered

## Testing
- npm run lint
- JWT_SECRET=dummy npm test -- userMenuHandlersFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ccd033ad1c8327bc19aa0f1030b96d