### PR TITLE
Improve Instagram likes recap payload for richer UI

### DIFF
--- a/docs/instaRekapLikesApi.md
+++ b/docs/instaRekapLikesApi.md
@@ -7,8 +7,33 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
 ```
 {
   "success": true,
-  "data": [ /* user like rows */ ],
-  "chartHeight": 300,
+  "data": [
+    {
+      "user_id": "U-01",
+      "nama": "Alice",
+      "username": "alice",
+      "jumlah_like": 4,
+      "ranking": 1,
+      "completionRate": 1,
+      "completionPercentage": 100,
+      "missingLikes": 0,
+      "status": "complete",
+      "badges": ["✅ Semua konten pada periode ini sudah di-like."]
+    },
+    {
+      "user_id": "U-02",
+      "nama": "Bob",
+      "username": "bob",
+      "jumlah_like": 1,
+      "ranking": 2,
+      "completionRate": 0.25,
+      "completionPercentage": 25,
+      "missingLikes": 3,
+      "status": "needs_attention",
+      "badges": ["⚠️ Kurang dari 50% konten yang sudah di-like."]
+    }
+  ],
+  "chartHeight": 320,
   "totalPosts": 4,
   "sudahUsers": ["alice"],
   "kurangUsers": ["bob"],
@@ -17,16 +42,58 @@ The `getInstaRekapLikes` endpoint returns Instagram like summaries for a client.
   "kurangUsersCount": 1,
   "belumUsersCount": 2,
   "noUsernameUsersCount": 1,
-  "usersCount": 4
+  "usersCount": 4,
+  "targetLikesPerUser": 2,
+  "summary": {
+    "totalPosts": 4,
+    "totalUsers": 4,
+    "targetOnTrackLikes": 2,
+    "totalLikes": 5,
+    "averageCompletionPercentage": 41.7,
+    "participationRatePercentage": 66.7,
+    "distribution": {
+      "complete": 1,
+      "onTrack": 0,
+      "needsAttention": 1,
+      "notStarted": 1,
+      "noUsername": 1,
+      "noPosts": 0
+    }
+  },
+  "chartData": [
+    { "label": "Alice", "likes": 4, "missingLikes": 0, "completionPercentage": 100 },
+    { "label": "Bob", "likes": 1, "missingLikes": 3, "completionPercentage": 25 }
+  ],
+  "insights": [
+    "✅ 1 akun telah mencapai target minimal 50% like.",
+    "⚠️ 1 akun perlu perhatian karena belum mencapai 50% like.",
+    "⏳ 1 akun belum memberikan like sama sekali.",
+    "❗ 1 akun belum memiliki username Instagram."
+  ],
+  "statusLegend": [
+    { "status": "complete", "label": "Complete", "description": "Semua konten pada periode ini telah di-like." },
+    { "status": "on_track", "label": "On Track", "description": "Minimal 50% konten sudah di-like." },
+    { "status": "needs_attention", "label": "Needs Attention", "description": "Sudah melakukan like tetapi belum mencapai 50% konten." },
+    { "status": "not_started", "label": "Not Started", "description": "Belum memberikan like pada periode ini." },
+    { "status": "no_username", "label": "No Username", "description": "Belum memiliki username Instagram di sistem." },
+    { "status": "no_posts", "label": "No Posts", "description": "Tidak ada konten untuk periode yang dipilih." }
+  ],
+  "noUsernameUsersDetails": [
+    { "userId": "U-04", "name": "Diana", "division": "Bidang", "clientId": "ditbinmas" }
+  ]
 }
 ```
 
