### PR TITLE
Add per-content Instagram likes recap export

### DIFF
--- a/src/service/likesRecapExcelService.js
+++ b/src/service/likesRecapExcelService.js
@@ -3,8 +3,33 @@ import path from 'path';
 import XLSX from 'xlsx';
 import { hariIndo } from '../utils/constants.js';
 
+function formatClientName(clientId = '') {
+  return clientId
+    .toLowerCase()
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+function buildExportPath(prefix, clientId) {
+  const exportDir = path.resolve('export_data/likes_recap');
+  const now = new Date();
+  const hari = hariIndo[now.getDay()];
+  const tanggalStr = now.toLocaleDateString('id-ID');
+  const jam = now.toLocaleTimeString('id-ID', { hour12: false });
+  const dateSafe = tanggalStr.replace(/\//g, '-');
+  const timeSafe = jam.replace(/[:.]/g, '-');
+  const formattedClient = formatClientName(clientId);
+
+  return {
+    exportDir,
+    filePath: path.join(
+      exportDir,
+      `${prefix}_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+    ),
+  };
+}
+
 export async function saveLikesRecapExcel(data, clientId) {
-  const { shortcodes, recap } = data;
+  const { shortcodes = [], recap = {} } = data || {};
   const wb = XLSX.utils.book_new();
   const recapDate = new Date().toLocaleDateString('id-ID');
 
@@ -17,15 +42,15 @@ export async function saveLikesRecapExcel(data, clientId) {
       `${recapDate} Belum Likes`,
     ];
 
-    const rows = users.map((u) => {
+    const rows = (users || []).map((u) => {
       const totalPost = shortcodes.length;
       const likedCount = shortcodes.reduce(
-        (sum, sc) => sum + (u[sc] ?? 0),
+        (sum, sc) => sum + (u?.[sc] ?? 0),
         0
       );
       return {
-        'Pangkat Nama': `${u.pangkat ? u.pangkat + ' ' : ''}${u.nama}`.trim(),
-        'Divisi / Satfung': u.satfung || '',
+        'Pangkat Nama': `${u?.pangkat ? `${u.pangkat} ` : ''}${u?.nama || ''}`.trim(),
+        'Divisi / Satfung': u?.satfung || '',
         [`${recapDate} Jumlah Post`]: totalPost,
         [`${recapDate} Sudah Likes`]: likedCount,
         [`${recapDate} Belum Likes`]: totalPost - likedCount,
@@ -36,22 +61,46 @@ export async function saveLikesRecapExcel(data, clientId) {
     XLSX.utils.book_append_sheet(wb, ws, polres);
   });
 
-  const exportDir = path.resolve('export_data/likes_recap');
+  const { exportDir, filePath } = buildExportPath(
+    'Rekap_Engagement_Instagram',
+    clientId
+  );
   await mkdir(exportDir, { recursive: true });
 
-  const now = new Date();
-  const hari = hariIndo[now.getDay()];
-  const tanggalStr = now.toLocaleDateString('id-ID');
-  const jam = now.toLocaleTimeString('id-ID', { hour12: false });
-  const dateSafe = tanggalStr.replace(/\//g, '-');
-  const timeSafe = jam.replace(/[:.]/g, '-');
-  const formattedClient = (clientId || '')
-    .toLowerCase()
-    .replace(/^./, (c) => c.toUpperCase());
-  const filePath = path.join(
-    exportDir,
-    `Rekap_Engagement_Instagram_${formattedClient}_${hari}_${dateSafe}_${timeSafe}.xlsx`
+  XLSX.writeFile(wb, filePath);
+  return filePath;
+}
+
+export async function saveLikesRecapPerContentExcel(data, clientId) {
+  const { shortcodes = [], recap = {} } = data || {};
+  const wb = XLSX.utils.book_new();
+
+  const header = ['Pangkat Nama', 'Satfung', ...shortcodes];
+
+  Object.entries(recap).forEach(([polres, users]) => {
+    const rows = (users || []).map((user) => {
+      const row = {
+        'Pangkat Nama': `${user?.pangkat ? `${user.pangkat} ` : ''}${
+          user?.nama || ''
+        }`.trim(),
+        Satfung: user?.satfung || '',
+      };
+      shortcodes.forEach((sc) => {
+        row[sc] = user?.[sc] ?? 0;
+      });
+      return row;
+    });
+
+    const ws = XLSX.utils.json_to_sheet(rows, { header });
+    XLSX.utils.book_append_sheet(wb, ws, polres);
+  });
+
+  const { exportDir, filePath } = buildExportPath(
+    'Rekap_Likes_Per_Konten_Instagram',
+    clientId
   );
+  await mkdir(exportDir, { recursive: true });
+
   XLSX.writeFile(wb, filePath);
   return filePath;
 }

--- a/tests/likesRecapExcelService.test.js
+++ b/tests/likesRecapExcelService.test.js
@@ -1,6 +1,9 @@
 import { unlink } from 'fs/promises';
 import XLSX from 'xlsx';
-import { saveLikesRecapExcel } from '../src/service/likesRecapExcelService.js';
+import {
+  saveLikesRecapExcel,
+  saveLikesRecapPerContentExcel,
+} from '../src/service/likesRecapExcelService.js';
 
 test('saveLikesRecapExcel creates recap with date columns', async () => {
   const data = {
@@ -25,6 +28,30 @@ test('saveLikesRecapExcel creates recap with date columns', async () => {
     [`${recapDate} Sudah Likes`]: 1,
     [`${recapDate} Belum Likes`]: 1,
   });
+
+  await unlink(filePath);
+});
+
+test('saveLikesRecapPerContentExcel creates sheet with shortcode columns', async () => {
+  const data = {
+    shortcodes: ['SC1', 'SC2'],
+    recap: {
+      'POLRES A': [
+        { pangkat: 'AKP', nama: 'Budi', satfung: 'Sat A', SC1: 1, SC2: 0 },
+        { pangkat: 'BRIPKA', nama: 'Rina', satfung: 'Sat B', SC1: 0, SC2: 1 },
+      ],
+    },
+  };
+
+  const filePath = await saveLikesRecapPerContentExcel(data, 'DITBINMAS');
+  const wb = XLSX.readFile(filePath);
+  const sheet = wb.Sheets['POLRES A'];
+  const rows = XLSX.utils.sheet_to_json(sheet);
+
+  expect(rows).toEqual([
+    { 'Pangkat Nama': 'AKP Budi', Satfung: 'Sat A', SC1: 1, SC2: 0 },
+    { 'Pangkat Nama': 'BRIPKA Rina', Satfung: 'Sat B', SC1: 0, SC2: 1 },
+  ]);
 
   await unlink(filePath);
 });


### PR DESCRIPTION
## Summary
- extend the dirrequest menu with a new Instagram per-content likes recap option and adjust the displayed menu list
- add a workbook generator for per-content Instagram likes recaps and cover it with unit tests
- update dirRequestHandlers tests to exercise the new flow and keep invalid option coverage in place

## Testing
- npm run lint
- npm test *(fails: userMenuHandlersFlow.test.js exits with "Jest worker encountered 4 child process exceptions")*

------
https://chatgpt.com/codex/tasks/task_e_68e3cfe523dc8327a94cea50959c21f3