### PR TITLE
Improve engagement recap period labeling

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -34,7 +34,7 @@ const ENGAGEMENT_RECAP_PERIOD_MAP = {
   "1": {
     period: "today",
     label: "hari ini",
-    description: "Hari ini (fungsi seperti saat ini)",
+    description: "Hari ini",
   },
   "2": {
     period: "yesterday",
@@ -44,17 +44,17 @@ const ENGAGEMENT_RECAP_PERIOD_MAP = {
   "3": {
     period: "this_week",
     label: "minggu ini",
-    description: "Minggu ini (Senin - Minggu, minggu berjalan)",
+    description: "Minggu ini",
   },
   "4": {
     period: "last_week",
     label: "minggu sebelumnya",
-    description: "Minggu sebelumnya (Senin - Minggu)",
+    description: "Minggu sebelumnya",
   },
   "5": {
     period: "this_month",
     label: "bulan ini",
-    description: "Bulan ini (bulan berjalan)",
+    description: "Bulan ini",
   },
   "6": {
     period: "last_month",

--- a/tests/engagementRankingExcelService.test.js
+++ b/tests/engagementRankingExcelService.test.js
@@ -212,7 +212,9 @@ describe('engagementRankingExcelService', () => {
     expect(mockMkdir).toHaveBeenCalled();
     expect(mockWriteFile).toHaveBeenCalled();
     expect(filePath).toBeTruthy();
-    expect(fileName).toMatch(/Rekap_Ranking_Engagement_\d{4}-\d{2}-\d{2}_\d{4}\.xlsx$/);
+    expect(fileName).toMatch(
+      /Rekap_Ranking_Engagement_Tanggal_\d{4}-\d{2}-\d{2}_\d{4}-\d{2}-\d{2}_\d{4}\.xlsx$/
+    );
   });
 
   test('saveEngagementRankingExcel supports weekly period label', async () => {
@@ -238,7 +240,10 @@ describe('engagementRankingExcelService', () => {
     expect(lastPostCall[2]).toBe('2024-06-09');
 
     const aoa = mockAoAToSheet.mock.calls.at(-1)[0];
-    expect(aoa[1][0]).toMatch(/Periode Data:/);
+    expect(aoa[1][0]).toMatch(/Minggu ke-/);
+
+    const savedPath = mockWriteFile.mock.calls.at(-1)[1];
+    expect(savedPath).toContain("Minggu_");
   });
 
   test('collectEngagementRanking rejects for non directorate client', async () => {


### PR DESCRIPTION
## Summary
- update the engagement recap menu options to use the simplified period descriptions requested
- include week numbers/date ranges or month headers in the engagement ranking Excel headers and filenames
- extend the engagement ranking Excel service tests to cover the new header and filename expectations

## Testing
- npm run lint
- npm test *(fails: Jest worker encountered child process exceptions and exceeded retry limit in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdeb7241c8327b99d01591ee8dfd9