-- **sudahUsers** – usernames that liked at least 50% of posts.
-- **kurangUsers** – usernames that liked some posts but less than 50%.
-- **belumUsers** – usernames that did not like any posts.
-- **belumUsersCount** – users who did not like any posts **or** have no Instagram username.
-- **noUsernameUsersCount** – number of users without an Instagram username.
-- **usersCount** – total number of users returned in `data`.
+- **data** – daftar pengguna dengan metrik tambahan untuk mempermudah pembuatan UI (status, persentase capaian, lencana penjelas).
+- **sudahUsers / kurangUsers / belumUsers** – daftar username untuk filter cepat di UI.
+- **belumUsersCount** – jumlah akun yang belum memberi like **ditambah** akun tanpa username Instagram.
+- **noUsernameUsersCount** – jumlah akun tanpa username; detail tambahan ada di `noUsernameUsersDetails`.
+- **targetLikesPerUser** – ambang minimal like (50% dari total konten) untuk dinyatakan “on track”.
+- **summary** – ringkasan agregat yang bisa ditampilkan sebagai kartu KPI.
+- **chartData** – data siap pakai untuk grafik stacked bar/polar chart (likes vs kekurangan).
+- **insights** – teks rekomendasi yang bisa langsung ditampilkan sebagai highlight.
+- **statusLegend** – legenda status supaya warna/ikon di UI konsisten.
+- **noUsernameUsersDetails** – daftar akun yang perlu dibantu melengkapi username Instagram.
 
 ### Directorate Clients
 

--- a/src/controller/instaController.js
+++ b/src/controller/instaController.js
@@ -14,6 +14,7 @@ import * as instaPostCacheService from "../service/instaPostCacheService.js";
 import * as profileCache from "../service/profileCacheService.js";
 import { sendSuccess } from "../utils/response.js";
 import { sendConsoleDebug } from "../middleware/debugHandler.js";
