### PR TITLE
Make Link Report WA notifications best-effort and add isWaReady()

### DIFF
--- a/docs/whatsapp_client_lifecycle.md
+++ b/docs/whatsapp_client_lifecycle.md
@@ -142,6 +142,18 @@ Adapter kini menambahkan retry khusus saat `client.initialize()` gagal dengan in
 - Backoff dikontrol oleh env `WA_WWEBJS_EXECUTION_CONTEXT_RETRY_BACKOFF_MS` (default `1500` ms).
 - Tujuan: mengurangi kegagalan inisialisasi sporadis pada momen reload/navigasi internal WhatsApp Web saat cron berjalan.
 
+
+## Notifikasi opsional tanpa blocking request
+
+Untuk notifikasi yang sifatnya _best effort_ (contoh: notifikasi Link Report ke user), controller bisa memakai helper `isWaReady()` sebelum memanggil `waitForWaReady()`.
+
+Pola yang direkomendasikan:
+
+- Jika `isWaReady() === false`, lewati pengiriman notifikasi dan tulis log warning yang jelas.
+- Jika `isWaReady() === true`, gunakan `waitForWaReady()` dengan timeout singkat (mis. 5 detik) sebelum kirim.
+
+Tujuan pendekatan ini adalah mencegah request API tertahan lama ketika client WA sedang belum siap, tanpa mengubah kontrak readiness utama di service.
+
 ## Endpoint status readiness
 
 Endpoint:

--- a/src/controller/linkReportController.js
+++ b/src/controller/linkReportController.js
@@ -6,7 +6,7 @@ import {
   formatNama,
 } from '../utils/utilsHelper.js';
 import { generateLinkReportExcelBuffer } from '../service/amplifyExportService.js';
-import waClient, { waitForWaReady } from '../service/waService.js';
+import waClient, { isWaReady, waitForWaReady } from '../service/waService.js';
 import { findUserById } from '../model/userModel.js';
 import { formatToWhatsAppId, safeSendMessage } from '../utils/waHelper.js';
 
@@ -89,9 +89,15 @@ export async function createLinkReport(req, res) {
 
     if (data.user_id) {
       try {
-        await waitForWaReady();
+        if (!isWaReady()) {
+          console.warn(
+            '[WA] Skipping link report notification: admin WhatsApp client is not ready yet.'
+          );
+        } else {
+          await waitForWaReady(5000);
+        }
         const user = await findUserById(data.user_id);
-        if (user?.whatsapp) {
+        if (isWaReady() && user?.whatsapp) {
           const wid = formatToWhatsAppId(user.whatsapp);
           const greeting = getGreeting();
           const fullName = formatNama(user);

--- a/src/service/waService.js
+++ b/src/service/waService.js
@@ -1305,6 +1305,10 @@ export function waitForWaReady(timeoutMs) {
   return waitForClientReady(waClient, timeoutMs);
 }
 
+export function isWaReady() {
+  return getClientReadinessState(waClient, "WA").ready;
+}
+
 // Expose readiness helper for consumers like safeSendMessage
 waClient.waitForWaReady = () => waitForClientReady(waClient);
 waUserClient.waitForWaReady = () => waitForClientReady(waUserClient);


### PR DESCRIPTION
### Motivation
- Link report creation was blocked by long WA readiness waits (logs showed `waitForClientReady` timing out after default 60000ms), causing API requests to be held for optional notifications.
- Need a lightweight readiness check so controllers can skip non-critical WA sends without changing core readiness semantics.
- Documentation should reflect the pattern for best-effort notifications so callers use a non-blocking approach.

### Description
- Added `isWaReady()` helper in `src/service/waService.js` to expose a quick check of admin WA readiness (`getClientReadinessState(waClient, "WA").ready`).
- Updated `createLinkReport` in `src/controller/linkReportController.js` to treat user notification as "best-effort": it now calls `isWaReady()` to skip early when admin client is not ready, uses `waitForWaReady(5000)` only when `isWaReady() === true`, and sends the WA message only if the client remains ready.
- Updated `docs/whatsapp_client_lifecycle.md` with a new section describing the recommended non-blocking notification pattern using `isWaReady()` + short `waitForWaReady()` timeout.

### Testing
- Ran `npm run lint`; lint passed successfully.
- Ran `npm test`; test run failed with multiple pre-existing suite failures across the repository (several unrelated failures including env/export issues and model/controller assertions), so full test-suite green is not achieved by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876ba3497483278a86a1a32a3dd6cd)