### PR TITLE
Adjust likes per content Excel column widths

### DIFF
--- a/src/service/likesRecapExcelService.js
+++ b/src/service/likesRecapExcelService.js
@@ -9,6 +9,25 @@ function formatClientName(clientId = '') {
     .replace(/^./, (c) => c.toUpperCase());
 }
 
+function buildColumnWidths(headers, rows) {
+  return headers.map((headerKey) => {
+    const columnValues = rows.map((row) => {
+      const value = row?.[headerKey];
+      if (value === null || value === undefined) {
+        return '';
+      }
+      return String(value);
+    });
+
+    const maxContentLength = columnValues.reduce(
+      (maxLength, value) => Math.max(maxLength, value.length),
+      String(headerKey).length
+    );
+
+    return { wch: maxContentLength + 2 };
+  });
+}
+
 function buildExportPath(prefix, clientId) {
   const exportDir = path.resolve('export_data/likes_recap');
   const now = new Date();
@@ -92,6 +111,7 @@ export async function saveLikesRecapPerContentExcel(data, clientId) {
     });
 
     const ws = XLSX.utils.json_to_sheet(rows, { header });
+    ws['!cols'] = buildColumnWidths(header, rows);
     XLSX.utils.book_append_sheet(wb, ws, polres);
   });
 


### PR DESCRIPTION
## Summary
- calculate column widths for each sheet in the Rekap likes per konten export so the longest value fits comfortably

## Testing
- npm run lint
- npm test *(fails: existing jest suites such as userMenuHandlersFlow fail locally due to worker exceptions and existing expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d468dc2c8327bf8c7bee4b0e7f24