### PR TITLE
Add scheduled Kasatker reports cron job

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ const cronModules = [
   './src/cron/cronDirRequestRekapAllSocmed.js',
   './src/cron/cronDirRequestSosmedRank.js',
   './src/cron/cronDirRequestEngageRank.js',
+  './src/cron/cronDirRequestLapharKasatker.js',
   './src/cron/cronDirRequestDirektorat.js',
   './src/cron/cronDbBackup.js',
 ];

--- a/src/cron/cronDirRequestLapharKasatker.js
+++ b/src/cron/cronDirRequestLapharKasatker.js
@@ -1,0 +1,122 @@
+import cron from "node-cron";
+import dotenv from "dotenv";
+dotenv.config();
+
+import { waGatewayClient } from "../service/waService.js";
+import { generateKasatkerReport } from "../service/kasatkerReportService.js";
+import { safeSendMessage } from "../utils/waHelper.js";
+import { sendDebug } from "../middleware/debugHandler.js";
+
+const TAG = "CRON DIRREQ KASATKER";
+const TARGET_CHAT_ID = "628127309190@c.us";
+const DEFAULT_CLIENT_ID = "DITBINMAS";
+const DEFAULT_ROLE_FLAG = "ditbinmas";
+
+function getJakartaDateParts(date = new Date()) {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Jakarta",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const formatted = formatter.formatToParts(date).reduce((acc, part) => {
+    if (part.type === "year" || part.type === "month" || part.type === "day") {
+      acc[part.type] = Number(part.value);
+    }
+    return acc;
+  }, {});
+  return {
+    year: formatted.year,
+    month: formatted.month,
+    day: formatted.day,
+  };
+}
+
+function isLastDayOfMonthJakarta(date = new Date()) {
+  const { year, month, day } = getJakartaDateParts(date);
+  if (!year || !month || !day) {
+    return false;
+  }
+  const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return day === lastDay;
+}
+
+async function sendKasatkerReport(period, description) {
+  sendDebug({ tag: TAG, msg: `Mulai laporan ${description}` });
+  try {
+    const narrative = await generateKasatkerReport({
+      clientId: DEFAULT_CLIENT_ID,
+      roleFlag: DEFAULT_ROLE_FLAG,
+      period,
+    });
+
+    const success = await safeSendMessage(
+      waGatewayClient,
+      TARGET_CHAT_ID,
+      String(narrative || "").trim()
+    );
+
+    if (success) {
+      sendDebug({
+        tag: TAG,
+        msg: `Laporan ${description} dikirim ke ${TARGET_CHAT_ID}`,
+      });
+    } else {
+      sendDebug({
+        tag: TAG,
+        msg: `Laporan ${description} gagal dikirim ke ${TARGET_CHAT_ID}`,
+      });
+    }
+
+    return success;
+  } catch (error) {
+    sendDebug({
+      tag: TAG,
+      msg: `[ERROR ${description}] ${error?.message || error}`,
+    });
+    return false;
+  }
+}
+
+export async function runDailyReport() {
+  return sendKasatkerReport("today", "harian");
+}
+
+export async function runWeeklyReport() {
+  return sendKasatkerReport("this_week", "mingguan");
+}
+
+export async function runMonthlyReport(date = new Date()) {
+  if (!isLastDayOfMonthJakarta(date)) {
+    sendDebug({
+      tag: TAG,
+      msg: "Lewati laporan bulanan karena belum akhir bulan",
+    });
+    return false;
+  }
+  return sendKasatkerReport("this_month", "bulanan");
+}
+
+if (process.env.JEST_WORKER_ID === undefined) {
+  cron.schedule("34 20 * * *", () => {
+    runDailyReport();
+  }, {
+    timezone: "Asia/Jakarta",
+  });
+
+  cron.schedule("45 20 * * 0", () => {
+    runWeeklyReport();
+  }, {
+    timezone: "Asia/Jakarta",
+  });
+
+  cron.schedule("50 20 * * *", () => {
+    runMonthlyReport();
+  }, {
+    timezone: "Asia/Jakarta",
+  });
+}
+
+export { isLastDayOfMonthJakarta };
+
+export default null;

