### PR TITLE
Include polres name in user identity summaries

### DIFF
--- a/src/handler/menu/userMenuHandlers.js
+++ b/src/handler/menu/userMenuHandlers.js
@@ -12,9 +12,11 @@ function ignore(..._args) {}
 
 // --- Helper Format Pesan ---
 function formatUserReport(user) {
+  const polresName = user.client_name || user.client_id || "-";
   return [
     "👤 *Identitas Anda*",
     "",
+    `*Nama Polres*: ${polresName}`,
     `*Nama*     : ${user.nama || "-"}`,
     `*Pangkat*  : ${user.title || "-"}`,
     `*NRP/NIP*  : ${user.user_id || "-"}`,

--- a/src/model/userModel.js
+++ b/src/model/userModel.js
@@ -447,7 +447,7 @@ export async function getUsersByDirektorat(flag, clientId = null) {
 export async function findUserByInsta(insta) {
   if (!insta) return null;
   const { rows } = await query(
-      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE LOWER(u.insta) = LOWER($1)\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      c.nama AS client_name,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN clients c ON c.client_id = u.client_id\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE LOWER(u.insta) = LOWER($1)\n     GROUP BY u.user_id, c.nama`,
     [insta]
   );
   return rows[0];
@@ -456,7 +456,7 @@ export async function findUserByInsta(insta) {
 export async function findUserByWhatsApp(wa) {
   if (!wa) return null;
   const { rows } = await query(
-      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.whatsapp = $1\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      c.nama AS client_name,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN clients c ON c.client_id = u.client_id\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.whatsapp = $1\n     GROUP BY u.user_id, c.nama`,
     [wa]
   );
   return rows[0];
@@ -466,7 +466,7 @@ export async function findUserByIdAndWhatsApp(userId, wa) {
   if (!userId || !wa) return null;
   const uid = normalizeUserId(userId);
   const { rows } = await query(
-      `SELECT u.*,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id = $1 AND u.whatsapp = $2\n     GROUP BY u.user_id`,
+      `SELECT u.*,\n      c.nama AS client_name,\n      bool_or(r.role_name='ditbinmas') AS ditbinmas,\n      bool_or(r.role_name='ditlantas') AS ditlantas,\n      bool_or(r.role_name='bidhumas') AS bidhumas,\n      bool_or(r.role_name='operator') AS operator\n     FROM "user" u\n     LEFT JOIN clients c ON c.client_id = u.client_id\n     LEFT JOIN user_roles ur ON u.user_id = ur.user_id\n     LEFT JOIN roles r ON ur.role_id = r.role_id\n     WHERE u.user_id = $1 AND u.whatsapp = $2\n     GROUP BY u.user_id, c.nama`,
     [uid, wa]
   );
   return rows[0];

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -107,8 +107,10 @@ const responseDelayMs = 800;
 
 // Helper ringkas untuk menampilkan data user
 function formatUserSummary(user) {
+  const polresName = user.client_name || user.client_id || "-";
   return (
     "👤 *Identitas Anda*\n" +
+    `*Nama Polres*: ${polresName}\n` +
     `*Nama*     : ${user.nama || "-"}\n` +
     `*Pangkat*  : ${user.title || "-"}\n` +
     `*NRP/NIP*  : ${user.user_id || "-"}\n` +


### PR DESCRIPTION
## Summary
- include the user's polres information ahead of the name in both interactive identity summaries and WhatsApp replies
- load the associated client name when looking up a user so the formatted message can display a readable polres label

## Testing
- npm run lint
- npm test *(fails: Jest worker encountered child process exceptions due to missing env configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cce6734554832793ab875f72cf632c