+import { formatLikesRecapResponse } from "../utils/likesRecapFormatter.js";
 
 export async function getInstaRekapLikes(req, res) {
   let client_id = req.query.client_id;
@@ -68,42 +69,12 @@ export async function getInstaRekapLikes(req, res) {
       endDate,
       role
     );
-    const length = Array.isArray(rows) ? rows.length : 0;
-    const chartHeight = Math.max(length * 30, 300);
 
-    const threshold = Math.ceil(totalKonten * 0.5);
-    const sudahUsers = [];
-    const kurangUsers = [];
-    const belumUsers = [];
-    const noUsernameUsers = [];
-
-    rows.forEach((u) => {
-      if (!u.username || u.username.trim() === "") {
-        noUsernameUsers.push(u.username);
-      } else if (u.jumlah_like >= threshold) {
-        sudahUsers.push(u.username);
-      } else if (u.jumlah_like > 0) {
-        kurangUsers.push(u.username);
-      } else {
-        belumUsers.push(u.username);
-      }
-    });
-
-    const belumUsersCount = belumUsers.length + noUsernameUsers.length;
+    const payload = formatLikesRecapResponse(rows, totalKonten);
 
     res.json({
       success: true,
-      data: rows,
-      chartHeight,
-      totalPosts: totalKonten,
-      sudahUsers,
-      kurangUsers,
-      belumUsers,
-      sudahUsersCount: sudahUsers.length,
-      kurangUsersCount: kurangUsers.length,
-      belumUsersCount,
-      noUsernameUsersCount: noUsernameUsers.length,
-      usersCount: length,
+      ...payload,
     });
   } catch (err) {
     sendConsoleDebug({ tag: "INSTA", msg: `Error getInstaRekapLikes: ${err.message}` });

--- a/src/controller/likesController.js
+++ b/src/controller/likesController.js
@@ -1,5 +1,6 @@
 import { getRekapLikesByClient } from "../model/instaLikeModel.js";
 import { sendConsoleDebug } from "../middleware/debugHandler.js";
+import { formatLikesRecapResponse } from "../utils/likesRecapFormatter.js";
 
 export async function getDitbinmasLikes(req, res) {
   const periode = req.query.periode || "harian";
@@ -17,42 +18,12 @@ export async function getDitbinmasLikes(req, res) {
       endDate,
       "ditbinmas"
     );
-    const length = Array.isArray(rows) ? rows.length : 0;
-    const chartHeight = Math.max(length * 30, 300);
 
-    const threshold = Math.ceil(totalKonten * 0.5);
-    const sudahUsers = [];
-    const kurangUsers = [];
-    const belumUsers = [];
-    const noUsernameUsers = [];
-
-    rows.forEach((u) => {
-      if (!u.username || u.username.trim() === "") {
-        noUsernameUsers.push(u.username);
-      } else if (u.jumlah_like >= threshold) {
-        sudahUsers.push(u.username);
-      } else if (u.jumlah_like > 0) {
-        kurangUsers.push(u.username);
-      } else {
-        belumUsers.push(u.username);
-      }
-    });
-
-    const belumUsersCount = belumUsers.length + noUsernameUsers.length;
+    const payload = formatLikesRecapResponse(rows, totalKonten);
 
     res.json({
       success: true,
-      data: rows,
-      chartHeight,
-      totalPosts: totalKonten,
-      sudahUsers,
-      kurangUsers,
-      belumUsers,
-      sudahUsersCount: sudahUsers.length,
-      kurangUsersCount: kurangUsers.length,
-      belumUsersCount,
-      noUsernameUsersCount: noUsernameUsers.length,
-      usersCount: length,
+      ...payload,
     });
   } catch (err) {
     sendConsoleDebug({ tag: "LIKES", msg: `Error getDitbinmasLikes: ${err.message}` });

--- a/src/utils/likesRecapFormatter.js
+++ b/src/utils/likesRecapFormatter.js
@@ -1,0 +1,260 @@
+// src/utils/likesRecapFormatter.js
+/**
+ * Format likes recap data into a richer payload that frontends can render directly.
+ * This adds UX-friendly metadata such as progress percentages, status labels,
+ * insight summaries, and chart helper data while keeping backward compatible fields.
+ *
+ * @param {Array<Object>} rowsInput
+ * @param {number} totalPostsInput
+ * @returns {Object}
+ */
+export function formatLikesRecapResponse(rowsInput, totalPostsInput) {
+  const rows = Array.isArray(rowsInput) ? rowsInput : [];
+  const totalPostsNumber = Number.isFinite(Number(totalPostsInput))
+    ? Number(totalPostsInput)
+    : 0;
+  const totalPosts = totalPostsNumber > 0 ? totalPostsNumber : 0;
+
+  const perRowHeight = 36;
+  const minChartHeight = 320;
+  const targetOnTrackLikes = totalPosts > 0 ? Math.ceil(totalPosts * 0.5) : 0;
+
+  const processedRows = [];
+  const sudahUsers = [];
+  const kurangUsers = [];
+  const belumUsers = [];
+  const noUsernameUsersDetails = [];
+  const chartData = [];
+  const distribution = {
+    complete: 0,
+    onTrack: 0,
+    needsAttention: 0,
+    notStarted: 0,
+    noUsername: 0,
+    noPosts: 0,
+  };
+
+  let totalLikes = 0;
+  let activeCompletionSum = 0;
+  let activeUserCount = 0;
+  let participatingUsers = 0;
+
+  rows.forEach((user, index) => {
+    const likesNumber = Number.isFinite(Number(user?.jumlah_like))
+      ? Number(user.jumlah_like)
+      : 0;
+    totalLikes += likesNumber;
+
+    const trimmedUsername =
+      typeof user?.username === "string" ? user.username.trim() : "";
+    const hasUsername = trimmedUsername.length > 0;
+
+    const completionRate = totalPosts > 0 ? likesNumber / totalPosts : 0;
+    const completionPercentage = totalPosts > 0
+      ? Math.round(completionRate * 100)
+      : 0;
+    const missingLikes = totalPosts > 0
+      ? Math.max(totalPosts - likesNumber, 0)
+      : 0;
+
+    let status;
+    if (totalPosts === 0) {
+      status = hasUsername ? "no_posts" : "no_username";
+    } else if (!hasUsername) {
+      status = "no_username";
+    } else if (likesNumber >= totalPosts) {
+      status = "complete";
+    } else if (likesNumber >= targetOnTrackLikes) {
+      status = "on_track";
+    } else if (likesNumber > 0) {
+      status = "needs_attention";
+    } else {
+      status = "not_started";
+    }
+
+    if (totalPosts > 0 && status !== "no_username" && status !== "no_posts") {
+      activeCompletionSum += completionRate;
+      activeUserCount += 1;
+      if (["complete", "on_track", "needs_attention"].includes(status)) {
+        participatingUsers += 1;
+      }
+    }
+
+    const badges = [];
+    if (status === "complete") {
+      badges.push("✅ Semua konten pada periode ini sudah di-like.");
+    }
+    if (status === "on_track") {
+      badges.push("📈 Minimal 50% konten sudah di-like.");
+    }
+    if (status === "needs_attention") {
+      badges.push("⚠️ Kurang dari 50% konten yang sudah di-like.");
+    }
+    if (status === "not_started") {
+      badges.push("⏳ Belum ada like pada periode ini.");
+    }
+    if (status === "no_posts") {
+      badges.push("ℹ️ Tidak ada konten yang perlu di-like pada periode ini.");
+    }
+    if (!hasUsername) {
+      badges.push("❗ Username Instagram belum tersedia.");
+    }
+
+    const processedUser = {
+      ...user,
+      username: hasUsername ? trimmedUsername : user?.username ?? null,
+      jumlah_like: likesNumber,
+      ranking: index + 1,
+      completionRate,
+      completionPercentage,
+      missingLikes,
+      status,
+      badges,
+    };
+
+    processedRows.push(processedUser);
+
+    switch (status) {
+      case "complete":
+        distribution.complete += 1;
+        sudahUsers.push(processedUser.username);
+        break;
+      case "on_track":
+        distribution.onTrack += 1;
+        sudahUsers.push(processedUser.username);
+        break;
+      case "needs_attention":
+        distribution.needsAttention += 1;
+        kurangUsers.push(processedUser.username);
+        break;
+      case "not_started":
+        distribution.notStarted += 1;
+        belumUsers.push(processedUser.username);
+        break;
+      case "no_username":
+        distribution.noUsername += 1;
+        noUsernameUsersDetails.push({
+          userId: user?.user_id ?? null,
+          name: user?.nama ?? null,
+          division: user?.divisi ?? null,
+          clientId: user?.client_id ?? null,
+        });
+        break;
+      case "no_posts":
+        distribution.noPosts += 1;
+        break;
+      default:
+        break;
+    }
+
+    const labelCandidate =
+      user?.nama ||
+      user?.title ||
+      (hasUsername ? trimmedUsername : null) ||
+      `Pengguna ${index + 1}`;
+
+    chartData.push({
+      label: labelCandidate,
+      likes: likesNumber,
+      missingLikes,
+      completionPercentage,
+    });
+  });
+
+  const chartHeight = Math.max(processedRows.length * perRowHeight, minChartHeight);
+  const belumUsersCount = belumUsers.length + noUsernameUsersDetails.length;
+  const noUsernameUsers = noUsernameUsersDetails.map(() => null);
+
+  const averageCompletionPercentage =
+    activeUserCount > 0 && totalPosts > 0
+      ? Number(((activeCompletionSum / activeUserCount) * 100).toFixed(1))
+      : 0;
+  const participationRatePercentage =
+    activeUserCount > 0
+      ? Number(((participatingUsers / activeUserCount) * 100).toFixed(1))
+      : 0;
+
+  const summary = {
+    totalPosts,
+    totalUsers: processedRows.length,
+    targetOnTrackLikes,
+    totalLikes,
+    averageCompletionPercentage,
+    participationRatePercentage,
+    distribution,
+  };
+
+  const insights = [];
+  const onTrackCount = distribution.complete + distribution.onTrack;
+  if (onTrackCount > 0) {
+    insights.push(`✅ ${onTrackCount} akun telah mencapai target minimal 50% like.`);
+  }
+  if (distribution.needsAttention > 0) {
+    insights.push(
+      `⚠️ ${distribution.needsAttention} akun perlu perhatian karena belum mencapai 50% like.`
+    );
+  }
+  if (distribution.notStarted > 0) {
+    insights.push(`⏳ ${distribution.notStarted} akun belum memberikan like sama sekali.`);
+  }
+  if (distribution.noUsername > 0) {
+    insights.push(`❗ ${distribution.noUsername} akun belum memiliki username Instagram.`);
+  }
+  if (distribution.noPosts > 0) {
+    insights.push("ℹ️ Tidak ada konten pada periode ini.");
+  }
+
+  const statusLegend = [
+    {
+      status: "complete",
+      label: "Complete",
+      description: "Semua konten pada periode ini telah di-like.",
+    },
+    {
+      status: "on_track",
+      label: "On Track",
+      description: "Minimal 50% konten sudah di-like.",
+    },
+    {
+      status: "needs_attention",
+      label: "Needs Attention",
+      description: "Sudah melakukan like tetapi belum mencapai 50% konten.",
+    },
+    {
+      status: "not_started",
+      label: "Not Started",
+      description: "Belum memberikan like pada periode ini.",
+    },
+    {
+      status: "no_username",
+      label: "No Username",
+      description: "Belum memiliki username Instagram di sistem.",
+    },
+    {
+      status: "no_posts",
+      label: "No Posts",
+      description: "Tidak ada konten untuk periode yang dipilih.",
+    },
+  ];
+
+  return {
+    data: processedRows,
+    chartHeight,
+    totalPosts,
+    sudahUsers,
+    kurangUsers,
+    belumUsers,
+    sudahUsersCount: sudahUsers.length,
+    kurangUsersCount: kurangUsers.length,
+    belumUsersCount,
+    noUsernameUsersCount: noUsernameUsersDetails.length,
+    noUsernameUsers,
+    usersCount: processedRows.length,
+    summary,
+    chartData,
+    insights,
+    statusLegend,
+    targetLikesPerUser: targetOnTrackLikes,
+    noUsernameUsersDetails,
+  };
+}

--- a/tests/ditbinmasLikesController.test.js
+++ b/tests/ditbinmasLikesController.test.js
@@ -32,6 +32,9 @@ test('returns ditbinmas like summaries', async () => {
   expect(mockGetRekap).toHaveBeenCalledWith('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
   expect(json).toHaveBeenCalledWith(
     expect.objectContaining({
+      success: true,
+      totalPosts: 4,
+      usersCount: 4,
       sudahUsers: ['alice'],
       kurangUsers: ['bob'],
       belumUsers: ['charlie'],
@@ -39,7 +42,22 @@ test('returns ditbinmas like summaries', async () => {
       kurangUsersCount: 1,
       belumUsersCount: 2,
       noUsernameUsersCount: 1,
-      usersCount: 4
+      targetLikesPerUser: 2,
+      summary: expect.objectContaining({
+        distribution: expect.objectContaining({
+          complete: 1,
+          needsAttention: 1,
+          notStarted: 1,
+          noUsername: 1,
+        }),
+      }),
+      data: expect.arrayContaining([
+        expect.objectContaining({ username: 'alice', status: 'complete' }),
+        expect.objectContaining({ username: 'bob', status: 'needs_attention' }),
+        expect.objectContaining({ username: 'charlie', status: 'not_started' }),
+      ]),
+      insights: expect.any(Array),
+      statusLegend: expect.any(Array),
     })
   );
 });

--- a/tests/instaControllerDateRange.test.js
+++ b/tests/instaControllerDateRange.test.js
@@ -44,7 +44,7 @@ test('accepts tanggal_mulai and tanggal_selesai', async () => {
   const res = { json };
   await getInstaRekapLikes(req, res);
   expect(mockGetRekap).toHaveBeenCalledWith('c1', 'harian', undefined, '2024-01-01', '2024-01-31', undefined);
-  expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 300 }));
+  expect(json).toHaveBeenCalledWith(expect.objectContaining({ chartHeight: 320 }));
 });
 
 test('returns 403 when client_id unauthorized', async () => {
@@ -105,6 +105,9 @@ test('returns user like summaries', async () => {
   await getInstaRekapLikes(req, res);
   expect(json).toHaveBeenCalledWith(
     expect.objectContaining({
+      success: true,
+      totalPosts: 4,
+      usersCount: 4,
       sudahUsers: ['alice'],
       kurangUsers: ['bob'],
       belumUsers: ['charlie'],
@@ -112,7 +115,22 @@ test('returns user like summaries', async () => {
       kurangUsersCount: 1,
       belumUsersCount: 2,
       noUsernameUsersCount: 1,
-      usersCount: 4
+      targetLikesPerUser: 2,
+      summary: expect.objectContaining({
+        distribution: expect.objectContaining({
+          complete: 1,
+          needsAttention: 1,
+          notStarted: 1,
+          noUsername: 1,
+        }),
+      }),
+      data: expect.arrayContaining([
+        expect.objectContaining({ username: 'alice', status: 'complete' }),
+        expect.objectContaining({ username: 'bob', status: 'needs_attention' }),
+        expect.objectContaining({ username: 'charlie', status: 'not_started' }),
+      ]),
+      insights: expect.any(Array),
+      statusLegend: expect.any(Array),
     })
   );
 });

--- a/tests/likesRoutes.test.js
+++ b/tests/likesRoutes.test.js
@@ -37,20 +37,86 @@ test('GET /likes/instagram returns ditbinmas like summary', async () => {
 
   expect(res.status).toBe(200);
   expect(mockGetRekap).toHaveBeenCalledWith('ditbinmas', 'harian', undefined, undefined, undefined, 'ditbinmas');
-  expect(res.body).toEqual(
+  expect(res.body.success).toBe(true);
+  expect(res.body.chartHeight).toBe(320);
+  expect(res.body.totalPosts).toBe(4);
+  expect(res.body.usersCount).toBe(4);
+  expect(res.body.sudahUsers).toEqual(['alice']);
+  expect(res.body.kurangUsers).toEqual(['bob']);
+  expect(res.body.belumUsers).toEqual(['charlie']);
+  expect(res.body.sudahUsersCount).toBe(1);
+  expect(res.body.kurangUsersCount).toBe(1);
+  expect(res.body.belumUsersCount).toBe(2);
+  expect(res.body.noUsernameUsersCount).toBe(1);
+  expect(res.body.targetLikesPerUser).toBe(2);
+  expect(res.body.summary).toEqual(
     expect.objectContaining({
-      sudahUsers: ['alice'],
-      kurangUsers: ['bob'],
-      belumUsers: ['charlie'],
-      sudahUsersCount: 1,
-      kurangUsersCount: 1,
-      belumUsersCount: 2,
-      noUsernameUsersCount: 1,
-      usersCount: 4,
       totalPosts: 4,
-      success: true
+      totalUsers: 4,
+      targetOnTrackLikes: 2,
+      totalLikes: 5,
+      distribution: expect.objectContaining({
+        complete: 1,
+        onTrack: 0,
+        needsAttention: 1,
+        notStarted: 1,
+        noUsername: 1,
+      }),
     })
   );
+  expect(res.body.summary.averageCompletionPercentage).toBeCloseTo(41.7);
+  expect(res.body.summary.participationRatePercentage).toBeCloseTo(66.7);
+  expect(res.body.data).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        username: 'alice',
+        status: 'complete',
+        completionPercentage: 100,
+        missingLikes: 0,
+        ranking: 1,
+      }),
+      expect.objectContaining({
+        username: 'bob',
+        status: 'needs_attention',
+        completionPercentage: 25,
+        missingLikes: 3,
+      }),
+      expect.objectContaining({
+        username: 'charlie',
+        status: 'not_started',
+        completionPercentage: 0,
+        missingLikes: 4,
+      }),
+      expect.objectContaining({
+        username: null,
+        status: 'no_username',
+        completionPercentage: 0,
+      }),
+    ])
+  );
+  expect(res.body.chartData).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ label: 'alice', likes: 4, missingLikes: 0 }),
+    ])
+  );
+  expect(res.body.insights).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('✅ 1 akun'),
+      expect.stringContaining('⚠️ 1 akun'),
+      expect.stringContaining('⏳ 1 akun'),
+      expect.stringContaining('❗ 1 akun'),
+    ])
+  );
+  expect(res.body.statusLegend).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ status: 'complete' }),
+      expect.objectContaining({ status: 'on_track' }),
+      expect.objectContaining({ status: 'needs_attention' }),
+      expect.objectContaining({ status: 'not_started' }),
+      expect.objectContaining({ status: 'no_username' }),
+    ])
+  );
+  expect(res.body.noUsernameUsersDetails).toHaveLength(1);
 
   expect(logSpy).toHaveBeenCalledWith('\x1b[33m%s\x1b[0m', 'GET /api/likes/instagram');
   logSpy.mockRestore();


### PR DESCRIPTION
## Summary
- add a reusable formatter that enriches Instagram like recap data with progress, status, insights, and chart helpers
- update the Instagram recap controllers to return the new UX-focused payload and refresh the API documentation
- align the related Jest tests with the richer response structure

## Testing
- npm run lint
- npm test -- likesRoutes.test.js ditbinmasLikesController.test.js instaControllerDateRange.test.js
- npm test *(fails: JavaScript heap out of memory when running the full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d2968f80908327afd01397799812c0