### PR TITLE
Increase WhatsApp response delay to three seconds

### DIFF
--- a/src/cron/cronDirRequestEngageRank.js
+++ b/src/cron/cronDirRequestEngageRank.js
@@ -1,4 +1,3 @@
-import cron from "node-cron";
 import dotenv from "dotenv";
 dotenv.config();
 

--- a/src/cron/cronDirRequestRekapUpdate.js
+++ b/src/cron/cronDirRequestRekapUpdate.js
@@ -1,4 +1,3 @@
-import cron from "node-cron";
 import dotenv from "dotenv";
 dotenv.config();
 

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -103,8 +103,8 @@ dotenv.config();
 
 const messageQueue = new PQueue({ concurrency: 1 });
 
-// Fixed delay to ensure consistent response timing
-const responseDelayMs = 800;
+// Fixed delay to ensure consistent 3-second response timing
+const responseDelayMs = 3000;
 
 // Helper ringkas untuk menampilkan data user
 function formatUserSummary(user) {


### PR DESCRIPTION
## Summary
- update the WhatsApp service response delay constant to wait three seconds before dispatching queued replies
- remove unused node-cron imports from DirRequest cron jobs to keep lint clean while schedules stay commented out

## Testing
- npm run lint
- npm test *(fails: multiple suites abort because cleanEnv triggers process.exit when required env vars are missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da41a29d308327b15a8ecb56afdcda