### PR TITLE
Add TikTok comment recap Excel option to DirRequest menu

### DIFF
--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -785,7 +785,26 @@ async function performAction(
         msg = "✅ File Excel dikirim.";
         break;
       }
-    case "19": {
+      case "19": {
+        const recapData = await collectKomentarRecap(clientId);
+        if (!recapData?.videoIds?.length) {
+          msg = `Tidak ada konten TikTok untuk *${clientId}* hari ini.`;
+          break;
+        }
+        const filePath = await saveCommentRecapExcel(recapData, clientId);
+        const buffer = await readFile(filePath);
+        await sendWAFile(
+          waClient,
+          buffer,
+          basename(filePath),
+          chatId,
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        );
+        await unlink(filePath);
+        msg = "✅ File Excel dikirim.";
+        break;
+      }
+      case "20": {
         const dirPath = "laphar";
         await mkdir(dirPath, { recursive: true });
         const [ig, tt] = await Promise.all([lapharDitbinmas(), lapharTiktokDitbinmas()]);
@@ -821,7 +840,7 @@ async function performAction(
         }
         return;
       }
-      case "21": {
+      case "22": {
         let filePath;
         try {
           filePath = await saveWeeklyLikesRecapExcel(clientId);
@@ -846,7 +865,7 @@ async function performAction(
         }
         break;
       }
-      case "22": {
+      case "23": {
         let filePath;
         try {
           filePath = await saveWeeklyCommentRecapExcel(clientId);
@@ -871,7 +890,7 @@ async function performAction(
         }
         break;
       }
-      case "23": {
+      case "24": {
         let filePath;
         try {
           filePath = await saveMonthlyLikesRecapExcel(clientId);
@@ -995,13 +1014,14 @@ export const dirRequestHandlers = {
         "1️⃣6️⃣ Laporan harian Instagram Ditbinmas\n" +
         "1️⃣7️⃣ Laporan harian TikTok Ditbinmas\n" +
         "1️⃣8️⃣ Rekap like Instagram (Excel)\n" +
-        "1️⃣9️⃣ Rekap gabungan semua sosmed\n" +
-        "2️⃣0️⃣ Rekap ranking engagement jajaran\n\n" +
+        "1️⃣9️⃣ Rekap komentar TikTok (Excel)\n" +
+        "2️⃣0️⃣ Rekap gabungan semua sosmed\n" +
+        "2️⃣1️⃣ Rekap ranking engagement jajaran\n\n" +
         "📆 *Laporan Mingguan*\n" +
-        "2️⃣1️⃣ Rekap file Instagram mingguan\n" +
-        "2️⃣2️⃣ Rekap file Tiktok mingguan\n\n" +
+        "2️⃣2️⃣ Rekap file Instagram mingguan\n" +
+        "2️⃣3️⃣ Rekap file Tiktok mingguan\n\n" +
         "🗓️ *Laporan Bulanan*\n" +
-        "2️⃣3️⃣ Rekap file Instagram bulanan\n\n" +
+        "2️⃣4️⃣ Rekap file Instagram bulanan\n\n" +
         "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n" +
         "Ketik *angka* menu atau *batal* untuk keluar.";
     await waClient.sendMessage(chatId, menu);
@@ -1046,6 +1066,7 @@ export const dirRequestHandlers = {
           "21",
           "22",
           "23",
+          "24",
         ].includes(choice)
     ) {
       await waClient.sendMessage(chatId, "Pilihan tidak valid. Ketik angka menu.");
@@ -1060,7 +1081,7 @@ export const dirRequestHandlers = {
     }
     const taskClientId = session.dir_client_id || userClientId;
 
-    if (choice === "20") {
+    if (choice === "21") {
       session.step = "choose_engagement_recap_period";
       await waClient.sendMessage(chatId, ENGAGEMENT_RECAP_MENU_TEXT);
       return;

--- a/tests/cronDirRequestEngageRank.test.js
+++ b/tests/cronDirRequestEngageRank.test.js
@@ -3,6 +3,8 @@ import { tmpdir } from 'os';
 import { join, basename } from 'path';
 import { writeFile, access } from 'fs/promises';
 
+process.env.DIRREQUEST_ENGAGE_RANK_RECIPIENT = '6281234560377@c.us';
+
 const mockSaveEngagementRankingExcel = jest.fn();
 const mockSafeSendMessage = jest.fn();
 const mockSendWAFile = jest.fn();

--- a/tests/dirRequestHandlers.test.js
+++ b/tests/dirRequestHandlers.test.js
@@ -705,7 +705,52 @@ test('choose_menu option 18 generates likes recap excel and sends file', async (
   );
 });
 
-test('choose_menu option 20 opens engagement recap submenu', async () => {
+test('choose_menu option 19 generates TikTok comment recap excel and sends file', async () => {
+  mockCollectKomentarRecap.mockResolvedValue({ videoIds: ['vid1'] });
+  mockSaveCommentRecapExcel.mockResolvedValue('/tmp/tiktok.xlsx');
+  mockReadFile.mockResolvedValue(Buffer.from('excel'));
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '778';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '19', waClient);
+
+  expect(mockCollectKomentarRecap).toHaveBeenCalledWith('ditbinmas');
+  expect(mockSaveCommentRecapExcel).toHaveBeenCalledWith({ videoIds: ['vid1'] }, 'ditbinmas');
+  expect(mockReadFile).toHaveBeenCalledWith('/tmp/tiktok.xlsx');
+  expect(mockSendWAFile).toHaveBeenCalledWith(
+    waClient,
+    expect.any(Buffer),
+    path.basename('/tmp/tiktok.xlsx'),
+    chatId,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  expect(mockUnlink).toHaveBeenCalledWith('/tmp/tiktok.xlsx');
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('File Excel dikirim')
+  );
+});
+
+test('choose_menu option 19 reports no TikTok content when recap empty', async () => {
+  mockCollectKomentarRecap.mockResolvedValue({ videoIds: [] });
+  const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
+  const chatId = '779';
+  const waClient = { sendMessage: jest.fn() };
+
+  await dirRequestHandlers.choose_menu(session, chatId, '19', waClient);
+
+  expect(mockSaveCommentRecapExcel).not.toHaveBeenCalled();
+  expect(mockReadFile).not.toHaveBeenCalled();
+  expect(mockSendWAFile).not.toHaveBeenCalled();
+  expect(mockUnlink).not.toHaveBeenCalled();
+  expect(waClient.sendMessage).toHaveBeenCalledWith(
+    chatId,
+    expect.stringContaining('Tidak ada konten TikTok')
+  );
+});
+
+test('choose_menu option 21 opens engagement recap submenu', async () => {
   const session = {
     selectedClientId: 'ditbinmas',
     clientName: 'DIT BINMAS',
@@ -714,7 +759,7 @@ test('choose_menu option 20 opens engagement recap submenu', async () => {
   const chatId = '788';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '20', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
 
   expect(session.step).toBe('choose_engagement_recap_period');
   expect(mockSaveEngagementRankingExcel).not.toHaveBeenCalled();
@@ -827,14 +872,14 @@ test('choose_engagement_recap_period mengingatkan saat pilihan tidak valid', asy
   );
 });
 
-test('choose_menu option 21 generates weekly likes recap excel and sends file', async () => {
+test('choose_menu option 22 generates weekly likes recap excel and sends file', async () => {
   mockSaveWeeklyLikesRecapExcel.mockResolvedValue('/tmp/weekly.xlsx');
   mockReadFile.mockResolvedValue(Buffer.from('excel'));
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '790';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '22', waClient);
 
   expect(mockSaveWeeklyLikesRecapExcel).toHaveBeenCalledWith('ditbinmas');
   expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly.xlsx');
@@ -852,13 +897,13 @@ test('choose_menu option 21 generates weekly likes recap excel and sends file', 
   );
 });
 
-test('choose_menu option 21 sends no data message when service returns null', async () => {
+test('choose_menu option 22 sends no data message when service returns null', async () => {
   mockSaveWeeklyLikesRecapExcel.mockResolvedValue(null);
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '791';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '21', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '22', waClient);
 
   expect(mockReadFile).not.toHaveBeenCalled();
   expect(mockSendWAFile).not.toHaveBeenCalled();
@@ -869,14 +914,14 @@ test('choose_menu option 21 sends no data message when service returns null', as
   );
 });
 
-test('choose_menu option 22 generates weekly comment recap excel and sends file', async () => {
+test('choose_menu option 23 generates weekly comment recap excel and sends file', async () => {
   mockSaveWeeklyCommentRecapExcel.mockResolvedValue('/tmp/weekly-comments.xlsx');
   mockReadFile.mockResolvedValue(Buffer.from('excel'));
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '792';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '22', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '23', waClient);
 
   expect(mockSaveWeeklyCommentRecapExcel).toHaveBeenCalledWith('ditbinmas');
   expect(mockReadFile).toHaveBeenCalledWith('/tmp/weekly-comments.xlsx');
@@ -894,13 +939,13 @@ test('choose_menu option 22 generates weekly comment recap excel and sends file'
   );
 });
 
-test('choose_menu option 22 sends no data message when service returns null', async () => {
+test('choose_menu option 23 sends no data message when service returns null', async () => {
   mockSaveWeeklyCommentRecapExcel.mockResolvedValue(null);
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '792';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '22', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '23', waClient);
 
   expect(mockReadFile).not.toHaveBeenCalled();
   expect(mockSendWAFile).not.toHaveBeenCalled();
@@ -911,14 +956,14 @@ test('choose_menu option 22 sends no data message when service returns null', as
   );
 });
 
-test('choose_menu option 23 generates monthly likes recap excel and sends file', async () => {
+test('choose_menu option 24 generates monthly likes recap excel and sends file', async () => {
   mockSaveMonthlyLikesRecapExcel.mockResolvedValue('/tmp/monthly.xlsx');
   mockReadFile.mockResolvedValue(Buffer.from('excel'));
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '991';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '23', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '24', waClient);
 
   expect(mockSaveMonthlyLikesRecapExcel).toHaveBeenCalledWith('ditbinmas');
   expect(mockReadFile).toHaveBeenCalledWith('/tmp/monthly.xlsx');
@@ -936,13 +981,13 @@ test('choose_menu option 23 generates monthly likes recap excel and sends file',
   );
 });
 
-test('choose_menu option 23 reports no data when service returns null', async () => {
+test('choose_menu option 24 reports no data when service returns null', async () => {
   mockSaveMonthlyLikesRecapExcel.mockResolvedValue(null);
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '992';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '23', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '24', waClient);
 
   expect(mockReadFile).not.toHaveBeenCalled();
   expect(mockSendWAFile).not.toHaveBeenCalled();
@@ -953,12 +998,12 @@ test('choose_menu option 23 reports no data when service returns null', async ()
   );
 });
 
-test('choose_menu option 24 is no longer available', async () => {
+test('choose_menu option 25 is no longer available', async () => {
   const session = { selectedClientId: 'ditbinmas', clientName: 'DIT BINMAS' };
   const chatId = '993';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '24', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '25', waClient);
 
   expect(mockSaveMonthlyCommentRecapExcel).not.toHaveBeenCalled();
   expect(mockReadFile).not.toHaveBeenCalled();
@@ -970,7 +1015,7 @@ test('choose_menu option 24 is no longer available', async () => {
   );
 });
 
-test('choose_menu option 19 sends combined sosmed recap and files', async () => {
+test('choose_menu option 20 sends combined sosmed recap and files', async () => {
   mockLapharDitbinmas.mockResolvedValue({
     text: 'ig',
     filename: 'ig.txt',
@@ -994,7 +1039,7 @@ test('choose_menu option 19 sends combined sosmed recap and files', async () => 
   const chatId = '888';
   const waClient = { sendMessage: jest.fn() };
 
-  await dirRequestHandlers.choose_menu(session, chatId, '19', waClient);
+  await dirRequestHandlers.choose_menu(session, chatId, '20', waClient);
 
   expect(mockLapharDitbinmas).toHaveBeenCalled();
   expect(mockLapharTiktokDitbinmas).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- insert a dedicated menu entry for generating TikTok comment recap Excel files and renumber downstream options
- extend validation and switch logic to handle the new numbering, including a new action that exports/returns the TikTok recap file
- update associated Jest suites to reflect the new numbering, cover the TikTok recap behavior, and lock in the cron recipient env override

## Testing
- npm run lint
- npm test -- --runTestsByPath tests/dirRequestHandlers.test.js tests/cronDirRequestEngageRank.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce21ef0a908327a9c469e7ea374aec