### PR TITLE
Allow Ditbinmas command to open Wabot menu

### DIFF
--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -708,7 +708,11 @@ Ketik *angka menu* di atas, atau *batal* untuk keluar.
   }
 
   const normalizedWabotCmd = text.toLowerCase().replace(/\s+/g, "");
-  if (normalizedWabotCmd === "wabot" || normalizedWabotCmd === "wabotditbinmas") {
+  if (
+    normalizedWabotCmd === "wabot" ||
+    normalizedWabotCmd === "wabotditbinmas" ||
+    normalizedWabotCmd === "ditbinmas"
+  ) {
     const waId =
       userWaNum.startsWith("62")
         ? userWaNum


### PR DESCRIPTION
## Summary
- allow the Ditbinmas keyword to trigger the Wabot Ditbinmas menu so users can access it with the expected command

## Testing
- npm run lint
- npm test *(fails: Jest worker encountered child process exceptions during test execution in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d282063a448327844898f363481264