### PR TITLE
feat: highlight new sosmed tasks

### DIFF
--- a/src/cron/cronDirRequestFetchSosmed.js
+++ b/src/cron/cronDirRequestFetchSosmed.js
@@ -16,6 +16,8 @@ const DIRREQUEST_GROUP = "120363419830216549@g.us";
 
 let lastIgCount = null;
 let lastTiktokCount = null;
+let lastIgShortcodes = [];
+let lastTiktokVideoIds = [];
 
 async function initializeLastCounts() {
   lastIgCount = await getInstaPostCount("DITBINMAS");
@@ -42,9 +44,13 @@ export async function runCron() {
     await handleFetchLikesInstagram(null, null, "DITBINMAS");
     await fetchAndStoreTiktokContent("DITBINMAS");
     await handleFetchKomentarTiktokBatch(null, null, "DITBINMAS");
-    const { text, igCount, tiktokCount } = await generateSosmedTaskMessage("DITBINMAS", {
+    const { text, igCount, tiktokCount, state } = await generateSosmedTaskMessage("DITBINMAS", {
       skipTiktokFetch: true,
       skipLikesFetch: true,
+      previousState: {
+        igShortcodes: lastIgShortcodes,
+        tiktokVideoIds: lastTiktokVideoIds,
+      },
     });
     if (igCount !== lastIgCount || tiktokCount !== lastTiktokCount) {
       const recipients = getRecipients();
@@ -57,6 +63,8 @@ export async function runCron() {
       });
       lastIgCount = igCount;
       lastTiktokCount = tiktokCount;
+      lastIgShortcodes = state?.igShortcodes ?? lastIgShortcodes;
+      lastTiktokVideoIds = state?.tiktokVideoIds ?? lastTiktokVideoIds;
     }
   } catch (err) {
     sendDebug({


### PR DESCRIPTION
## Summary
- track previously sent Instagram shortcodes and TikTok video IDs inside the Ditbinmas sosmed cron
- enrich sosmed task messages with numbering, upload times, and [BARU] tags for new content while returning the updated state
- expand cron and sosmed task tests to cover the new state handling and messaging format

## Testing
- npm run lint
- npm test -- sosmedTask.test.js
- npm test -- cronDirRequestFetchSosmed.test.js
- npm test *(fails: Jest worker OOM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c993b3008327928bd5ec8e9c2b04