### PR TITLE
Exclude error-prone annotations from runtime classpath

### DIFF
--- a/pegiat_medsos_apps/app/build.gradle.kts
+++ b/pegiat_medsos_apps/app/build.gradle.kts
@@ -17,6 +17,13 @@ fun env(name: String): String =
     envProps.getProperty(name) ?: System.getenv(name) ?: ""
 
 
+configurations.configureEach {
+    if (name.contains("RuntimeClasspath", ignoreCase = true)) {
+        exclude(group = "com.google.errorprone", module = "error_prone_annotations")
+    }
+}
+
+
 android {
     namespace = "com.cicero.repostapp"
     compileSdk = 35


### PR DESCRIPTION
## Summary
- filter runtime classpath configurations to drop the error_prone_annotations artifact and avoid duplicate class packaging

## Testing
- npm run lint
- npm test (fails: Jest worker encountered child process exceptions in tests/userMenuHandlersFlow.test.js)


------
https://chatgpt.com/codex/tasks/task_e_68e5038444e48327a8dced30de6ef610