### PR TITLE
Adjust binding confirmation declines

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -211,11 +211,17 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
       return;
     }
     if (answer === "tidak") {
-      await waClient.sendMessage(chatId, "Baik, nomor tidak dihubungkan.");
+      await waClient.sendMessage(
+        chatId,
+        "Nomor WhatsApp ini tetap tidak terhubung dengan NRP. Jika ingin mencoba lagi, ketik *userrequest* atau hubungi operator bila membutuhkan bantuan."
+      );
       session.exit = true;
       return;
     }
-    await waClient.sendMessage(chatId, "Balas *ya* untuk menghubungkan nomor, atau *tidak* untuk membatalkan.");
+    await waClient.sendMessage(
+      chatId,
+      "Balas *ya* untuk menghubungkan nomor, atau *tidak* untuk membatalkan."
+    );
   },
 
   // --- Update User ID manual
@@ -269,11 +275,17 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
       return;
     }
     if (ans === "tidak") {
-      await waClient.sendMessage(chatId, "Proses update dibatalkan.");
+      await waClient.sendMessage(
+        chatId,
+        "Nomor WhatsApp ini tidak dihubungkan ke NRP. Ketik *userrequest* untuk kembali ke menu atau hubungi operator bila membutuhkan bantuan."
+      );
       session.exit = true;
       return;
     }
-    await waClient.sendMessage(chatId, "Balas *ya* untuk menghubungkan nomor, atau *tidak* untuk membatalkan.");
+    await waClient.sendMessage(
+      chatId,
+      "Balas *ya* untuk menghubungkan nomor, atau *tidak* untuk membatalkan."
+    );
   },
 
   // --- Pilih field update


### PR DESCRIPTION
## Summary
- update confirmBindUser to clarify decline response and point users to `userrequest` or operator support before closing the session
- update confirmBindUpdate decline message with guidance on next steps and ensure the session exits after the clarified closing message

## Testing
- npm run lint
- npm test *(fails: Jest workers exceeded retry limit / heap OOM in tests/userMenuHandlersFlow.test.js and tests/absensiKomentarDitbinmasReport.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd12c29e88327b3cf9bbbac8c8a2a