### PR TITLE
Avoid duplicate sosmed fetches in cron

### DIFF
--- a/src/cron/cronDirRequestFetchSosmed.js
+++ b/src/cron/cronDirRequestFetchSosmed.js
@@ -42,7 +42,10 @@ export async function runCron() {
     await handleFetchLikesInstagram(null, null, "DITBINMAS");
     await fetchAndStoreTiktokContent("DITBINMAS");
     await handleFetchKomentarTiktokBatch(null, null, "DITBINMAS");
-    const { text, igCount, tiktokCount } = await generateSosmedTaskMessage();
+    const { text, igCount, tiktokCount } = await generateSosmedTaskMessage("DITBINMAS", {
+      skipTiktokFetch: true,
+      skipLikesFetch: true,
+    });
     if (igCount !== lastIgCount || tiktokCount !== lastTiktokCount) {
       const recipients = getRecipients();
       for (const wa of recipients) {

--- a/tests/sosmedTask.test.js
+++ b/tests/sosmedTask.test.js
@@ -72,6 +72,8 @@ test('generateSosmedTaskMessage can skip internal fetches', async () => {
     skipLikesFetch: true,
   });
 
+  expect(mockGetShortcodesTodayByClient).toHaveBeenCalledWith('DITBINMAS');
+  expect(mockGetTiktokPostsToday).toHaveBeenCalledWith('DITBINMAS');
   expect(mockHandleFetchKomentarTiktokBatch).not.toHaveBeenCalled();
   expect(mockHandleFetchLikesInstagram).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- ensure the DIR request cron passes skip flags to generateSosmedTaskMessage after performing the manual fetch steps
- extend the sosmed task unit test to verify database reads still occur when skips are enabled

## Testing
- npm run lint
- npm test (fails: Jest worker child process exceptions in this environment)
- npm test -- tests/sosmedTask.test.js tests/cronDirRequestFetchSosmed.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ccd66b2ec08327bebbb9306be0531a