### PR TITLE
Centralize link report 2-day interval rule

### DIFF
--- a/src/model/linkReportModel.js
+++ b/src/model/linkReportModel.js
@@ -1,11 +1,13 @@
 import { query } from '../repository/db.js';
 
+const LINK_REPORT_INTERVAL = '2 days';
+
 export async function hasRecentLinkReport(shortcode, user_id) {
   const res = await query(
     `SELECT 1 FROM link_report
      WHERE shortcode = $1
        AND user_id IS NOT DISTINCT FROM $2
-       AND created_at >= NOW() - INTERVAL '2 days'
+       AND created_at >= NOW() - INTERVAL '${LINK_REPORT_INTERVAL}'
      LIMIT 1`,
     [shortcode, user_id]
   );
@@ -27,7 +29,7 @@ export async function createLinkReport(data) {
      SELECT p.shortcode, $2, $3, $4, $5, $6, $7, p.created_at
      FROM insta_post p
      WHERE p.shortcode = $1
-       AND p.created_at >= (NOW() AT TIME ZONE 'Asia/Jakarta') - INTERVAL '2 days'
+       AND p.created_at >= (NOW() AT TIME ZONE 'Asia/Jakarta') - INTERVAL '${LINK_REPORT_INTERVAL}'
      ON CONFLICT (shortcode, user_id) DO UPDATE
      SET instagram_link = EXCLUDED.instagram_link,
          facebook_link = EXCLUDED.facebook_link,
@@ -48,7 +50,7 @@ export async function createLinkReport(data) {
   );
 
   if (res.rows.length === 0) {
-    const err = new Error('shortcode not found or older than 2 days');
+    const err = new Error(`shortcode not found or older than ${LINK_REPORT_INTERVAL}`);
     err.statusCode = 400;
     throw err;
   }

--- a/tests/linkReportModel.test.js
+++ b/tests/linkReportModel.test.js
@@ -15,6 +15,7 @@ let getReportsTodayByShortcode;
 let getReportsThisMonthByClient;
 let getReportsPrevMonthByClient;
 let getRekapLinkByClient;
+let hasRecentLinkReport;
 
 beforeAll(async () => {
   const mod = await import('../src/model/linkReportModel.js');
@@ -27,6 +28,7 @@ beforeAll(async () => {
   getReportsThisMonthByClient = mod.getReportsThisMonthByClient;
   getReportsPrevMonthByClient = mod.getReportsPrevMonthByClient;
   getRekapLinkByClient = mod.getRekapLinkByClient;
+  hasRecentLinkReport = mod.hasRecentLinkReport;
 });
 
 beforeEach(() => {
@@ -56,6 +58,13 @@ test('createLinkReport inserts row', async () => {
     expect.any(String),
     ['abc', '1', 'a', null, null, null, null]
   );
+});
+
+test('hasRecentLinkReport enforces 2-day interval', async () => {
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  await hasRecentLinkReport('abc', 'user-1');
+  const sql = mockQuery.mock.calls[0][0];
+  expect(sql).toContain("INTERVAL '2 days'");
 });
 
 test('createLinkReport throws when shortcode missing or older than 2 days', async () => {


### PR DESCRIPTION
## Summary
- centralize the link report recency interval in the model and reuse it in validation and errors
- extend the link report model tests to cover the enforced 2-day duplicate window

## Testing
- npm run lint
- npm test -- linkReportModel.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3e481c4408327bba0034e9c9cf3b8