### PR TITLE
Add pagination support to link report API

### DIFF
--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -80,11 +80,24 @@ test('createLinkReport throws when recent link report exists', async () => {
 });
 
 test('getLinkReports joins with insta_post', async () => {
-  mockQuery.mockResolvedValueOnce({ rows: [{ shortcode: 'abc', caption: 'c' }] });
-  const rows = await getLinkReports();
-  expect(rows).toEqual([{ shortcode: 'abc', caption: 'c' }]);
-  expect(mockQuery).toHaveBeenCalledWith(
-    expect.stringContaining('FROM link_report r')
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ shortcode: 'abc', caption: 'c' }] })
+    .mockResolvedValueOnce({ rows: [{ count: '1' }] });
+  const result = await getLinkReports();
+  expect(result).toEqual({
+    rows: [{ shortcode: 'abc', caption: 'c' }],
+    totalCount: 1,
+    limit: 20,
+    offset: 0
+  });
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('FROM link_report r'),
+    [20, 0]
+  );
+  expect(mockQuery).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining('SELECT COUNT(*)::int AS count FROM link_report')
   );
 });
 


### PR DESCRIPTION
## Summary
- add pagination handling to the link report controller so clients can request specific pages or offsets
- paginate the link report query, returning total counts alongside the requested slice
- update the link report model tests to assert the new response shape and parameters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3ddee87048327a56ba9bd5ecbd509