### PR TITLE
Improve update field guidance messages

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -333,6 +333,10 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
         // Simpan list pangkat di session agar bisa dipakai saat validasi
         session.availableTitles = sorted;
         await waClient.sendMessage(chatId, "Daftar pangkat yang dapat dipilih:\n" + msgList);
+        await waClient.sendMessage(
+          chatId,
+          "Balas dengan angka dari daftar atau ketik nama pangkat persis. Ketik *batal* untuk membatalkan."
+        );
       }
     }
     if (field === "satfung") {
@@ -350,6 +354,10 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
           chatId,
           "Daftar satfung yang dapat dipilih:\n" + msgList
         );
+        await waClient.sendMessage(
+          chatId,
+          "Balas dengan angka dari daftar atau ketik nama satfung persis. Ketik *batal* untuk membatalkan."
+        );
       }
     }
     session.step = "updateAskValue";
@@ -361,7 +369,7 @@ Balas *ya* jika benar, *tidak* jika bukan, atau *batal* untuk menutup sesi.
 
     await waClient.sendMessage(
       chatId,
-      `Ketik nilai baru untuk field *${allowedFields[idx].label}*${extra}:`
+      `Ketik nilai baru untuk field *${allowedFields[idx].label}*${extra}. Balas dengan angka atau nama pada daftar, atau ketik *batal* untuk membatalkan:`
     );
   },
 


### PR DESCRIPTION
## Summary
- add follow-up instruction after listing pangkat/satfung options so users know they can reply with numbers or exact names and may choose *batal*
- update the "Ketik nilai baru" prompt to reference replying with a number or name from the provided list

## Testing
- npm run lint
- JWT_SECRET=dummy NODE_OPTIONS=--max-old-space-size=4096 npm test *(fails: tests/absensiKomentarDitbinmasReport.test.js hit heap OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd1e1cb148327a078204ad7ba9f81