--- a/tests/cronDirRequestLapharKasatker.test.js
+++ b/tests/cronDirRequestLapharKasatker.test.js
@@ -1,0 +1,110 @@
+import { jest } from '@jest/globals';
+
+const mockGenerateKasatkerReport = jest.fn();
+const mockSafeSendMessage = jest.fn();
+const mockSendDebug = jest.fn();
+
+jest.unstable_mockModule('../src/service/waService.js', () => ({
+  waGatewayClient: { id: 'gateway' },
+}));
+
+jest.unstable_mockModule('../src/service/kasatkerReportService.js', () => ({
+  generateKasatkerReport: mockGenerateKasatkerReport,
+}));
+
+jest.unstable_mockModule('../src/utils/waHelper.js', () => ({
+  safeSendMessage: mockSafeSendMessage,
+}));
+
+jest.unstable_mockModule('../src/middleware/debugHandler.js', () => ({
+  sendDebug: mockSendDebug,
+}));
+
+let runDailyReport;
+let runWeeklyReport;
+let runMonthlyReport;
+let isLastDayOfMonthJakarta;
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  process.env.JWT_SECRET = 'test-secret';
+  mockGenerateKasatkerReport.mockResolvedValue(' Narasi Kasatker ');
+  mockSafeSendMessage.mockResolvedValue(true);
+
+  ({
+    runDailyReport,
+    runWeeklyReport,
+    runMonthlyReport,
+    isLastDayOfMonthJakarta,
+  } = await import('../src/cron/cronDirRequestLapharKasatker.js'));
+});
+
+test('runDailyReport generates and sends harian report', async () => {
+  const result = await runDailyReport();
+
+  expect(mockGenerateKasatkerReport).toHaveBeenCalledWith({
+    clientId: 'DITBINMAS',
+    roleFlag: 'ditbinmas',
+    period: 'today',
+  });
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    { id: 'gateway' },
+    '628127309190@c.us',
+    'Narasi Kasatker'
+  );
+  expect(result).toBe(true);
+});
+
+test('runWeeklyReport generates and sends weekly report', async () => {
+  await runWeeklyReport();
+
+  expect(mockGenerateKasatkerReport).toHaveBeenCalledWith({
+    clientId: 'DITBINMAS',
+    roleFlag: 'ditbinmas',
+    period: 'this_week',
+  });
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    { id: 'gateway' },
+    '628127309190@c.us',
+    'Narasi Kasatker'
+  );
+});
+
+test('runMonthlyReport skips when not last day in Jakarta timezone', async () => {
+  const date = new Date('2024-01-30T12:00:00+07:00');
+  const result = await runMonthlyReport(date);
+
+  expect(result).toBe(false);
+  expect(mockGenerateKasatkerReport).not.toHaveBeenCalled();
+  expect(mockSafeSendMessage).not.toHaveBeenCalled();
+  expect(mockSendDebug).toHaveBeenCalledWith({
+    tag: 'CRON DIRREQ KASATKER',
+    msg: 'Lewati laporan bulanan karena belum akhir bulan',
+  });
+});
+
+test('runMonthlyReport sends report on last day of month in Jakarta timezone', async () => {
+  const date = new Date('2024-01-31T12:00:00+07:00');
+  const result = await runMonthlyReport(date);
+
+  expect(result).toBe(true);
+  expect(mockGenerateKasatkerReport).toHaveBeenCalledWith({
+    clientId: 'DITBINMAS',
+    roleFlag: 'ditbinmas',
+    period: 'this_month',
+  });
+  expect(mockSafeSendMessage).toHaveBeenCalledWith(
+    { id: 'gateway' },
+    '628127309190@c.us',
+    'Narasi Kasatker'
+  );
+});
+
+test('isLastDayOfMonthJakarta respects Asia/Jakarta timezone boundaries', () => {
+  const almostMidnightJakarta = new Date('2024-02-29T23:00:00+07:00');
+  const justAfterMidnightJakarta = new Date('2024-03-01T00:30:00+07:00');
+
+  expect(isLastDayOfMonthJakarta(almostMidnightJakarta)).toBe(true);
+  expect(isLastDayOfMonthJakarta(justAfterMidnightJakarta)).toBe(false);
+});


### PR DESCRIPTION
## Summary
- schedule automatic Kasatker report deliveries via the WA gateway for daily, weekly, and end-of-month cadences
- wrap report generation with timezone-aware helpers and centralized delivery logging for the Ditbinmas client
- add targeted unit tests that validate the cron helper behavior and skip logic for non-month-end executions

## Testing
- `JWT_SECRET=test-secret npm test -- cronDirRequestLapharKasatker`


------
https://chatgpt.com/codex/tasks/task_e_68e6519717488327abb9ec394dc69339