### PR TITLE
Simplify dirrequest client selection

### DIFF
--- a/src/cron/cronDirRequestEngageRank.js
+++ b/src/cron/cronDirRequestEngageRank.js
@@ -10,7 +10,24 @@ import { saveEngagementRankingExcel } from "../service/engagementRankingExcelSer
 import { safeSendMessage, sendWAFile } from "../utils/waHelper.js";
 import { sendDebug } from "../middleware/debugHandler.js";
 
-const RECIPIENT = process.env.DIRREQUEST_ENGAGE_RANK_RECIPIENT || "08127309190@c.us";
+const DEFAULT_RECIPIENT = "08127309190@c.us";
+const rawRecipient = process.env.DIRREQUEST_ENGAGE_RANK_RECIPIENT;
+const RECIPIENT = (() => {
+  if (typeof rawRecipient !== "string") {
+    return DEFAULT_RECIPIENT;
+  }
+  const trimmed = rawRecipient.trim();
+  if (!trimmed) {
+    return DEFAULT_RECIPIENT;
+  }
+  if (trimmed.endsWith("@g.us")) {
+    return trimmed;
+  }
+  if (trimmed.endsWith("@c.us") && trimmed.startsWith("081")) {
+    return trimmed;
+  }
+  return DEFAULT_RECIPIENT;
+})();
 const CLIENT_ID = "DITBINMAS";
 const ROLE_FLAG = "ditbinmas";
 
@@ -59,9 +76,7 @@ function buildNarrative(now = getJakartaDate()) {
 
 export async function runCron({ recipients } = {}) {
   const targetRecipients =
-    Array.isArray(recipients) && recipients.length
-      ? recipients
-      : [RECIPIENT];
+    Array.isArray(recipients) && recipients.length ? recipients : [RECIPIENT];
 
   sendDebug({
     tag: "CRON DIRREQ ENGAGE RANK",

--- a/src/handler/menu/dirRequestHandlers.js
+++ b/src/handler/menu/dirRequestHandlers.js
@@ -962,36 +962,16 @@ async function performAction(
   }
 
 export const dirRequestHandlers = {
-  async choose_dash_user(session, chatId, text, waClient) {
+  async choose_dash_user(session, chatId, _text, waClient) {
     const dashUsers = session.dash_users || [];
-    if (!text) {
-      const list = await Promise.all(
-        dashUsers.map(async (u, idx) => {
-          let cid = u.client_ids[0];
-          let c = cid ? await findClientById(cid) : null;
-          if (!cid || c?.client_type?.toLowerCase() === "direktorat") {
-            cid = u.role;
-            c = await findClientById(cid);
-          }
-          const name = (c?.nama || cid).toUpperCase();
-          return `${idx + 1}. ${name} (${cid.toUpperCase()})`;
-        })
-      );
+    const chosen = dashUsers[0];
+    if (!chosen) {
       await waClient.sendMessage(
         chatId,
-        `Pilih Client:\n${list.join("\n")}\n\nBalas angka untuk memilih atau *batal* untuk keluar.`
+        "❌ Data dashboard user tidak ditemukan untuk akses dirrequest."
       );
       return;
     }
-    const idx = parseInt(text.trim(), 10) - 1;
-    if (isNaN(idx) || idx < 0 || idx >= dashUsers.length) {
-      await waClient.sendMessage(
-        chatId,
-        "Pilihan client tidak valid. Balas angka yang tersedia."
-      );
-      return;
-    }
-    const chosen = dashUsers[idx];
     session.role = chosen.role;
     session.client_ids = [DITBINMAS_CLIENT_ID];
     session.dir_client_id = DITBINMAS_CLIENT_ID;

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -661,17 +661,8 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
       );
       return;
     }
-    if (validUsers.length === 1) {
+    if (validUsers.length >= 1) {
       const du = validUsers[0];
-      let dirClientId = null;
-      try {
-        const roleClient = await clientService.findClientById(du.role);
-        if (roleClient?.client_type?.toLowerCase() === "direktorat") {
-          dirClientId = du.role;
-        }
-      } catch (e) {
-        // ignore lookup errors and fallback to dashboard user client_ids
-      }
       const defaultClientId = "DITBINMAS";
       let defaultClientName = defaultClientId;
       try {
@@ -695,18 +686,6 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
       await dirRequestHandlers.main(getSession(chatId), chatId, "", waClient);
       return;
     }
-    setSession(chatId, {
-      menu: "dirrequest",
-      step: "choose_dash_user",
-      dash_users: validUsers,
-    });
-    await dirRequestHandlers.choose_dash_user(
-      getSession(chatId),
-      chatId,
-      "",
-      waClient
-    );
-    return;
   }
 
   // -- Routing semua step session clientrequest ke handler step terkait --


### PR DESCRIPTION
## Summary
- bypass the manual client-selection prompt for the dirrequest menu and always initialise the session with DITBINMAS
- adjust the dirrequest multi-user handler to auto-select the first dashboard user while keeping the DITBINMAS context
- harden the engage rank cron recipient handling so it falls back to the default number when the configured ID is not an 081... user or a group

## Testing
- npm run lint
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d14089499483278583debbc996bb1f